### PR TITLE
Fix black flash on page load

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,19 +2,6 @@ import { AudioProcessor } from './src/audio/AudioProcessor.js'
 import { makeVisualizer } from './src/Visualizer.js'
 import { getInitialShader } from './src/shaderLoader.js'
 
-// Add service worker registration
-window.addEventListener('load', async () => {
-    const { serviceWorker } = navigator
-    if(!serviceWorker) {
-        return
-    }
-    serviceWorker.addEventListener('message', processServiceWorkerMessage)
-    // Add cache version to URL to force update when version changes
-    const registration = await serviceWorker.register(`/service-worker.js`)
-    registration.addEventListener('statechange', (e) => {})
-    registration.addEventListener('message', processServiceWorkerMessage)
-})
-
 /**
  * Process messages from the service worker
  * @param {MessageEvent} event
@@ -25,6 +12,23 @@ const processServiceWorkerMessage = (event) => {
         return window.location.reload()
     }
 }
+
+// Add service worker message listener immediately (before load)
+// This ensures we catch reload messages from the SW even during initial page load
+if (navigator.serviceWorker) {
+    navigator.serviceWorker.addEventListener('message', processServiceWorkerMessage)
+}
+
+// Add service worker registration
+window.addEventListener('load', async () => {
+    const { serviceWorker } = navigator
+    if(!serviceWorker) {
+        return
+    }
+    // Add cache version to URL to force update when version changes
+    const registration = await serviceWorker.register(`/service-worker.js`)
+    registration.addEventListener('statechange', (e) => {})
+})
 
 const events = ['touchstart', 'touchmove', 'touchstop', 'keydown', 'mousedown', 'resize']
 let ranMain = false

--- a/src/Visualizer.js
+++ b/src/Visualizer.js
@@ -130,6 +130,10 @@ export const makeVisualizer = async ({ canvas, initialImageUrl, fullscreen }) =>
 
     const bufferInfo = createBufferInfoFromArrays(gl, { position: positions })
 
+    // Resize canvas to display size before capturing initial dimensions
+    // This prevents the first frame from triggering resize logic and causing a black flash
+    resizeCanvasToDisplaySize(gl.canvas, 1)
+
     let frameNumber = 0
     let lastRender = performance.now()
     let programInfo


### PR DESCRIPTION
## Summary
- Fixes black flash that appeared for a few frames on every page load
- Improves service worker reload timing so new versions are properly detected

## Changes
- `src/Visualizer.js`: Call `resizeCanvasToDisplaySize` during init before capturing canvas dimensions, preventing first-frame resize from triggering framebuffer clear to black
- `index.js`: Move SW message listener before `load` event to catch reload messages that arrive during initial page load

## Test plan
- [ ] Load any shader page - should not flash black on initial load
- [ ] Make a change to a shader, reload - should show new version (or trigger reload)
- [ ] Kill dev server, reload - should serve cached version offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)