### PR TITLE
Add oklab color space utilities to shader compilation

### DIFF
--- a/src/monaco.js
+++ b/src/monaco.js
@@ -146,6 +146,9 @@ async function init() {
         'hslmix',
         'hsl2rgb',
         'rgb2hsl',
+        'rgb2oklab',
+        'oklab2rgb',
+        'oklabmix',
         'map',
         'centerUv',
         'animateSmooth',
@@ -671,6 +674,9 @@ async function init() {
                 animateEaseOutElastic: 'Elastic easing that creates a bouncy effect with overshoot at the end.',
                 animateEaseInOutElastic: 'Elastic easing that creates a bouncy effect with overshoot at both start and end.',
                 animateSmoothBounce: 'Creates a smoother bouncing effect that decreases in amplitude over time.',
+                rgb2oklab: 'Converts RGB color to Oklab perceptual color space. Accepts vec3 or vec4 (alpha passed through).',
+                oklab2rgb: 'Converts Oklab color back to RGB. Accepts vec3 or vec4 (alpha passed through).',
+                oklabmix: 'Mixes two colors in Oklab perceptual space. Produces more natural gradients than HSL or RGB. Accepts vec3 or vec4.',
             }
 
             const description = audioFeatureDescriptions[word.word]

--- a/src/shader-transformers/shader-wrapper.js
+++ b/src/shader-transformers/shader-wrapper.js
@@ -186,6 +186,8 @@ vec3 rgb2hsl(vec3 c) {
 
     return vec3(h, s, l);
 }
+vec4 hsl2rgb(vec4 hsl) { return vec4(hsl2rgb(hsl.xyz), hsl.w); }
+vec4 rgb2hsl(vec4 c) { return vec4(rgb2hsl(c.rgb), c.a); }
 
 vec2 centerUv(vec2 res, vec2 coord) {
     return (coord / res - 0.5) * 2.0 + 0.5;
@@ -200,6 +202,47 @@ vec3 hslmix(vec3 c1, vec3 c2, float t){
     vec3 hsl2 = rgb2hsl(c2);
     vec3 hsl = mix(hsl1, hsl2, t);
     return hsl2rgb(hsl);
+}
+
+vec4 hslmix(vec4 c1, vec4 c2, float t){
+    return vec4(hslmix(c1.rgb, c2.rgb, t), mix(c1.a, c2.a, t));
+}
+
+// Oklab color space conversions
+// Oklab is a perceptual color space - mixing in Oklab produces more natural gradients than HSL or RGB
+vec3 rgb2oklab(vec3 c) {
+    float l = 0.4122214708 * c.r + 0.5363325363 * c.g + 0.0514459929 * c.b;
+    float m = 0.2119034982 * c.r + 0.6806995451 * c.g + 0.1073969566 * c.b;
+    float s = 0.0883024619 * c.r + 0.2817188376 * c.g + 0.6299787005 * c.b;
+    l = pow(l, 1.0/3.0); m = pow(m, 1.0/3.0); s = pow(s, 1.0/3.0);
+    return vec3(
+        0.2104542553 * l + 0.7936177850 * m - 0.0040720468 * s,
+        1.9779984951 * l - 2.4285922050 * m + 0.4505937099 * s,
+        0.0259040371 * l + 0.7827717662 * m - 0.8086757660 * s
+    );
+}
+
+vec3 oklab2rgb(vec3 lab) {
+    float l = lab.x + 0.3963377774 * lab.y + 0.2158037573 * lab.z;
+    float m = lab.x - 0.1055613458 * lab.y - 0.0638541728 * lab.z;
+    float s = lab.x - 0.0894841775 * lab.y - 1.2914855480 * lab.z;
+    l = l * l * l; m = m * m * m; s = s * s * s;
+    return vec3(
+         4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+        -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+        -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s
+    );
+}
+
+vec4 rgb2oklab(vec4 c) { return vec4(rgb2oklab(c.rgb), c.a); }
+vec4 oklab2rgb(vec4 lab) { return vec4(oklab2rgb(lab.xyz), lab.w); }
+
+vec3 oklabmix(vec3 c1, vec3 c2, float t) {
+    return oklab2rgb(mix(rgb2oklab(c1), rgb2oklab(c2), t));
+}
+
+vec4 oklabmix(vec4 c1, vec4 c2, float t) {
+    return vec4(oklabmix(c1.rgb, c2.rgb, t), mix(c1.a, c2.a, t));
 }
 
 // Utility to make any value pingpong (go forward then backward)

--- a/vscode-extension/index.ts
+++ b/vscode-extension/index.ts
@@ -231,7 +231,7 @@ export function activate(context: vscode.ExtensionContext) {
                 ]
 
                 // Paper Cranes Helper Functions
-                const helperFunctions = ["getLastFrameColor", "rgb2hsl", "hsl2rgb", "hslmix", "map"]
+                const helperFunctions = ["getLastFrameColor", "rgb2hsl", "hsl2rgb", "hslmix", "rgb2oklab", "oklab2rgb", "oklabmix", "map"]
 
                 // Paper Cranes Constants
                 const constants = ["PI", "TAU", "EPSILON", "resolution", "time", "random"]
@@ -424,7 +424,10 @@ export function activate(context: vscode.ExtensionContext) {
                         "Returns the color from the previous frame at the given UV coordinate.\nUsage: getLastFrameColor(vec2 uv)",
                     rgb2hsl: "Converts RGB color to HSL color space.\nUsage: rgb2hsl(vec3 rgb)",
                     hsl2rgb: "Converts HSL color to RGB color space.\nUsage: hsl2rgb(vec3 hsl)",
-                    hslmix: "Mixes two colors in HSL space.\nUsage: hslmix(vec3 col1, vec3 col2, float t)",
+                    hslmix: "Mixes two colors in HSL space.\nUsage: hslmix(vec3 col1, vec3 col2, float t)\nAlso accepts vec4 (alpha passed through).",
+                    rgb2oklab: "Converts RGB color to Oklab perceptual color space.\nUsage: rgb2oklab(vec3 rgb) or rgb2oklab(vec4 rgba)",
+                    oklab2rgb: "Converts Oklab color back to RGB.\nUsage: oklab2rgb(vec3 lab) or oklab2rgb(vec4 laba)",
+                    oklabmix: "Mixes two colors in Oklab perceptual space. Produces more natural gradients than HSL or RGB.\nUsage: oklabmix(vec3 col1, vec3 col2, float t)\nAlso accepts vec4 (alpha interpolated).",
                     map: "Maps a value from one range to another.\nUsage: map(float value, float inMin, float inMax, float outMin, float outMax)",
 
                     // Constants

--- a/vscode-extension/paper-cranes-fragment-shader.tmLanguage.json
+++ b/vscode-extension/paper-cranes-fragment-shader.tmLanguage.json
@@ -25,7 +25,7 @@
           },
           {
             "name": "support.function.paper-cranes",
-            "match": "\\b(rgb2hsl|hsl2rgb|getLastFrameColor|mapValue)\\b"
+            "match": "\\b(rgb2hsl|hsl2rgb|hslmix|rgb2oklab|oklab2rgb|oklabmix|getLastFrameColor|mapValue)\\b"
           },
           {
             "name": "support.constant.paper-cranes",


### PR DESCRIPTION
## Summary
- Adds Oklab perceptual color space functions (`rgb2oklab`, `oklab2rgb`, `oklabmix`) to the shader compilation step alongside existing HSL utilities
- Adds `vec4` overloads for all color functions (both HSL and Oklab) so they work naturally with alpha channels
- Validated with `glslangValidator` — all overloads compile cleanly

## Test plan
- [ ] Load any existing shader and confirm it still works (no regressions from new utility functions)
- [ ] Write a shader using `oklabmix()` and verify perceptually smooth color gradients

🤖 Generated with [Claude Code](https://claude.com/claude-code)