### PR TITLE
Add 20 ChromaDepth 3D shaders collection

### DIFF
--- a/shaders/claude/chromadepth-apollonian.frag
+++ b/shaders/claude/chromadepth-apollonian.frag
@@ -1,0 +1,322 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, fractal, apollonian, spheres, raymarching
+// ChromaDepth Apollonian Gasket - Nested sphere inversion fractal
+// Red = nearest (large outer spheres), Violet = farthest (tiny inner spheres)
+// Designed for ChromaDepth 3D glasses
+
+#define MAX_STEPS 40
+#define MAX_DIST 20.0
+#define SURF_DIST 0.002
+#define NORM_EPS 0.003
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// Inversion radius: bass modulates the fractal's inversion sphere
+#define INV_RADIUS (1.0 + bassZScore * 0.08)
+// #define INV_RADIUS 1.0
+
+// Fold offset: spectral centroid shifts the fold position
+#define FOLD_OFFSET (1.0 + spectralCentroidZScore * 0.06)
+// #define FOLD_OFFSET 1.0
+
+// Brightness: energy drives overall lightness
+#define BRIGHTNESS (0.55 + energyZScore * 0.12)
+// #define BRIGHTNESS 0.55
+
+// Beat pulse: brief flash on beats
+#define BEAT_PULSE (beat ? 1.25 : 1.0)
+// #define BEAT_PULSE 1.0
+
+// Treble specular: treble boosts specular highlights
+#define SPEC_POWER (16.0 + trebleZScore * 8.0)
+// #define SPEC_POWER 16.0
+
+// Specular intensity from treble
+#define SPEC_INTENSITY (0.3 + trebleNormalized * 0.4)
+// #define SPEC_INTENSITY 0.3
+
+// Camera orbit speed modulation
+#define CAM_SPEED (0.08 + spectralFluxZScore * 0.02)
+// #define CAM_SPEED 0.08
+
+// Color depth shift from spectral entropy
+#define DEPTH_SHIFT (spectralEntropyNormalized * 0.1)
+// #define DEPTH_SHIFT 0.0
+
+// Pitch class hue nudge
+#define HUE_NUDGE (pitchClassNormalized * 0.05)
+// #define HUE_NUDGE 0.0
+
+// Bass slope for slow structural drift
+#define STRUCT_DRIFT (bassSlope * 0.3)
+// #define STRUCT_DRIFT 0.0
+
+// Camera distance modulation from energy
+#define CAM_DIST_MOD (energyNormalized * 0.5)
+// #define CAM_DIST_MOD 0.0
+
+// Mids modulate ambient light
+#define AMBIENT (0.15 + midsZScore * 0.05)
+// #define AMBIENT 0.15
+
+// Spectral roughness adds grit to the surface
+#define SURFACE_GRIT (spectralRoughnessNormalized * 0.02)
+// #define SURFACE_GRIT 0.0
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+// Maps 0-1 depth to chromadepth rainbow:
+// 0.0 = red (closest), 0.5 = green (mid), 1.0 = blue/violet (farthest)
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// APOLLONIAN GASKET SDF (Sphere Inversion Fractal)
+// ============================================================================
+
+// Returns vec2(distance, generation) where generation = iteration depth
+vec2 apollonianSDF(vec3 p) {
+    float scale = 1.0;
+    float invR = INV_RADIUS;
+    float foldOff = FOLD_OFFSET;
+    float generation = 0.0;
+
+    // Sphere inversion fractal: fold, invert, repeat
+    for (int i = 0; i < 6; i++) {
+        // Box fold: reflect into positive octant with offset
+        p = abs(p);
+        // Conditional folds to create gasket structure
+        if (p.x - p.y < 0.0) p.xy = p.yx;
+        if (p.x - p.z < 0.0) p.xz = p.zx;
+        if (p.y - p.z < 0.0) p.yz = p.zy;
+
+        // Offset fold to break symmetry and create nesting
+        p = p * 2.0 - vec3(foldOff + STRUCT_DRIFT);
+        scale *= 2.0;
+
+        // Sphere inversion: invert through sphere of radius invR
+        float r2 = dot(p, p);
+        float k = max(invR / r2, 1.0);
+        p *= k;
+        scale *= k;
+
+        generation += 1.0;
+    }
+
+    // Final distance estimate: sphere at the end
+    float d = (length(p) - 1.0 + SURFACE_GRIT * sin(p.x * 30.0 + p.y * 30.0)) / max(scale, 0.001);
+
+    return vec2(d, generation);
+}
+
+// ============================================================================
+// RAYMARCHING
+// ============================================================================
+
+// Returns vec4(distance, generation, steps, closest_approach)
+vec4 raymarch(vec3 ro, vec3 rd) {
+    float t = 0.0;
+    float minDist = MAX_DIST;
+
+    for (int i = 0; i < MAX_STEPS; i++) {
+        vec3 p = ro + rd * t;
+        vec2 res = apollonianSDF(p);
+        float d = res.x;
+
+        minDist = min(minDist, d);
+
+        if (d < SURF_DIST) {
+            return vec4(t, res.y, float(i), minDist);
+        }
+        if (t > MAX_DIST) break;
+
+        // Step with a safety factor for the inversion SDF
+        t += d * 0.8;
+    }
+
+    return vec4(MAX_DIST, 0.0, float(MAX_STEPS), minDist);
+}
+
+// ============================================================================
+// NORMAL CALCULATION
+// ============================================================================
+
+vec3 getNormal(vec3 p) {
+    vec2 e = vec2(NORM_EPS, 0.0);
+    return normalize(vec3(
+        apollonianSDF(p + e.xyy).x - apollonianSDF(p - e.xyy).x,
+        apollonianSDF(p + e.yxy).x - apollonianSDF(p - e.yxy).x,
+        apollonianSDF(p + e.yyx).x - apollonianSDF(p - e.yyx).x
+    ));
+}
+
+// ============================================================================
+// CHEAP AMBIENT OCCLUSION (2 samples for mobile)
+// ============================================================================
+
+float cheapAO(vec3 p, vec3 n) {
+    float d1 = apollonianSDF(p + n * 0.1).x;
+    float d2 = apollonianSDF(p + n * 0.3).x;
+    return clamp(0.5 + (d1 + d2) * 2.0, 0.0, 1.0);
+}
+
+// ============================================================================
+// HASH FUNCTION
+// ============================================================================
+
+float hash(float n) {
+    return fract(sin(n) * 43758.5453);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    // Camera: slow orbit around the fractal
+    float camAngle = iTime * CAM_SPEED;
+    float camPitch = sin(iTime * 0.03) * 0.2 + 0.3;
+    float camDist = 4.5 - CAM_DIST_MOD;
+
+    vec3 ro = vec3(
+        sin(camAngle) * cos(camPitch) * camDist,
+        sin(camPitch) * camDist * 0.6 + 0.5,
+        cos(camAngle) * cos(camPitch) * camDist
+    );
+
+    vec3 lookAt = vec3(0.0, 0.0, 0.0);
+
+    // Camera matrix
+    vec3 forward = normalize(lookAt - ro);
+    vec3 right = normalize(cross(vec3(0.0, 1.0, 0.0), forward));
+    vec3 up = cross(forward, right);
+
+    float fov = 1.6;
+    vec3 rd = normalize(uv.x * right + uv.y * up + fov * forward);
+
+    // Raymarch
+    vec4 result = raymarch(ro, rd);
+    float dist = result.x;
+    float generation = result.y;
+    float steps = result.z;
+    float closest = result.w;
+
+    // Background: deep black/dark violet gradient (neutral in chromadepth)
+    vec3 col = vec3(0.0);
+    float skyGrad = rd.y * 0.5 + 0.5;
+    // Very subtle dark background - mostly black for chromadepth neutrality
+    vec3 bgCol = hsl2rgb(vec3(0.75, 0.3, 0.02 + skyGrad * 0.02));
+    col = bgCol;
+
+    // Glow from near-misses (AO glow around the fractal)
+    if (dist >= MAX_DIST && closest < 0.5) {
+        float glowIntensity = exp(-closest * 6.0);
+        // Glow uses depth coloring too - far misses = violet glow
+        float glowDepth = 0.7 + 0.3 * (1.0 - glowIntensity);
+        vec3 glowCol = chromadepth(glowDepth) * glowIntensity * 0.3;
+        col += glowCol;
+    }
+
+    if (dist < MAX_DIST) {
+        vec3 p = ro + rd * dist;
+        vec3 n = getNormal(p);
+
+        // Map generation to chromadepth depth:
+        // generation 0-1 = large outer spheres = red (near) = t near 0
+        // generation 5-6 = tiny inner spheres = violet (far) = t near 1
+        float depthT = generation / 6.0;
+        depthT = clamp(depthT + DEPTH_SHIFT, 0.0, 1.0);
+
+        // Also blend in ray distance for spatial depth
+        float rayDepthT = clamp((dist - 1.5) / 10.0, 0.0, 1.0);
+        // Mix: 70% generation-based, 30% ray-distance-based
+        float finalDepth = mix(depthT, rayDepthT, 0.3);
+        finalDepth = clamp(finalDepth + HUE_NUDGE, 0.0, 1.0);
+
+        // Get chromadepth base color
+        vec3 baseCol = chromadepth(finalDepth);
+
+        // Lighting
+        vec3 lightDir = normalize(vec3(0.6, 0.8, 0.4));
+        vec3 halfVec = normalize(lightDir - rd);
+
+        float diff = max(dot(n, lightDir), 0.0);
+        float spec = pow(max(dot(n, halfVec), 0.0), SPEC_POWER);
+
+        // Fill light from opposite side
+        vec3 fillDir = normalize(vec3(-0.4, 0.3, -0.6));
+        float fill = max(dot(n, fillDir), 0.0) * 0.25;
+
+        // Ambient occlusion
+        float ao = cheapAO(p, n);
+
+        // Combine lighting
+        float ambient = clamp(AMBIENT, 0.05, 0.4);
+        float lighting = ambient + diff * 0.6 + fill;
+        lighting *= ao;
+        lighting = clamp(lighting, 0.0, 1.0);
+
+        // Apply lighting to base chromadepth color
+        // Modulate lightness without destroying hue/saturation
+        vec3 litCol = baseCol * lighting;
+
+        // Add specular highlight (white-ish, keeping chromadepth readable)
+        vec3 specCol = chromadepth(max(finalDepth - 0.15, 0.0)); // specular tinted toward nearer hue
+        litCol += specCol * spec * SPEC_INTENSITY;
+
+        // Fake reflection: blend with a shifted depth color based on normal direction
+        float reflectT = clamp(finalDepth + (n.y * 0.15 - n.x * 0.1), 0.0, 1.0);
+        vec3 reflCol = chromadepth(reflectT) * 0.15;
+        litCol = mix(litCol, reflCol, 0.15);
+
+        // Brightness modulation
+        litCol *= clamp(BRIGHTNESS, 0.2, 1.0);
+
+        // Beat pulse
+        litCol *= BEAT_PULSE;
+
+        // Rim lighting for edge pop
+        float rim = pow(1.0 - max(dot(n, -rd), 0.0), 3.0);
+        vec3 rimCol = chromadepth(max(finalDepth - 0.2, 0.0));
+        litCol += rimCol * rim * 0.2;
+
+        // Depth fog: fade distant surfaces toward black (neutral in chromadepth)
+        float fog = exp(-dist * 0.12);
+        litCol = mix(bgCol, litCol, fog);
+
+        col = litCol;
+    }
+
+    // Vignette (keeps edges dark = neutral in chromadepth)
+    vec2 vc = fragCoord / iResolution.xy - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.6;
+
+    // Gentle frame feedback for motion smoothing
+    vec4 prev = getLastFrameColor(fragCoord / iResolution.xy);
+    col = mix(prev.rgb * 0.97, col, 0.7);
+
+    // Ensure saturation stays high for chromadepth effect
+    vec3 colHSL = rgb2hsl(col);
+    colHSL.y = min(colHSL.y * 1.1, 1.0);
+    colHSL.z = clamp(colHSL.z, 0.0, 0.6);
+    col = hsl2rgb(colHSL);
+
+    // Subtle dithering to reduce banding
+    float dither = (hash(dot(fragCoord, vec2(12.9898, 78.233)) + iTime) - 0.5) / 255.0;
+    col += dither;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-burning-ship.frag
+++ b/shaders/claude/chromadepth-burning-ship.frag
@@ -1,0 +1,259 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, fractal, burning-ship
+// ChromaDepth Burning Ship Fractal
+// The Burning Ship: z = (|Re(z)| + i|Im(z)|)^2 + c
+// Creates hull shapes and antenna structures unique to this fractal.
+// Auto-zooms along the antenna feature near c = (-1.755, 0.02).
+// ChromaDepth: Red = closest (boundary), Blue/Violet = farthest (fast escape), Black = neutral.
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (swap constants for audio uniforms)
+// ============================================================================
+
+// Real part drift: bass shifts along the antenna
+#define C_REAL_SHIFT (bassZScore * 0.008)
+// #define C_REAL_SHIFT 0.0
+
+// Imaginary part drift: treble shifts perpendicular
+#define C_IMAG_SHIFT (trebleZScore * 0.006)
+// #define C_IMAG_SHIFT 0.0
+
+// Zoom depth modulation: energy deepens the zoom
+#define ZOOM_ENERGY (energyNormalized * 0.4)
+// #define ZOOM_ENERGY 0.2
+
+// Zoom jump: spectral flux triggers zoom jumps
+#define ZOOM_JUMP (spectralFluxZScore * 0.15)
+// #define ZOOM_JUMP 0.0
+
+// Zoom slope: energy slope adjusts zoom rate
+#define ZOOM_TREND (energySlope * 8.0 * energyRSquared)
+// #define ZOOM_TREND 0.0
+
+// View rotation: spectral centroid rotates the view slowly
+#define VIEW_ROTATION (spectralCentroidZScore * 0.03)
+// #define VIEW_ROTATION 0.0
+
+// Brightness modulation from energy
+#define BRIGHTNESS_MOD (energyZScore * 0.12)
+// #define BRIGHTNESS_MOD 0.0
+
+// Beat flash
+#define BEAT_FLASH (beat ? 1.2 : 1.0)
+// #define BEAT_FLASH 1.0
+
+// Hue offset from pitch class
+#define HUE_DRIFT (pitchClassNormalized * 0.08)
+// #define HUE_DRIFT 0.0
+
+// Bass punch for interior glow
+#define BASS_GLOW (max(bassZScore, 0.0) * 0.15)
+// #define BASS_GLOW 0.0
+
+// Feedback strength from spectral entropy
+#define FEEDBACK_AMOUNT (0.3 + spectralEntropyNormalized * 0.15)
+// #define FEEDBACK_AMOUNT 0.35
+
+// Mids drift for pan
+#define PAN_DRIFT (midsZScore * 0.005)
+// #define PAN_DRIFT 0.0
+
+// Drop detection
+#define DROP_INTENSITY (max(-energyZScore, 0.0))
+// #define DROP_INTENSITY 0.0
+
+// Max iterations (mobile-safe)
+#define MAX_ITER 64
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+// 0.0 = red (closest), 0.5 = green (mid), 1.0 = violet (farthest)
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    // --- AUTO-ZOOM along the antenna feature ---
+    // The antenna of the Burning Ship sits near c = (-1.755, 0.02).
+    // We auto-zoom deeper over time, oscillating slightly along the antenna.
+    float t = iTime * 0.03;
+
+    // Zoom increases exponentially over time (slow auto-zoom in)
+    float baseZoom = exp(mod(t * 1.2, 8.0));
+    float zoom = baseZoom * (1.0 + ZOOM_ENERGY) + ZOOM_JUMP;
+    zoom = clamp(zoom, 1.0, 5000.0);
+    zoom += ZOOM_TREND * 0.5;
+    zoom = max(zoom, 0.5);
+
+    // Target position drifts along the antenna
+    // The main antenna extends from roughly (-1.75, 0.0) toward (-1.78, 0.0)
+    float driftPhase = t * 0.7;
+    float targetReal = -1.755 + sin(driftPhase) * 0.015 + C_REAL_SHIFT;
+    float targetImag = 0.02 + cos(driftPhase * 0.618) * 0.008 + C_IMAG_SHIFT;
+
+    // Apply pan drift
+    targetImag += PAN_DRIFT;
+
+    // Apply view rotation
+    float angle = iTime * 0.01 + VIEW_ROTATION;
+    float ca = cos(angle), sa = sin(angle);
+    uv = mat2(ca, -sa, sa, ca) * uv;
+
+    // Scale UV by zoom and center on target
+    vec2 c = vec2(targetReal, targetImag) + uv / zoom;
+
+    // --- BURNING SHIP ITERATION ---
+    // z_{n+1} = (|Re(z_n)| + i*|Im(z_n)|)^2 + c
+    vec2 z = vec2(0.0);
+    float smoothIter = 0.0;
+    bool escaped = false;
+
+    // Orbit traps for interior structure
+    float trapAxisX = 1e10;   // distance to real axis
+    float trapAxisY = 1e10;   // distance to imaginary axis
+    float trapOrigin = 1e10;  // distance to origin
+    float trapCross = 1e10;   // min of axis distances
+    float orbitAngle = 0.0;
+
+    for (int i = 0; i < MAX_ITER; i++) {
+        // The Burning Ship formula: abs before squaring
+        z = vec2(abs(z.x), abs(z.y));
+        z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+
+        float mag2 = dot(z, z);
+
+        // Orbit traps
+        trapAxisX = min(trapAxisX, abs(z.y));
+        trapAxisY = min(trapAxisY, abs(z.x));
+        trapOrigin = min(trapOrigin, sqrt(mag2));
+        trapCross = min(trapCross, min(abs(z.x), abs(z.y)));
+        orbitAngle += atan(z.y, z.x);
+
+        if (mag2 > 256.0) {
+            // Smooth iteration count
+            smoothIter = float(i) - log2(log2(mag2)) + 4.0;
+            escaped = true;
+            break;
+        }
+        smoothIter = float(i);
+    }
+
+    // --- DEPTH MAPPING for ChromaDepth ---
+    float depth;
+    float brightness = 1.0;
+
+    if (escaped) {
+        // Exterior: boundary = red (near), fast escape = violet (far)
+        float iterFrac = smoothIter / float(MAX_ITER);
+        float logIter = log(1.0 + smoothIter) / log(1.0 + float(MAX_ITER));
+
+        // Near boundary (high iterFrac = many iterations before escape)
+        // maps to lower depth (redder = closer)
+        // Fast escape (low iterFrac) maps to higher depth (violet = farther)
+        depth = mix(0.95, 0.35, pow(logIter, 0.45));
+
+        // Brightness fades for fast escape (far away = darker)
+        brightness = mix(0.12, 0.9, pow(logIter, 0.55));
+    } else {
+        // Interior: orbit traps reveal the ship hull structure
+        float tOrigin = clamp(trapOrigin * 1.2, 0.0, 1.0);
+        float tAxisX = clamp(trapAxisX * 3.0, 0.0, 1.0);
+        float tAxisY = clamp(trapAxisY * 3.0, 0.0, 1.0);
+        float tCross = clamp(trapCross * 2.5, 0.0, 1.0);
+        float tAngle = fract(orbitAngle * 0.06);
+        float tAngle2 = abs(sin(orbitAngle * 0.15));
+
+        // The ship hull and antenna show up as sharp features in the axis traps
+        float hullDetail = min(tAxisX, tAxisY);
+        float structure = hullDetail * 0.4 + tCross * 0.3 + tOrigin * 0.3;
+
+        // Angular texture for variation
+        float texture = tAngle * 0.4 + tAngle2 * 0.3 + tOrigin * 0.3;
+
+        // Combine with contrast
+        float contrast = abs(structure - texture) * 0.6;
+        float blend = structure * 0.35 + texture * 0.35 + contrast * 0.3;
+
+        // S-curve for better spread
+        blend = smoothstep(0.05, 0.95, blend);
+
+        // Interior: red (0.0) through green (0.4) — closest layers
+        depth = blend * 0.4;
+
+        // Interior brightness with structural variation
+        brightness = 0.45 + hullDetail * 0.2 + (1.0 - tOrigin) * 0.2 + contrast * 0.15;
+    }
+
+    // Drop effect: push toward red (near)
+    depth = mix(depth, 0.0, DROP_INTENSITY * 0.4);
+
+    // Hue drift from pitch
+    depth = fract(depth + HUE_DRIFT);
+
+    // --- COLOR ---
+    vec3 col = chromadepth(depth);
+
+    // Brightness modulation
+    col *= clamp(brightness + BRIGHTNESS_MOD, 0.15, 1.3);
+
+    // Bass glow on interior
+    if (!escaped) {
+        col += BASS_GLOW * vec3(0.3, 0.05, 0.0);
+    }
+
+    // Beat flash
+    col *= BEAT_FLASH;
+
+    // Edge glow from derivatives
+    float edge = length(vec2(dFdx(depth), dFdy(depth)));
+    float edgeGlow = smoothstep(0.0, 0.05, edge) * 0.2;
+    col += edgeGlow * vec3(1.0, 0.9, 0.8);
+
+    // --- FRAME FEEDBACK ---
+    // Gentle feedback with slow drift to prevent static loops
+    float fbAngle = iTime * 0.008;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotatedUV = vec2(
+        centered.x * fbc - centered.y * fbs,
+        centered.x * fbs + centered.y * fbc
+    ) + 0.5;
+
+    // Slight zoom-in on feedback for trailing effect
+    vec2 fbUV = mix(vec2(0.5), rotatedUV, 0.998);
+    fbUV = clamp(fbUV, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    // Decay previous frame
+    prev *= 0.96;
+
+    // Blend: new frame dominates, feedback provides gentle trails
+    float fbAmount = clamp(FEEDBACK_AMOUNT, 0.15, 0.5);
+    fbAmount -= DROP_INTENSITY * 0.15; // drops = more new frame
+    fbAmount = clamp(fbAmount, 0.1, 0.5);
+
+    col = mix(col, prev, fbAmount);
+
+    // --- VIGNETTE ---
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    // Final clamp
+    col = clamp(col, 0.0, 1.0);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-coral.frag
+++ b/shaders/claude/chromadepth-coral.frag
@@ -1,0 +1,563 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, coral, organic, raymarching
+// ChromaDepth Coral Reef - Procedural underwater reef with branching coral,
+// anemone tentacles, and rocky base. Designed for ChromaDepth 3D glasses.
+// Red = closest coral tips, Green = mid-depth, Blue/Violet = deep crevices
+// Black = neutral depth
+
+#define MAX_STEPS 40
+#define MAX_DIST 18.0
+#define SURF_DIST 0.004
+#define NORM_EPS 0.004
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// Coral growth/retraction: bass expands coral branches
+#define CORAL_GROWTH (0.9 + bassZScore * 0.15)
+// #define CORAL_GROWTH 1.0
+
+// Tentacle sway amplitude: mids drive anemone movement
+#define TENTACLE_SWAY (midsZScore * 0.25)
+// #define TENTACLE_SWAY 0.12
+
+// Caustic animation speed: treble accelerates light ripples
+#define CAUSTIC_SPEED (1.0 + trebleZScore * 0.6)
+// #define CAUSTIC_SPEED 1.0
+
+// Water clarity / fog density: energy clears the water
+#define WATER_CLARITY (0.06 - energyNormalized * 0.025)
+// #define WATER_CLARITY 0.05
+
+// Bioluminescent flash on beat
+#define BIO_FLASH (beat ? 0.35 : 0.0)
+// #define BIO_FLASH 0.0
+
+// Camera drift speed: spectral flux nudges forward motion
+#define DRIFT_SPEED (0.15 + spectralFluxZScore * 0.06)
+// #define DRIFT_SPEED 0.18
+
+// Color hue shift from pitch class
+#define HUE_SHIFT (pitchClassNormalized * 0.04)
+// #define HUE_SHIFT 0.0
+
+// Spectral entropy adds turbulence to coral surface
+#define SURFACE_TURB (spectralEntropyNormalized * 0.12)
+// #define SURFACE_TURB 0.06
+
+// Bass slope for trend-based growth (building = expanding)
+#define GROWTH_TREND (bassSlope * 8.0 * bassRSquared)
+// #define GROWTH_TREND 0.0
+
+// Energy slope for atmospheric trend
+#define ATMOSPHERE_TREND (energySlope * 5.0 * energyRSquared)
+// #define ATMOSPHERE_TREND 0.0
+
+// Spectral centroid brightness modulation
+#define BRIGHTNESS_MOD (1.0 + spectralCentroidZScore * 0.08)
+// #define BRIGHTNESS_MOD 1.0
+
+// Roughness drives coral texture detail
+#define ROUGHNESS_DETAIL (spectralRoughnessNormalized * 0.04)
+// #define ROUGHNESS_DETAIL 0.02
+
+// Bass brightness pulse
+#define BASS_PULSE (0.95 + bassNormalized * 0.1)
+// #define BASS_PULSE 1.0
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// UTILITY
+// ============================================================================
+
+float hash(float n) {
+    return fract(sin(n) * 43758.5453);
+}
+
+float hash2(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+// Simple 3D noise for organic shapes
+float noise3(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float n = dot(i, vec3(1.0, 57.0, 113.0));
+    return mix(
+        mix(mix(hash(n), hash(n + 1.0), f.x),
+            mix(hash(n + 57.0), hash(n + 58.0), f.x), f.y),
+        mix(mix(hash(n + 113.0), hash(n + 114.0), f.x),
+            mix(hash(n + 170.0), hash(n + 171.0), f.x), f.y),
+        f.z
+    );
+}
+
+mat2 rot2(float a) {
+    float c = cos(a), s = sin(a);
+    return mat2(c, -s, s, c);
+}
+
+float smin(float a, float b, float k) {
+    float h = clamp(0.5 + 0.5 * (b - a) / max(k, 0.001), 0.0, 1.0);
+    return mix(b, a, h) - k * h * (1.0 - h);
+}
+
+// ============================================================================
+// SDF PRIMITIVES
+// ============================================================================
+
+float sdSphere(vec3 p, float r) {
+    return length(p) - r;
+}
+
+float sdCapsule(vec3 p, vec3 a, vec3 b, float r) {
+    vec3 ab = b - a;
+    float t = clamp(dot(p - a, ab) / max(dot(ab, ab), 0.001), 0.0, 1.0);
+    return length(p - a - ab * t) - r;
+}
+
+float sdBox(vec3 p, vec3 b) {
+    vec3 q = abs(p) - b;
+    return length(max(q, 0.0)) + min(max(q.x, max(q.y, q.z)), 0.0);
+}
+
+float sdPlane(vec3 p, float h) {
+    return p.y - h;
+}
+
+// ============================================================================
+// CORAL STRUCTURES
+// ============================================================================
+
+// Branching coral using box-fold IFS with organic distortion
+float branchingCoral(vec3 p, float growth) {
+    float d = 1e10;
+    float scale = 1.8 * growth;
+
+    // Organic offset based on position
+    p += vec3(
+        sin(p.y * 2.3 + iTime * 0.1) * SURFACE_TURB,
+        0.0,
+        cos(p.x * 1.7 + iTime * 0.08) * SURFACE_TURB
+    );
+
+    vec3 z = p;
+    float dr = 1.0;
+
+    // IFS fractal: 6 iterations max for mobile
+    for (int i = 0; i < 6; i++) {
+        // Box fold: fold space to create branching
+        z = clamp(z, -1.0, 1.0) * 2.0 - z;
+
+        // Sphere fold with audio-reactive radius
+        float r2 = dot(z, z);
+        float minR2 = 0.25 + ROUGHNESS_DETAIL;
+        if (r2 < minR2) {
+            float t = 1.0 / max(minR2, 0.001);
+            z *= t;
+            dr *= t;
+        } else if (r2 < 1.0) {
+            float t = 1.0 / max(r2, 0.001);
+            z *= t;
+            dr *= t;
+        }
+
+        z = z * scale + p;
+        dr = dr * abs(scale) + 1.0;
+
+        // Early bail for mobile perf
+        if (dot(z, z) > 100.0) break;
+    }
+
+    return length(z) / max(abs(dr), 0.001) - 0.002;
+}
+
+// Sea anemone tentacles: displaced cylinders swaying with mids
+float anemone(vec3 p, vec3 base, float tentacleCount) {
+    float d = 1e10;
+    float t = iTime;
+
+    for (float i = 0.0; i < 5.0; i++) {
+        float angle = (i / max(tentacleCount, 0.001)) * 6.283 + hash(i * 13.7) * 1.5;
+        float spread = 0.15 + hash(i * 7.3) * 0.1;
+        float height = 0.4 + hash(i * 19.1) * 0.3;
+
+        // Sway with audio
+        float swayX = sin(t * 1.5 + i * 2.1 + p.y * 3.0) * (0.06 + TENTACLE_SWAY * 0.1);
+        float swayZ = cos(t * 1.2 + i * 1.7 + p.y * 2.5) * (0.04 + TENTACLE_SWAY * 0.08);
+
+        vec3 tipOffset = vec3(
+            cos(angle) * spread + swayX,
+            height,
+            sin(angle) * spread + swayZ
+        );
+
+        vec3 basePos = base;
+        vec3 tipPos = base + tipOffset;
+
+        // Thicker at base, thinner at tip
+        float tentacle = sdCapsule(p, basePos, tipPos, 0.02);
+
+        // Bulbous tip
+        float tip = sdSphere(p - tipPos, 0.035);
+        tentacle = smin(tentacle, tip, 0.03);
+
+        d = smin(d, tentacle, 0.02);
+    }
+
+    return d;
+}
+
+// Rocky base terrain using layered noise
+float rockyBase(vec3 p) {
+    float base = p.y + 1.2;
+
+    // Layered displacement for rocky texture
+    float disp = 0.0;
+    disp += noise3(p * 1.5) * 0.4;
+    disp += noise3(p * 3.0 + 17.0) * 0.2;
+    disp += noise3(p * 6.0 + 31.0) * 0.08;
+
+    // Create ridges and crevices
+    float ridges = abs(sin(p.x * 2.5 + p.z * 1.8)) * 0.15;
+
+    return base - disp - ridges;
+}
+
+// ============================================================================
+// FULL SCENE SDF
+// ============================================================================
+
+// Material IDs: 0=miss, 1=coral, 2=anemone, 3=rock, 4=sand
+struct Hit {
+    float d;
+    float mat;
+};
+
+Hit hMin(Hit a, Hit b) {
+    return a.d < b.d ? a : b;
+}
+
+Hit sminH(Hit a, Hit b, float k) {
+    float h = clamp(0.5 + 0.5 * (b.d - a.d) / max(k, 0.001), 0.0, 1.0);
+    float d = mix(b.d, a.d, h) - k * h * (1.0 - h);
+    float m = h > 0.5 ? a.mat : b.mat;
+    return Hit(d, m);
+}
+
+Hit sceneSDF(vec3 p) {
+    Hit result = Hit(MAX_DIST, 0.0);
+
+    float growth = clamp(CORAL_GROWTH + GROWTH_TREND * 0.05, 0.7, 1.3);
+
+    // --- BRANCHING CORAL CLUSTERS ---
+
+    // Cluster 1: large central formation
+    vec3 c1p = p - vec3(0.0, -0.2, 0.0);
+    c1p.xz *= rot2(0.3);
+    float coral1 = branchingCoral(c1p * 1.2, growth) / 1.2;
+    result = hMin(result, Hit(coral1, 1.0));
+
+    // Cluster 2: left side, different orientation
+    vec3 c2p = p - vec3(-1.8, -0.5, 1.2);
+    c2p.xz *= rot2(1.8);
+    c2p.yz *= rot2(0.2);
+    float coral2 = branchingCoral(c2p * 1.5, growth * 0.9) / 1.5;
+    result = hMin(result, Hit(coral2, 1.0));
+
+    // Cluster 3: right side, smaller
+    vec3 c3p = p - vec3(1.5, -0.4, -0.8);
+    c3p.xz *= rot2(3.1);
+    float coral3 = branchingCoral(c3p * 1.8, growth * 0.85) / 1.8;
+    result = hMin(result, Hit(coral3, 1.0));
+
+    // Cluster 4: background
+    vec3 c4p = p - vec3(0.5, -0.3, -2.5);
+    c4p.xz *= rot2(0.9);
+    float coral4 = branchingCoral(c4p * 1.3, growth * 0.95) / 1.3;
+    result = hMin(result, Hit(coral4, 1.0));
+
+    // --- SEA ANEMONES ---
+
+    // Anemone 1: nestled in coral
+    float anem1 = anemone(p, vec3(-0.5, -0.6, 0.8), 5.0);
+    result = hMin(result, Hit(anem1, 2.0));
+
+    // Anemone 2: on rock ledge
+    float anem2 = anemone(p, vec3(0.8, -0.7, 0.3), 5.0);
+    result = hMin(result, Hit(anem2, 2.0));
+
+    // Anemone 3: background
+    float anem3 = anemone(p, vec3(-1.0, -0.8, -1.5), 5.0);
+    result = hMin(result, Hit(anem3, 2.0));
+
+    // --- ROCKY BASE ---
+    float rock = rockyBase(p);
+    result = sminH(result, Hit(rock, 3.0), 0.15);
+
+    // --- SANDY FLOOR ---
+    float sand = p.y + 1.5 + noise3(p * 4.0) * 0.05;
+    result = sminH(result, Hit(sand, 4.0), 0.1);
+
+    return result;
+}
+
+// ============================================================================
+// NORMALS
+// ============================================================================
+
+vec3 getNormal(vec3 p) {
+    vec2 e = vec2(NORM_EPS, 0.0);
+    return normalize(vec3(
+        sceneSDF(p + e.xyy).d - sceneSDF(p - e.xyy).d,
+        sceneSDF(p + e.yxy).d - sceneSDF(p - e.yxy).d,
+        sceneSDF(p + e.yyx).d - sceneSDF(p - e.yyx).d
+    ));
+}
+
+// ============================================================================
+// FAKE CAUSTICS
+// ============================================================================
+
+float caustics(vec2 p, float time) {
+    float speed = time * CAUSTIC_SPEED;
+    float c = 0.0;
+    // Two layers of animated sin waves for caustic pattern
+    c += sin(p.x * 3.7 + speed * 0.8) * sin(p.y * 4.3 - speed * 0.6) * 0.5;
+    c += sin(p.x * 5.1 - speed * 1.1 + p.y * 2.8) * sin(p.y * 6.7 + speed * 0.9) * 0.3;
+    c += sin((p.x + p.y) * 2.5 + speed * 0.5) * 0.2;
+    return c * c; // square for sharper bright lines
+}
+
+// ============================================================================
+// CHEAP AO (2-sample for mobile)
+// ============================================================================
+
+float cheapAO(vec3 p, vec3 n) {
+    float d1 = sceneSDF(p + n * 0.08).d;
+    float d2 = sceneSDF(p + n * 0.25).d;
+    return clamp(0.5 + (d1 + d2) * 2.5, 0.0, 1.0);
+}
+
+// ============================================================================
+// RAYMARCHING
+// ============================================================================
+
+Hit raymarch(vec3 ro, vec3 rd) {
+    float t = 0.0;
+
+    for (int i = 0; i < MAX_STEPS; i++) {
+        vec3 p = ro + rd * t;
+        Hit h = sceneSDF(p);
+
+        if (h.d < SURF_DIST) {
+            return Hit(t, h.mat);
+        }
+        if (t > MAX_DIST) break;
+
+        // Slightly conservative step for complex SDF
+        t += h.d * 0.85;
+    }
+
+    return Hit(MAX_DIST, 0.0);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    float t = iTime;
+
+    // --- CAMERA: slow drift forward through the reef ---
+    float driftZ = t * DRIFT_SPEED;
+    float camSway = sin(t * 0.15) * 0.8;
+    float camBob = sin(t * 0.22) * 0.15;
+
+    vec3 ro = vec3(
+        camSway + spectralCentroidZScore * 0.03,
+        0.3 + camBob,
+        3.0 + driftZ
+    );
+
+    // Look slightly ahead and down into the reef
+    vec3 lookAt = ro + vec3(sin(t * 0.08) * 0.5, -0.3, -2.5);
+
+    vec3 forward = normalize(lookAt - ro);
+    vec3 right = normalize(cross(vec3(0.0, 1.0, 0.0), forward));
+    vec3 up = cross(forward, right);
+
+    float fov = 1.6;
+    vec3 rd = normalize(uv.x * right + uv.y * up + fov * forward);
+
+    // --- RAYMARCH ---
+    Hit result = raymarch(ro, rd);
+    float dist = result.d;
+    float mat = result.mat;
+
+    // --- UNDERWATER BACKGROUND ---
+    // Deep blue water that fades darker with depth
+    float bgGrad = clamp(rd.y * 0.5 + 0.5, 0.0, 1.0);
+    // Deeper looking down, lighter looking up
+    float bgDepth = mix(0.95, 0.65, bgGrad);
+    vec3 bgCol = chromadepth(bgDepth);
+    // Darken the deep background
+    bgCol *= mix(0.15, 0.4, bgGrad);
+
+    // Underwater light rays from above (god rays)
+    float rays = 0.0;
+    float rayX = screenUV.x * 8.0 + t * 0.3;
+    rays += pow(max(0.0, sin(rayX)), 12.0) * 0.15;
+    rays += pow(max(0.0, sin(rayX * 0.7 + 1.5)), 8.0) * 0.1;
+    rays *= max(0.0, rd.y + 0.3); // only visible looking upward
+    bgCol += vec3(0.05, 0.12, 0.15) * rays;
+
+    vec3 col = bgCol;
+
+    if (dist < MAX_DIST) {
+        vec3 p = ro + rd * dist;
+        vec3 n = getNormal(p);
+
+        // --- LIGHTING ---
+        // Key light from above-right (sun through water)
+        vec3 lightDir = normalize(vec3(0.3, 0.9, -0.2));
+        float diff = max(dot(n, lightDir), 0.0);
+
+        // Fill light from water scatter
+        float fill = max(dot(n, vec3(-0.2, 0.3, 0.5)), 0.0) * 0.25;
+
+        // Cheap AO
+        float ao = cheapAO(p, n);
+
+        // Caustic light pattern on surfaces
+        float causticsVal = caustics(p.xz, t) * max(0.0, n.y) * 0.5;
+
+        // Total light
+        float totalLight = (diff + fill) * ao + causticsVal;
+
+        // --- CHROMADEPTH MAPPING ---
+        // Map hit distance to 0-1: near = 0 (red), far = 1 (violet)
+        float depthT = clamp((dist - 1.0) / (MAX_DIST - 2.0), 0.0, 1.0);
+
+        // Material adjustments to depth perception
+        float lightness = 0.35 + totalLight * 0.25;
+
+        if (mat < 1.5) {
+            // Coral: tips closer = redder, base deeper = greener
+            // Slight forward push for coral
+            depthT *= 0.85;
+            lightness += 0.05;
+            // Add surface detail coloring
+            float coralTex = noise3(p * 8.0 + 5.0) * 0.03;
+            depthT += coralTex;
+        } else if (mat < 2.5) {
+            // Anemone: bright, slightly forward (saturated colors)
+            depthT *= 0.8;
+            lightness += 0.1;
+            // Bioluminescent glow
+            float glow = sin(t * 3.0 + p.y * 10.0) * 0.5 + 0.5;
+            lightness += glow * 0.06;
+        } else if (mat < 3.5) {
+            // Rock: neutral mid-depth
+            depthT *= 0.95;
+            lightness -= 0.03;
+        } else {
+            // Sand: far, blue-ish
+            depthT = mix(depthT, 0.8, 0.3);
+            lightness -= 0.05;
+        }
+
+        depthT = clamp(depthT + HUE_SHIFT, 0.0, 1.0);
+
+        col = chromadepth(depthT);
+        col *= clamp(lightness, 0.08, 0.6);
+
+        // --- BIOLUMINESCENT FLASH on beat ---
+        if (BIO_FLASH > 0.01) {
+            // Flash centered on nearby surfaces, pulsing outward
+            float flashDist = clamp(1.0 - dist * 0.1, 0.0, 1.0);
+            // Bioluminescent teal-green
+            vec3 bioColor = hsl2rgb(vec3(0.48, 0.9, 0.5));
+            col += bioColor * BIO_FLASH * flashDist;
+        }
+
+        // Brightness modulation
+        col *= BRIGHTNESS_MOD;
+        col *= BASS_PULSE;
+
+        // --- DEPTH FOG: fade toward deep blue with distance ---
+        float fogAmount = 1.0 - exp(-dist * WATER_CLARITY);
+        fogAmount = clamp(fogAmount + ATMOSPHERE_TREND * 0.02, 0.0, 0.95);
+        // Fog color: deep blue water
+        vec3 fogCol = chromadepth(0.9) * 0.2;
+        col = mix(col, fogCol, fogAmount);
+    }
+
+    // --- FLOATING PARTICLES (underwater dust/plankton) ---
+    for (int i = 0; i < 8; i++) {
+        float fi = float(i);
+        float px = hash(fi * 7.3) * 2.0 - 1.0;
+        float py = hash(fi * 13.1) * 1.5 - 0.75;
+        float pz = hash(fi * 23.7) * 3.0;
+
+        px += sin(t * 0.3 + fi * 2.1) * 0.2;
+        py += sin(t * 0.4 + fi * 1.7) * 0.1;
+
+        // Project particle to screen space (approximate)
+        vec3 particlePos = vec3(px, py, pz);
+        vec3 toParticle = particlePos - ro;
+        float proj = dot(toParticle, normalize(rd));
+        if (proj < 0.5) continue;
+
+        vec2 particleScreen = vec2(
+            dot(toParticle, right) / max(proj, 0.001),
+            dot(toParticle, up) / max(proj, 0.001)
+        );
+
+        float pdist = length(uv - particleScreen);
+        float particleBright = smoothstep(0.015, 0.0, pdist);
+        particleBright *= 0.3 + 0.2 * sin(t * 2.0 + fi * 5.0);
+
+        // Particles glow faintly in the chromadepth range
+        float particleDepth = clamp(pz / 4.0, 0.3, 0.7);
+        col += chromadepth(particleDepth) * particleBright * 0.15;
+    }
+
+    // --- VIGNETTE ---
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    // --- FRAME FEEDBACK (subtle motion blur for underwater feel) ---
+    vec4 prev = getLastFrameColor(screenUV);
+    col = mix(prev.rgb * 0.96, col, 0.7);
+
+    // --- ENSURE SATURATION for chromadepth ---
+    vec3 colHSL = rgb2hsl(col);
+    colHSL.y = min(colHSL.y * 1.1, 1.0);
+    colHSL.z = clamp(colHSL.z, 0.03, 0.55);
+    col = hsl2rgb(colHSL);
+
+    // Subtle dithering
+    float dither = (hash(dot(fragCoord, vec2(12.9898, 78.233)) + iTime) - 0.5) / 255.0;
+    col += dither;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-geodesic.frag
+++ b/shaders/claude/chromadepth-geodesic.frag
@@ -1,0 +1,454 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, geodesic, sphere, geometric, raymarching
+// ChromaDepth Geodesic Sphere - Nested icosahedral shells with fractal subdivision
+// Outermost shell = red/near, inner shells = green -> blue/violet (far)
+// Camera orbits outside looking through gaps between shells
+// Designed for ChromaDepth 3D glasses: Red=near, Green=mid, Blue/Violet=far
+
+#define MAX_STEPS 40
+#define MAX_DIST 20.0
+#define SURF_DIST 0.003
+#define NORM_EPS 0.003
+#define PI 3.14159265
+#define TAU 6.28318530
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// Shell separation: bass breathing - shells expand/contract
+#define SHELL_BREATHE (bassZScore * 0.12)
+// #define SHELL_BREATHE 0.0
+
+// Face subdivision detail: spectral centroid shifts edge thickness
+#define FACE_DETAIL (spectralCentroidZScore * 0.3)
+// #define FACE_DETAIL 0.0
+
+// Rotation speed: pitch class controls orbit rate
+#define ROTATION_AUDIO (pitchClassNormalized * 0.4)
+// #define ROTATION_AUDIO 0.0
+
+// Face brightness pulse: energy drives individual face glow
+#define FACE_BRIGHTNESS (0.85 + energyZScore * 0.15)
+// #define FACE_BRIGHTNESS 0.85
+
+// Beat expansion: beat triggers shell expansion pulse
+#define BEAT_EXPAND (beat ? 0.15 : 0.0)
+// #define BEAT_EXPAND 0.0
+
+// Treble edge glow: treble adds glow between faces
+#define EDGE_GLOW_AMOUNT (0.2 + trebleZScore * 0.3)
+// #define EDGE_GLOW_AMOUNT 0.2
+
+// Camera zoom from energy
+#define CAM_ZOOM (energyNormalized * 0.5)
+// #define CAM_ZOOM 0.0
+
+// Bass slope for trend-aware breathing
+#define BASS_TREND (bassSlope * 15.0 * bassRSquared)
+// #define BASS_TREND 0.0
+
+// Spectral centroid trend for smooth detail changes
+#define DETAIL_TREND (spectralCentroidSlope * 10.0 * spectralCentroidRSquared)
+// #define DETAIL_TREND 0.0
+
+// Entropy for chaos modulation
+#define CHAOS_AMOUNT (spectralEntropyNormalized)
+// #define CHAOS_AMOUNT 0.5
+
+// Mids for camera vertical bob
+#define CAM_BOB (midsZScore * 0.08)
+// #define CAM_BOB 0.0
+
+// Roughness for surface texture
+#define SURFACE_ROUGHNESS (spectralRoughnessNormalized)
+// #define SURFACE_ROUGHNESS 0.5
+
+// Spectral flux for jitter
+#define FLUX_JITTER (spectralFluxZScore * 0.02)
+// #define FLUX_JITTER 0.0
+
+// Energy trend for build detection
+#define ENERGY_TREND (energySlope * 12.0 * energyRSquared)
+// #define ENERGY_TREND 0.0
+
+// Bass normalized for smooth modulation
+#define BASS_SMOOTH (bassNormalized)
+// #define BASS_SMOOTH 0.5
+
+// Treble normalized
+#define TREBLE_SMOOTH (trebleNormalized)
+// #define TREBLE_SMOOTH 0.5
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// UTILITY
+// ============================================================================
+
+mat2 rot2(float a) {
+    float c = cos(a), s = sin(a);
+    return mat2(c, -s, s, c);
+}
+
+float hash(float n) {
+    return fract(sin(n) * 43758.5453);
+}
+
+float hash3(vec3 p) {
+    return fract(sin(dot(p, vec3(127.1, 311.7, 74.7))) * 43758.5453);
+}
+
+// ============================================================================
+// ICOSAHEDRON SDF
+// ============================================================================
+
+// Icosahedron SDF using the intersection of half-spaces
+// The 12 vertices of a regular icosahedron define 20 triangular faces
+// We use the face normals for an exact SDF
+
+float sdIcosahedron(vec3 p, float r) {
+    // Golden ratio
+    float phi = (1.0 + sqrt(5.0)) * 0.5;
+    float invLen = 1.0 / sqrt(1.0 + phi * phi);
+
+    // Icosahedron face normals (normalized)
+    // There are 20 faces but due to symmetry we only need unique face normal directions
+    vec3 n1 = vec3(0.0, 1.0, phi) * invLen;
+    vec3 n2 = vec3(0.0, 1.0, -phi) * invLen;
+    vec3 n3 = vec3(1.0, phi, 0.0) * invLen;
+    vec3 n4 = vec3(-1.0, phi, 0.0) * invLen;
+    vec3 n5 = vec3(phi, 0.0, 1.0) * invLen;
+    vec3 n6 = vec3(-phi, 0.0, 1.0) * invLen;
+
+    vec3 ap = abs(p);
+
+    // Distance as max of dot products with face normals (exploiting symmetry with abs)
+    float d = dot(ap, n1);
+    d = max(d, dot(ap, n2));
+    d = max(d, dot(ap, n3));
+    d = max(d, dot(ap, n4));
+    d = max(d, dot(ap, n5));
+    d = max(d, dot(ap, n6));
+
+    return d - r;
+}
+
+// ============================================================================
+// GEODESIC FACE PATTERN
+// ============================================================================
+
+// Creates the triangular face subdivision pattern on a sphere surface
+// Returns edge distance (0 at edge, positive inside face)
+float geodesicFaces(vec3 p, float freq) {
+    // Project point onto unit sphere (guard against zero-length)
+    vec3 n = normalize(p + vec3(0.0001));
+
+    // Use icosahedral symmetry to fold into fundamental domain
+    // We approximate this with a triangular tiling on the sphere
+    // using spherical coordinates mapped to a hex/tri grid
+
+    // Convert to spherical coords
+    float theta = acos(clamp(n.y, -1.0, 1.0));
+    float phi_angle = atan(n.z, n.x);
+
+    // Triangular grid on the sphere surface
+    float u = theta * freq;
+    float v = phi_angle * freq * 0.5;
+
+    // Triangular tiling
+    float gu = fract(u);
+    float gv = fract(v);
+
+    // Distance to nearest triangle edge (3 edges per triangle)
+    float triEdge;
+    if (gu + gv < 1.0) {
+        triEdge = min(min(gu, gv), 1.0 - gu - gv);
+    } else {
+        float gu2 = 1.0 - gu;
+        float gv2 = 1.0 - gv;
+        triEdge = min(min(gu2, gv2), 1.0 - gu2 - gv2);
+    }
+
+    return triEdge;
+}
+
+// ============================================================================
+// NESTED GEODESIC SHELLS SDF
+// ============================================================================
+
+// Returns: vec2(distance, shellIndex)
+// shellIndex: 0 = outermost (red/near), higher = inner (blue/far)
+
+vec2 geodesicShells(vec3 p, float time) {
+    // Audio-reactive shell parameters
+    float breathe = SHELL_BREATHE + BASS_TREND * 0.02;
+    float beatPulse = BEAT_EXPAND;
+
+    // Number of nested shells
+    float d = MAX_DIST;
+    float shellId = 0.0;
+
+    // Detail frequency increases for inner shells (more subdivision)
+    float detailBase = 3.0 + FACE_DETAIL + DETAIL_TREND * 0.1;
+
+    for (int i = 0; i < 4; i++) {
+        float fi = float(i);
+
+        // Shell radii: outermost (0) to innermost (3)
+        float baseRadius = 2.2 - fi * 0.5;
+
+        // Shell radius with breathing and beat
+        float radius = baseRadius + breathe * (1.0 - fi * 0.2) + beatPulse * (1.0 - fi * 0.25);
+
+        // Per-shell rotation (inner shells rotate differently)
+        vec3 rp = p;
+        float rotSpeed = 0.15 + ROTATION_AUDIO;
+        float shellAngle = time * rotSpeed * (1.0 + fi * 0.3) * (mod(fi, 2.0) < 0.5 ? 1.0 : -1.0);
+        rp.xz *= rot2(shellAngle);
+        rp.xy *= rot2(shellAngle * 0.3 + fi * 0.5);
+
+        // Icosahedron shell
+        float icoD = sdIcosahedron(rp, radius);
+
+        // Shell thickness
+        float thickness = 0.04 + 0.02 * BASS_SMOOTH;
+
+        // Hollow shell: intersect outer and inner icosahedra
+        float shellD = max(icoD, -(sdIcosahedron(rp, radius - thickness)));
+
+        // Geodesic face pattern: carve gaps along triangle edges
+        float faceFreq = detailBase + fi * 1.5;
+        float edgeDist = geodesicFaces(rp, faceFreq);
+
+        // Edge width: controls gap size between triangular faces
+        float edgeWidth = 0.08 + CHAOS_AMOUNT * 0.04 - TREBLE_SMOOTH * 0.02;
+        edgeWidth = max(edgeWidth, 0.03);
+
+        // Carve out edges (create gaps between faces)
+        float faceMask = smoothstep(0.0, edgeWidth, edgeDist);
+
+        // Combine: shell geometry with face cutouts
+        // Where faceMask is 0 (near edges), push distance away (carve gap)
+        float gapCarve = mix(0.05, 0.0, faceMask);
+        float finalD = shellD + gapCarve;
+
+        // Individual face pulsing from energy
+        if (edgeDist > edgeWidth) {
+            vec3 rpn = normalize(rp + vec3(0.0001));
+            float faceId = floor(faceFreq * acos(clamp(rpn.y, -1.0, 1.0)))
+                         + floor(faceFreq * 0.5 * atan(rpn.z, rpn.x));
+            float facePulse = sin(faceId * 3.7 + time * 2.0) * 0.5 + 0.5;
+            facePulse *= max(0.0, energyZScore) * 0.01;
+            finalD -= facePulse;
+        }
+
+        if (finalD < d) {
+            d = finalD;
+            shellId = fi;
+        }
+    }
+
+    return vec2(d, shellId);
+}
+
+// ============================================================================
+// SCENE SDF
+// ============================================================================
+
+vec2 sceneSDF(vec3 p) {
+    return geodesicShells(p, iTime);
+}
+
+// ============================================================================
+// NORMAL CALCULATION
+// ============================================================================
+
+vec3 getNormal(vec3 p) {
+    vec2 e = vec2(NORM_EPS, 0.0);
+    float d = sceneSDF(p).x;
+    return normalize(vec3(
+        sceneSDF(p + e.xyy).x - d,
+        sceneSDF(p + e.yxy).x - d,
+        sceneSDF(p + e.yyx).x - d
+    ));
+}
+
+// ============================================================================
+// CEL SHADING
+// ============================================================================
+
+float celShade(float d) {
+    if (d > 0.65) return 1.0;
+    if (d > 0.35) return 0.65;
+    if (d > 0.1) return 0.4;
+    return 0.2;
+}
+
+// ============================================================================
+// RAYMARCHING
+// ============================================================================
+
+vec2 raymarch(vec3 ro, vec3 rd) {
+    float t = 0.0;
+
+    for (int i = 0; i < MAX_STEPS; i++) {
+        vec3 p = ro + rd * t;
+        vec2 h = sceneSDF(p);
+
+        if (h.x < SURF_DIST) {
+            return vec2(t, h.y);
+        }
+        if (t > MAX_DIST) break;
+
+        // Step with slight over-relaxation for speed, but safe minimum
+        t += max(h.x * 0.8, SURF_DIST * 0.5);
+    }
+
+    return vec2(MAX_DIST, -1.0);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    // --- Camera: orbit outside the sphere looking in ---
+    float camAngle = iTime * 0.12 + ROTATION_AUDIO * 0.5;
+    float camHeight = sin(iTime * 0.07) * 0.8 + CAM_BOB;
+    float camRadius = 5.0 - CAM_ZOOM + sin(iTime * 0.09) * 0.3;
+
+    vec3 ro = vec3(
+        sin(camAngle) * camRadius,
+        1.5 + camHeight,
+        cos(camAngle) * camRadius
+    );
+
+    // Look at center with slight offset for interest
+    vec3 lookAt = vec3(
+        sin(iTime * 0.03) * 0.2 + FLUX_JITTER,
+        sin(iTime * 0.05) * 0.15,
+        cos(iTime * 0.04) * 0.2
+    );
+
+    // Camera matrix
+    vec3 forward = normalize(lookAt - ro);
+    vec3 right = normalize(cross(vec3(0.0, 1.0, 0.0), forward));
+    vec3 up = cross(forward, right);
+
+    float fov = 1.6 + ENERGY_TREND * 0.05;
+    vec3 rd = normalize(uv.x * right + uv.y * up + fov * forward);
+
+    // --- Raymarch ---
+    vec2 result = raymarch(ro, rd);
+    float dist = result.x;
+    float shellId = result.y;
+
+    // --- Background: dark with subtle depth stars ---
+    vec3 col = vec3(0.0);
+
+    // Faint starfield for background depth
+    float starSeed = hash(floor(rd.x * 80.0) * 100.0 + floor(rd.y * 80.0));
+    if (starSeed > 0.97) {
+        float twinkle = 0.3 + 0.7 * pow(max(0.0, sin(iTime * 2.0 + starSeed * 50.0)), 8.0);
+        col = chromadepth(0.9) * twinkle * 0.3; // far stars = blue/violet
+    }
+
+    if (dist < MAX_DIST) {
+        vec3 p = ro + rd * dist;
+        vec3 n = getNormal(p);
+
+        // --- Lighting ---
+        vec3 lightDir = normalize(vec3(0.6, 0.8, 0.4));
+        vec3 lightDir2 = normalize(vec3(-0.5, 0.3, -0.6));
+
+        float diff = max(dot(n, lightDir), 0.0);
+        float fill = max(dot(n, lightDir2), 0.0) * 0.25;
+        float cel = celShade(diff + fill);
+
+        // Rim lighting
+        float rim = pow(1.0 - max(dot(n, -rd), 0.0), 3.0);
+        float rimMask = smoothstep(-0.2, 0.5, dot(n, lightDir));
+
+        // --- ChromaDepth: shell index maps to depth color ---
+        // shellId 0 = outermost = red (near), shellId 3 = innermost = blue/violet (far)
+        float depthT = shellId / 3.0;
+
+        // Also blend in actual ray distance for subtle depth variation within each shell
+        float distT = clamp((dist - 2.5) / 8.0, 0.0, 1.0);
+        depthT = mix(depthT, distT, 0.2);
+
+        vec3 baseCol = chromadepth(depthT);
+
+        // Apply cel shading to lightness
+        float lightness = 0.3 + cel * 0.5;
+        lightness *= clamp(FACE_BRIGHTNESS, 0.5, 1.3);
+
+        col = baseCol * lightness;
+
+        // Rim light: use shell color but brighter
+        float rimAmount = rim * rimMask * 0.4;
+        col += chromadepth(max(depthT - 0.1, 0.0)) * rimAmount;
+
+        // --- Edge glow between faces (treble-reactive) ---
+        // Detect face edges via normal discontinuity
+        float edgeDetect = length(vec2(
+            length(dFdx(n)),
+            length(dFdy(n))
+        ));
+        float edgeGlow = smoothstep(0.3, 1.5, edgeDetect) * clamp(EDGE_GLOW_AMOUNT, 0.0, 0.8);
+
+        // Edge glow color: slightly warmer (toward red/near) than the shell
+        vec3 glowCol = chromadepth(max(depthT - 0.15, 0.0));
+        col += glowCol * edgeGlow * 0.6;
+
+        // --- Surface texture from roughness ---
+        float texNoise = hash3(floor(p * (8.0 + SURFACE_ROUGHNESS * 4.0)));
+        col *= 0.92 + texNoise * 0.08 * SURFACE_ROUGHNESS;
+
+        // --- Beat flash ---
+        if (beat) {
+            col *= 1.15;
+        }
+
+        // --- Depth fog toward background ---
+        float fog = exp(-dist * 0.08);
+        col = mix(vec3(0.0), col, fog);
+
+    }
+
+    // --- Vignette ---
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    // --- Frame feedback: subtle trail ---
+    vec4 prev = getLastFrameColor(screenUV);
+    col = mix(prev.rgb * 0.93, col, 0.7);
+
+    // --- Ensure good ChromaDepth saturation ---
+    vec3 colHSL = rgb2hsl(col);
+    colHSL.y = min(colHSL.y * 1.2, 1.0);
+    colHSL.z = clamp(colHSL.z, 0.02, 0.58);
+    col = hsl2rgb(colHSL);
+
+    // Subtle dithering
+    float dither = (hash(dot(fragCoord, vec2(12.9898, 78.233)) + iTime) - 0.5) / 255.0;
+    col += dither;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-hyperbolic.frag
+++ b/shaders/claude/chromadepth-hyperbolic.frag
@@ -1,0 +1,350 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, hyperbolic, tiling, poincare
+// ChromaDepth Hyperbolic Tiling — Poincaré Disk Model
+// Renders a {7,3} hyperbolic tiling where tiles near the center are large (red/close)
+// and tiles near the boundary are tiny (blue/far), naturally mapping to chromadepth depth.
+// Möbius transformations rotate and translate in hyperbolic space.
+// Red = closest, Green = mid-depth, Blue/Violet = farthest, Black = neutral
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// Bass rotates the disk via Möbius transform
+#define DISK_ROTATION (bassZScore * 0.15)
+// #define DISK_ROTATION 0.0
+
+// Energy scales overall tile brightness
+#define TILE_BRIGHTNESS (0.7 + energyNormalized * 0.5)
+// #define TILE_BRIGHTNESS 1.0
+
+// Spectral entropy distorts near boundary
+#define BOUNDARY_DISTORT (spectralEntropyNormalized * 0.08)
+// #define BOUNDARY_DISTORT 0.0
+
+// Pitch class shifts base hue
+#define HUE_SHIFT (pitchClassNormalized * 0.12)
+// #define HUE_SHIFT 0.0
+
+// Beat triggers ripple from center outward
+#define BEAT_RIPPLE (beat ? 1.0 : 0.0)
+// #define BEAT_RIPPLE 0.0
+
+// Spectral centroid shifts the Möbius translation point
+#define MOBIUS_DRIFT (spectralCentroidZScore * 0.06)
+// #define MOBIUS_DRIFT 0.0
+
+// Treble brightens edge glow
+#define EDGE_GLOW_STRENGTH (0.4 + trebleZScore * 0.2)
+// #define EDGE_GLOW_STRENGTH 0.4
+
+// Mids shift the tiling offset
+#define TILING_SHIFT (midsZScore * 0.03)
+// #define TILING_SHIFT 0.0
+
+// Spectral flux adds shimmer to edges
+#define EDGE_SHIMMER (spectralFluxZScore * 0.15)
+// #define EDGE_SHIMMER 0.0
+
+// Bass slope controls slow rotation drift
+#define SLOW_ROTATE (bassSlope * 80.0 * bassRSquared)
+// #define SLOW_ROTATE 0.0
+
+// Roughness adds grain to tile fills
+#define TILE_GRAIN (spectralRoughnessNormalized * 0.15)
+// #define TILE_GRAIN 0.0
+
+// Energy trend confidence gates feedback
+#define TREND_CONFIDENCE (energyRSquared)
+// #define TREND_CONFIDENCE 0.5
+
+// Bass normalized for gentle pulsing
+#define BASS_PULSE (bassNormalized * 0.08)
+// #define BASS_PULSE 0.0
+
+// Treble normalized for edge detail
+#define TREBLE_DETAIL (trebleNormalized)
+// #define TREBLE_DETAIL 0.5
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+#define PI 3.14159265359
+#define TAU 6.28318530718
+#define P 7        // p-gon tiling: heptagonal
+#define Q 3        // q polygons meet at each vertex
+#define FP float(P)
+#define FQ float(Q)
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// COMPLEX ARITHMETIC HELPERS
+// ============================================================================
+
+// Complex multiplication: (a+bi)(c+di)
+vec2 cmul(vec2 a, vec2 b) {
+    return vec2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+}
+
+// Complex conjugate
+vec2 cconj(vec2 z) {
+    return vec2(z.x, -z.y);
+}
+
+// Complex division: a / b
+vec2 cdiv(vec2 a, vec2 b) {
+    float d = dot(b, b);
+    return vec2(a.x * b.x + a.y * b.y, a.y * b.x - a.x * b.y) / max(d, 1e-10);
+}
+
+// ============================================================================
+// MÖBIUS TRANSFORMATION
+// ============================================================================
+// Möbius transform: f(z) = (z - a) / (1 - conj(a)*z)
+// This is a hyperbolic isometry on the Poincaré disk (|a| < 1)
+
+vec2 mobius(vec2 z, vec2 a) {
+    vec2 num = z - a;
+    vec2 den = vec2(1.0, 0.0) - cmul(cconj(a), z);
+    return cdiv(num, den);
+}
+
+// Rotation in the complex plane
+vec2 crot(vec2 z, float angle) {
+    float c = cos(angle);
+    float s = sin(angle);
+    return vec2(z.x * c - z.y * s, z.x * s + z.y * c);
+}
+
+// ============================================================================
+// HYPERBOLIC DISTANCE
+// ============================================================================
+// Hyperbolic distance from origin in Poincaré disk: d = 2 * atanh(|z|)
+
+float hypDist(vec2 z) {
+    float r = length(z);
+    r = min(r, 0.999);
+    return 2.0 * atanh(r);
+}
+
+// ============================================================================
+// {7,3} TILING VIA REFLECTIONS
+// ============================================================================
+// Strategy: reflect the point across the edges of a fundamental domain
+// until we land inside it. Count reflections for tile coloring.
+//
+// The fundamental domain of {p,q} has angles PI/p, PI/q, PI/2 at the
+// three vertices of a hyperbolic triangle.
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    // --- UV setup ---
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    // Scale to fit disk nicely in viewport
+    uv *= 2.2;
+
+    float r = length(uv);
+
+    // Outside the disk = black (neutral in chromadepth)
+    if (r >= 1.0) {
+        // Faint boundary ring
+        float ring = smoothstep(1.02, 1.0, r) * smoothstep(0.98, 1.0, r);
+        vec3 rimColor = chromadepth(0.95) * ring * 0.3;
+        fragColor = vec4(rimColor, 1.0);
+        return;
+    }
+
+    // --- Apply audio-reactive Möbius transform ---
+    // This rotates/translates the entire hyperbolic plane
+
+    // Rotation via complex multiplication
+    float rotAngle = iTime * 0.03 + DISK_ROTATION + SLOW_ROTATE * 0.01;
+    vec2 z = crot(uv, rotAngle);
+
+    // Translation via Möbius transform (shifts the "center" of the view)
+    float driftAngle = iTime * 0.07 + TILING_SHIFT;
+    vec2 mobiusCenter = vec2(
+        cos(driftAngle) * (0.1 + MOBIUS_DRIFT * 0.5),
+        sin(driftAngle * 0.7) * (0.08 + TILING_SHIFT)
+    );
+    // Keep Möbius center strictly inside disk
+    float mcLen = length(mobiusCenter);
+    if (mcLen > 0.45) mobiusCenter *= 0.45 / max(mcLen, 0.001);
+
+    z = mobius(z, mobiusCenter);
+
+    // Boundary distortion: warp points near boundary
+    float zr = length(z);
+    if (zr > 0.7) {
+        float distortAmount = (zr - 0.7) / 0.3 * BOUNDARY_DISTORT;
+        float da = sin(atan(z.y, z.x) * 5.0 + iTime * 0.5) * distortAmount;
+        z = crot(z, da);
+    }
+
+    // --- Fundamental domain via reflections ---
+    // For {p,q}: reflect across hyperbolic lines that bound the fundamental triangle
+    //
+    // Edge 1: the line through the origin at angle PI/p (geodesic = diameter)
+    // Edge 2: the perpendicular bisector (geodesic arc)
+    // Edge 3: the line through the origin along the real axis
+
+    // Precompute angles
+    float angleP = PI / FP;  // PI/7
+    float angleQ = PI / FQ;  // PI/3
+
+    // The hyperbolic distance from center to the midpoint of a p-gon edge
+    // For {p,q}: cosh(d) = cos(PI/q) / sin(PI/p)
+    float coshD = cos(angleQ) / max(sin(angleP), 0.001);
+    // Convert to Poincaré disk radius: r = tanh(d/2)
+    // From cosh(d): sinh(d) = sqrt(cosh^2 - 1), tanh(d/2) = sinh(d)/(1+cosh(d))
+    float sinhD = sqrt(max(coshD * coshD - 1.0, 0.0));
+    float edgeR = sinhD / (1.0 + coshD);
+
+    // The reflection geodesic (circle orthogonal to unit disk)
+    // passes through edgeR at angle 0, and is orthogonal to the unit circle.
+    // Center of the geodesic circle: at distance 1/edgeR from origin along angle 0
+    // Radius of the geodesic circle: sqrt(1/edgeR^2 - 1)
+    float geoCenter = 1.0 / max(edgeR, 0.001);
+    float geoRadius = sqrt(max(geoCenter * geoCenter - 1.0, 0.0));
+
+    int reflCount = 0;
+    const int MAX_REFLECT = 32;
+
+    for (int i = 0; i < MAX_REFLECT; i++) {
+        bool reflected = false;
+
+        // Reflection 1: across the real axis (y < 0 -> reflect)
+        if (z.y < 0.0) {
+            z.y = -z.y;
+            reflCount++;
+            reflected = true;
+        }
+
+        // Reflection 2: across the line at angle PI/p from origin
+        // This is a Euclidean reflection across the line y = x*tan(PI/p)
+        float lineAngle = angleP;
+        // Rotate z by -lineAngle, reflect if y < 0, rotate back
+        vec2 zRot = crot(z, -lineAngle);
+        if (zRot.y < 0.0) {
+            zRot.y = -zRot.y;
+            z = crot(zRot, lineAngle);
+            reflCount++;
+            reflected = true;
+        }
+
+        // Reflection 3: across the geodesic (circle inversion)
+        // The geodesic is the circle centered at (geoCenter, 0) with radius geoRadius
+        vec2 circleCenter = vec2(geoCenter, 0.0);
+        vec2 diff = z - circleCenter;
+        float dist2 = dot(diff, diff);
+        if (dist2 < geoRadius * geoRadius) {
+            // Invert through the circle
+            z = circleCenter + diff * (geoRadius * geoRadius) / max(dist2, 1e-10);
+            reflCount++;
+            reflected = true;
+        }
+
+        if (!reflected) break;
+    }
+
+    // --- Tile identification and coloring ---
+
+    // Distance from the point to the fundamental domain edges = edge proximity
+    // Edge to real axis
+    float edgeDist1 = abs(z.y);
+    // Edge to line at angle PI/p
+    float cosA = cos(angleP);
+    float sinA = sin(angleP);
+    float edgeDist2 = abs(-z.x * sinA + z.y * cosA);
+    // Edge to geodesic circle
+    vec2 circleCenter = vec2(geoCenter, 0.0);
+    float edgeDist3 = abs(length(z - circleCenter) - geoRadius);
+
+    float minEdgeDist = min(min(edgeDist1, edgeDist2), edgeDist3);
+
+    // --- Depth mapping: distance from center = depth ---
+    float diskR = length(uv); // use original UV for depth, not transformed
+    float depth = diskR;      // 0 at center (red/close), 1 at boundary (blue/far)
+
+    // Apply hue shift from pitch class
+    float depthShifted = fract(depth + HUE_SHIFT);
+
+    // --- Chromadepth coloring ---
+    vec3 tileColor = chromadepth(depthShifted);
+
+    // Tile parity coloring: even/odd reflections get slightly different treatment
+    float parity = mod(float(reflCount), 2.0);
+
+    // Vary brightness by parity and tile grain
+    float tileBright = mix(0.85, 1.0, parity);
+    tileBright *= TILE_BRIGHTNESS;
+
+    // Add subtle variation based on reflection count for tile identity
+    float tileId = float(reflCount) / float(MAX_REFLECT);
+    float tileHueShift = tileId * 0.04 * (1.0 + TILE_GRAIN);
+    tileColor = chromadepth(fract(depthShifted + tileHueShift));
+
+    // --- Edge glow (tile boundary detection) ---
+    float edgeWidth = 0.008 + 0.004 * (1.0 - diskR); // thicker edges near center
+    float edgeGlow = smoothstep(edgeWidth * 1.5, edgeWidth * 0.3, minEdgeDist);
+
+    // Edge shimmer from spectral flux
+    float shimmer = 1.0 + sin(float(reflCount) * 2.7 + iTime * 3.0) * EDGE_SHIMMER * 0.5;
+    edgeGlow *= shimmer;
+
+    // Edge color: bright warm white near center, cool at edges
+    vec3 edgeColor = chromadepth(depthShifted * 0.8) * (1.3 + TREBLE_DETAIL * 0.3);
+    edgeColor = mix(edgeColor, vec3(1.0, 0.95, 0.9), 0.3);
+
+    float edgeIntensity = clamp(EDGE_GLOW_STRENGTH + EDGE_SHIMMER * 0.2, 0.0, 1.0);
+
+    // --- Beat ripple ---
+    float ripplePhase = fract(iTime * 0.8);  // continuous phase
+    float ripple = sin((diskR - ripplePhase) * 25.0) * exp(-diskR * 3.0);
+    ripple *= BEAT_RIPPLE * 0.15;
+
+    // --- Compose final color ---
+    vec3 col = tileColor * tileBright;
+
+    // Add edge glow
+    col = mix(col, edgeColor, edgeGlow * edgeIntensity);
+
+    // Add ripple brightness
+    col *= 1.0 + ripple;
+
+    // Add bass pulse (gentle overall brightness pulse)
+    col *= 1.0 + BASS_PULSE * sin(iTime * 2.0);
+
+    // Tile grain: subtle noise-like variation
+    float grain = fract(sin(dot(z, vec2(12.9898, 78.233))) * 43758.5453);
+    col += (grain - 0.5) * TILE_GRAIN * 0.1;
+
+    // --- Feedback: subtle trail from previous frame ---
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec3 prev = getLastFrameColor(screenUV).rgb;
+    float fbAmount = 0.15 + TREND_CONFIDENCE * 0.1;
+    fbAmount = clamp(fbAmount, 0.1, 0.35);
+    col = mix(prev * 0.95, col, 1.0 - fbAmount);
+
+    // --- Vignette (dark edges for chromadepth) ---
+    vec2 vc = fragCoord.xy / iResolution.xy - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    // Clamp to prevent white-out
+    col = clamp(col, 0.0, 1.0);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-interference.frag
+++ b/shaders/claude/chromadepth-interference.frag
@@ -1,0 +1,181 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, interference, waves, moire
+// ChromaDepth Wave Interference - Multiple wave sources create moire depth patterns
+// Red = constructive interference (closest), Blue = destructive (farthest), Black = neutral
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (swap constants for audio uniforms)
+// ============================================================================
+
+// Wave frequency: spectral centroid controls ripple density
+#define WAVE_FREQ (12.0 + spectralCentroidZScore * 4.0)
+// #define WAVE_FREQ 12.0
+
+// Number of active wave sources (2-6): energy scales source count
+#define SOURCE_COUNT_F (2.0 + clamp(energyNormalized * 4.0, 0.0, 4.0))
+// #define SOURCE_COUNT_F 4.0
+
+// Wave amplitude: bass drives how tall the waves are
+#define WAVE_AMP (0.6 + bassZScore * 0.25)
+// #define WAVE_AMP 0.6
+
+// Orbit radius: treble controls how far sources wander
+#define ORBIT_RADIUS (0.25 + trebleZScore * 0.08)
+// #define ORBIT_RADIUS 0.25
+
+// Phase modulation: spectral flux shifts phase relationships
+#define PHASE_MOD (spectralFluxZScore * 1.5)
+// #define PHASE_MOD 0.0
+
+// Beat burst: adds a central wave pulse on beat
+#define BEAT_BURST (beat ? 1.0 : 0.0)
+// #define BEAT_BURST 0.0
+
+// Overall brightness: energy controls intensity
+#define BRIGHTNESS (0.85 + energyZScore * 0.15)
+// #define BRIGHTNESS 0.85
+
+// Feedback blend: how much previous frame bleeds through
+#define FEEDBACK_MIX 0.25
+
+// Radial blur offset for feedback
+#define BLUR_OFFSET (0.003 + bassNormalized * 0.002)
+// #define BLUR_OFFSET 0.003
+
+// Orbit speed modulation: mids affect rotation speed
+#define ORBIT_SPEED (0.15 + midsZScore * 0.05)
+// #define ORBIT_SPEED 0.15
+
+// Hue shift from pitch class for subtle color variation
+#define HUE_SHIFT (pitchClassNormalized * 0.05)
+// #define HUE_SHIFT 0.0
+
+// Entropy-driven wave distortion
+#define WAVE_DISTORT (spectralEntropyNormalized * 0.3)
+// #define WAVE_DISTORT 0.0
+
+// Slope-driven drift: bass slope drifts the pattern
+#define DRIFT_X (bassSlope * 0.02)
+// #define DRIFT_X 0.0
+
+#define DRIFT_Y (spectralCentroidSlope * 0.015)
+// #define DRIFT_Y 0.0
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// WAVE SOURCE POSITIONS
+// ============================================================================
+
+vec2 getSourcePos(int idx, float time) {
+    float angle = float(idx) * 1.0471975 + time * ORBIT_SPEED * (1.0 + float(idx) * 0.13);
+    float r = ORBIT_RADIUS * (0.8 + 0.2 * sin(time * 0.3 + float(idx) * 2.0));
+    return vec2(cos(angle) * r, sin(angle) * r) + vec2(DRIFT_X, DRIFT_Y);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    // Centered UV with aspect ratio correction
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    float time = iTime;
+    float freq = WAVE_FREQ;
+    float amp = clamp(WAVE_AMP, 0.1, 1.5);
+    int srcCount = int(clamp(SOURCE_COUNT_F, 2.0, 6.0));
+    float phaseMod = PHASE_MOD;
+
+    // ---- Accumulate interference from all sources ----
+    float interference = 0.0;
+
+    for (int i = 0; i < 6; i++) {
+        if (i >= srcCount) break;
+
+        vec2 srcPos = getSourcePos(i, time);
+        float dist = length(uv - srcPos);
+
+        // Each source has a slightly different frequency for moire
+        float f = freq * (1.0 + float(i) * 0.07);
+
+        // Phase offset per source, modulated by audio
+        float phase = float(i) * 1.047 + phaseMod * float(i) * 0.4;
+
+        // Optional distortion from entropy
+        float distorted = dist + WAVE_DISTORT * sin(dist * 8.0 + time);
+
+        // Sinusoidal wave from this source
+        float wave = sin(distorted * f - time * 2.5 + phase);
+
+        interference += wave;
+    }
+
+    // ---- Beat burst: temporary central wave ----
+    float burstDecay = BEAT_BURST;
+    if (burstDecay > 0.0) {
+        float burstDist = length(uv);
+        float burstWave = sin(burstDist * freq * 1.5 - time * 6.0) * burstDecay;
+        interference += burstWave * 1.5;
+    }
+
+    // Normalize interference by source count
+    float maxPossible = float(srcCount) + burstDecay * 1.5;
+    interference /= max(maxPossible, 1.0);
+
+    // Scale by amplitude
+    interference *= amp;
+
+    // ---- Map interference to chromadepth depth ----
+    // interference ranges roughly -1 to 1
+    // Map so constructive (positive) = red/near, destructive (negative) = blue/far
+    // 0.0 maps to mid-depth green
+    float depth = 0.5 - interference * 0.5;
+    depth = clamp(depth, 0.0, 1.0);
+
+    // Apply hue shift
+    depth = fract(depth + HUE_SHIFT);
+
+    vec3 col = chromadepth(depth);
+
+    // Intensity modulation: quiet interference fades toward black
+    float intensityMask = smoothstep(0.0, 0.15, abs(interference));
+    col *= mix(0.3, 1.0, intensityMask);
+
+    // Brightness
+    col *= clamp(BRIGHTNESS, 0.3, 1.3);
+
+    // ---- Frame feedback with radial blur ----
+    vec2 feedUV = fragCoord.xy / iResolution.xy;
+    // Radial blur: sample previous frame slightly toward center
+    vec2 center = vec2(0.5);
+    vec2 toCenter = normalize(center - feedUV) * BLUR_OFFSET;
+    vec4 prev = getLastFrameColor(feedUV + toCenter);
+
+    // Decay previous frame slightly to prevent accumulation
+    vec3 prevCol = prev.rgb * 0.96;
+
+    // Blend with feedback
+    col = mix(col, max(col, prevCol), FEEDBACK_MIX);
+
+    // Gentle vignette (keeps edges dark for chromadepth)
+    vec2 vigUV = fragCoord.xy / iResolution.xy - 0.5;
+    float vign = 1.0 - dot(vigUV, vigUV) * 0.5;
+    col *= vign;
+
+    // Clamp to prevent white-out
+    col = clamp(col, 0.0, 1.0);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-kaleidoscope.frag
+++ b/shaders/claude/chromadepth-kaleidoscope.frag
@@ -1,0 +1,324 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, kaleidoscope, fractal
+// ChromaDepth Fractal Kaleidoscope
+// UV folding creates symmetric patterns, Julia iteration adds fractal detail.
+// Fold depth -> chromadepth: center folds = red (closest), outer folds = blue (farthest).
+// Feedback samples from rotated+scaled previous frame for recursive kaleidoscope effect.
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (swap constants for audio uniforms)
+// ============================================================================
+
+// Symmetry fold count: spectral centroid drives complexity (4-12 folds)
+#define FOLD_COUNT (4.0 + spectralCentroidZScore * 2.0 + spectralCentroidNormalized * 4.0)
+// #define FOLD_COUNT 6.0
+
+// Zoom: energy drives zoom level
+#define ZOOM (1.8 + energyZScore * 0.3)
+// #define ZOOM 1.8
+
+// Rotation: pitch class rotates the kaleidoscope
+#define ROTATION_SPEED (iTime * 0.08 + pitchClassNormalized * 1.5)
+// #define ROTATION_SPEED (iTime * 0.08)
+
+// Julia c parameter: bass and treble slopes morph the fractal
+#define C_REAL (-0.74 + bassSlope * 15.0 * bassRSquared)
+// #define C_REAL -0.74
+
+#define C_IMAG (0.18 + spectralCentroidSlope * 12.0 * spectralCentroidRSquared)
+// #define C_IMAG 0.18
+
+// Treble adds detail sharpness
+#define TREBLE_DETAIL (trebleZScore * 0.15)
+// #define TREBLE_DETAIL 0.0
+
+// Energy level for brightness
+#define ENERGY_BRIGHT (0.85 + energyNormalized * 0.3)
+// #define ENERGY_BRIGHT 1.0
+
+// Beat pulse
+#define BEAT_FLASH (beat ? 1.15 : 1.0)
+// #define BEAT_FLASH 1.0
+
+// Feedback strength: spectral entropy controls recursive depth
+#define FEEDBACK_MIX (0.25 + spectralEntropyNormalized * 0.15)
+// #define FEEDBACK_MIX 0.3
+
+// Feedback rotation driven by mids
+#define FB_ROTATE (midsZScore * 0.04)
+// #define FB_ROTATE 0.0
+
+// Feedback zoom driven by spectral flux
+#define FB_ZOOM (1.0 - spectralFluxZScore * 0.03)
+// #define FB_ZOOM 1.0
+
+// Drop detection: negative energy z-score = drop
+#define DROP_AMOUNT (max(-energyZScore, 0.0))
+// #define DROP_AMOUNT 0.0
+
+// Bass punch for color saturation
+#define BASS_SAT (bassNormalized * 0.15)
+// #define BASS_SAT 0.0
+
+// Roughness adds grit to fold edges
+#define ROUGHNESS_EDGE (spectralRoughnessNormalized * 0.3)
+// #define ROUGHNESS_EDGE 0.0
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+#define MAX_ITER 48
+#define PI 3.14159265359
+#define TAU 6.28318530718
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// KALEIDOSCOPE UV FOLDING
+// ============================================================================
+
+// Returns: folded UV and fold count (number of reflections applied)
+// The fold count is our depth metric for chromadepth.
+
+vec2 kaleidoFold(vec2 p, float sides, out float foldDepth) {
+    // Convert to polar
+    float angle = atan(p.y, p.x);
+    float radius = length(p);
+
+    // Sector angle
+    float sector = TAU / max(sides, 3.0);
+
+    // Count which sector we're in (this = depth layers)
+    float sectorIndex = floor(angle / sector + 0.5);
+    foldDepth = abs(sectorIndex);
+
+    // Fold into fundamental domain
+    angle = mod(angle, sector);
+    // Mirror fold
+    if (angle > sector * 0.5) {
+        angle = sector - angle;
+        foldDepth += 0.5;
+    }
+
+    // Back to cartesian
+    return vec2(cos(angle), sin(angle)) * radius;
+}
+
+// Additional fold: triangle fold for extra structure
+vec2 triFold(vec2 p, out float extraDepth) {
+    extraDepth = 0.0;
+
+    // Fold across x-axis
+    if (p.y < 0.0) {
+        p.y = -p.y;
+        extraDepth += 1.0;
+    }
+
+    // Fold across 60-degree line
+    float line60 = p.x * 0.5 - p.y * 0.866;
+    if (line60 < 0.0) {
+        // Reflect across the line y = x*tan(60)
+        float d = p.x * 0.5 - p.y * 0.866;
+        p -= 2.0 * d * vec2(0.5, -0.866);
+        extraDepth += 1.0;
+    }
+
+    return p;
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    // --- GLOBAL ROTATION ---
+    float angle = ROTATION_SPEED;
+    float ca = cos(angle), sa = sin(angle);
+    uv = mat2(ca, -sa, sa, ca) * uv;
+
+    // --- ZOOM ---
+    float zoom = clamp(ZOOM, 0.8, 4.0);
+    uv *= zoom;
+
+    // --- KALEIDOSCOPE FOLDING ---
+    float sides = clamp(FOLD_COUNT, 3.0, 12.0);
+    float foldDepth = 0.0;
+    vec2 foldedUV = kaleidoFold(uv, sides, foldDepth);
+
+    // Additional triangle fold for more structure
+    float extraDepth = 0.0;
+    foldedUV = triFold(foldedUV, extraDepth);
+    foldDepth += extraDepth * 0.5;
+
+    // Normalize fold depth: more folds from center = deeper
+    // Higher fold count means more possible sectors, so normalize
+    float maxFolds = sides * 0.5 + 2.0;
+    float depthNorm = clamp(foldDepth / maxFolds, 0.0, 1.0);
+
+    // Radius also contributes to depth (further from center = deeper)
+    float radiusDepth = clamp(length(uv) / (zoom * 1.2), 0.0, 1.0);
+
+    // --- JULIA ITERATION on folded UV ---
+    vec2 z = foldedUV;
+    vec2 c = vec2(
+        clamp(C_REAL, -1.3, 0.5),
+        clamp(C_IMAG, -0.9, 0.9)
+    );
+
+    float smoothIter = 0.0;
+    float trapMin = 1e10;
+    float trapCross = 1e10;
+    float orbitAngle = 0.0;
+    bool escaped = false;
+
+    for (int i = 0; i < MAX_ITER; i++) {
+        z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+
+        float mag2 = dot(z, z);
+        float mag = sqrt(mag2);
+
+        trapMin = min(trapMin, mag);
+        trapCross = min(trapCross, min(abs(z.x), abs(z.y)));
+        orbitAngle += atan(z.y, z.x);
+
+        if (mag2 > 256.0) {
+            smoothIter = float(i) - log2(log2(mag2)) + 4.0;
+            escaped = true;
+            break;
+        }
+        smoothIter = float(i);
+    }
+
+    float iterNorm = smoothIter / float(MAX_ITER);
+
+    // --- DEPTH CALCULATION ---
+    // Combine fold depth, radius depth, and fractal iteration depth
+    float fractalDepth;
+
+    if (escaped) {
+        // Exterior: near boundary = mid-depth, fast escape = far
+        float logIter = log(1.0 + smoothIter) / log(1.0 + float(MAX_ITER));
+        fractalDepth = mix(0.6, 1.0, 1.0 - pow(logIter, 0.5));
+    } else {
+        // Interior: orbit traps determine local depth
+        float tOrigin = clamp(trapMin * 1.2, 0.0, 1.0);
+        float tCross = clamp(trapCross * 2.5, 0.0, 1.0);
+        float tAngle = fract(orbitAngle * 0.06);
+
+        fractalDepth = tOrigin * 0.3 + tCross * 0.3 + tAngle * 0.4;
+        fractalDepth = smoothstep(0.05, 0.95, fractalDepth);
+        fractalDepth *= 0.55; // Interior stays in red-green range
+    }
+
+    // Final depth: fold structure + fractal detail + radial distance
+    // Center of symmetry = low depth = red (closest)
+    // More folds from center = higher depth = bluer
+    float depth = depthNorm * 0.35 + fractalDepth * 0.45 + radiusDepth * 0.2;
+
+    // Treble adds edge sharpness to depth gradients
+    float depthEdge = length(vec2(dFdx(depth), dFdy(depth)));
+    depth += depthEdge * TREBLE_DETAIL;
+
+    // Drops push everything toward red (foreground)
+    depth = mix(depth, 0.0, DROP_AMOUNT * 0.4);
+
+    depth = clamp(depth, 0.0, 1.0);
+
+    // --- COLOR ---
+    vec3 col = chromadepth(depth);
+
+    // Brightness from energy
+    col *= clamp(ENERGY_BRIGHT, 0.3, 1.4);
+
+    // Roughness adds grit at fold edges
+    float foldEdge = abs(fract(foldDepth) - 0.5) * 2.0;
+    float edgeBright = smoothstep(0.7, 1.0, foldEdge) * ROUGHNESS_EDGE;
+    col += edgeBright * vec3(1.0, 0.9, 0.8);
+
+    // Saturation boost from bass
+    vec3 colHSL = vec3(0.0); // use inline conversion
+    float lum = dot(col, vec3(0.299, 0.587, 0.114));
+    col = mix(vec3(lum), col, 1.0 + BASS_SAT);
+
+    // Beat flash
+    col *= BEAT_FLASH;
+
+    // Exterior brightness fade
+    if (escaped) {
+        float fadeFactor = pow(iterNorm, 0.5);
+        col *= mix(0.2, 0.9, fadeFactor);
+    }
+
+    col = clamp(col, 0.0, 1.0);
+
+    // --- FRAME FEEDBACK ---
+    // Sample previous frame from rotated + scaled position for recursive kaleidoscope
+    float fbAngle = iTime * 0.015 + FB_ROTATE;
+    float fbScale = clamp(FB_ZOOM, 0.93, 1.07);
+
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotatedFB = vec2(
+        centered.x * fbc - centered.y * fbs,
+        centered.x * fbs + centered.y * fbc
+    );
+    rotatedFB *= fbScale;
+    rotatedFB += 0.5;
+
+    // Add a small warp from the fold structure so feedback follows the pattern
+    vec2 foldWarp = vec2(
+        sin(foldDepth * 2.0 + iTime * 0.3) * 0.008,
+        cos(foldDepth * 2.0 - iTime * 0.2) * 0.008
+    );
+    rotatedFB += foldWarp;
+
+    rotatedFB = clamp(rotatedFB, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(rotatedFB).rgb;
+
+    // Oklab blending for perceptually uniform mix
+    vec3 colOk = rgb2oklab(col);
+    vec3 prevOk = rgb2oklab(prev);
+
+    // Decay previous frame to prevent accumulation
+    prevOk.x *= 0.96;
+    prevOk.yz *= 0.98;
+
+    float fbMix = clamp(FEEDBACK_MIX, 0.1, 0.5);
+    // On drops, reduce feedback to let new frame dominate
+    fbMix *= (1.0 - DROP_AMOUNT * 0.6);
+
+    // New frame weight
+    float newWeight = 1.0 - fbMix;
+    vec3 blended = mix(prevOk, colOk, newWeight);
+
+    // Preserve chroma: if blended is losing saturation, pull from fresh frame
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.6) {
+        blended.yz = mix(blended.yz, colOk.yz, 0.35);
+    }
+
+    col = oklab2rgb(blended);
+
+    // --- VIGNETTE ---
+    // Darken edges: important for chromadepth (black = neutral)
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.9;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-kali.frag
+++ b/shaders/claude/chromadepth-kali.frag
@@ -1,0 +1,270 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, fractal, kali
+// ChromaDepth Kali Set — Intricate filigree fractal with orbit trap depth
+// The Kali fold: p = abs(p) / dot(p,p) - param creates infinitely recursive structures.
+// Orbit trap distances drive chromadepth: close traps = red (near), far traps = blue (far).
+// Parameters wander through beautiful configurations, audio steers the path.
+// ChromaDepth: Red = closest, Green = mid, Blue/Violet = farthest, Black = neutral
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (swap constants for audio uniforms)
+// ============================================================================
+
+// --- KALI PARAMETER MODULATION via LINEAR REGRESSION ---
+
+// Param X: bass slope with rSquared gating — steady bass builds reshape the fold
+#define KALI_MOD_X (bassSlope * 18.0 * bassRSquared)
+// #define KALI_MOD_X 0.0
+
+// Param Y: spectral centroid slope gated by confidence — brightness trends shift structure
+#define KALI_MOD_Y (spectralCentroidSlope * 15.0 * spectralCentroidRSquared)
+// #define KALI_MOD_Y 0.0
+
+// Param Z: treble zScore — instant high-frequency reactivity for fine detail shifts
+#define KALI_MOD_Z (trebleZScore * 0.03)
+// #define KALI_MOD_Z 0.0
+
+// --- ZOOM via ENERGY ---
+#define ZOOM_MOD (energyZScore * 0.12)
+// #define ZOOM_MOD 0.0
+
+// --- ROTATION via PITCH CLASS ---
+#define ROTATION_MOD (pitchClassNormalized * 0.4)
+// #define ROTATION_MOD 0.0
+
+// --- BASS PUNCH for brightness ---
+#define BASS_PUNCH (bassZScore)
+// #define BASS_PUNCH 0.0
+
+// --- SPECTRAL FLUX for edge glow ---
+#define FLUX_EDGE (max(spectralFluxZScore, 0.0))
+// #define FLUX_EDGE 0.0
+
+// --- DROP DETECTION ---
+#define DROP_INTENSITY (max(-energyZScore, 0.0))
+// #define DROP_INTENSITY 0.0
+
+// --- ENTROPY for chaos modulation ---
+#define ENTROPY_LEVEL (spectralEntropyNormalized)
+// #define ENTROPY_LEVEL 0.5
+
+// --- ROUGHNESS for saturation ---
+#define ROUGHNESS_SAT (spectralRoughnessNormalized)
+// #define ROUGHNESS_SAT 0.5
+
+// --- MIDS for pan ---
+#define PAN_MOD (midsZScore * 0.03)
+// #define PAN_MOD 0.0
+
+// --- BEAT ---
+#define BEAT_HIT (beat ? 1.0 : 0.0)
+// #define BEAT_HIT 0.0
+
+// --- ENERGY TREND CONFIDENCE ---
+#define CONFIDENCE (energyRSquared * 0.5 + bassRSquared * 0.3 + spectralCentroidRSquared * 0.2)
+// #define CONFIDENCE 0.5
+
+// --- MOBILE LIMITS ---
+#define MAX_ITER 12
+#define PHI 1.61803398875
+
+// ============================================================================
+// CHROMADEPTH: full spectrum red -> violet via smooth HSL
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// KALI FOLD: p = abs(p) / dot(p,p) - param
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    float t = iTime * 0.03;
+
+    // --- WANDERING KALI PARAMETERS ---
+    // The kali_param vector slowly explores parameter space.
+    // Sweet spots for the Kali fractal are roughly in 0.4-1.2 range.
+    // We orbit through known beautiful configurations.
+    vec3 kaliParam;
+    kaliParam.x = 0.75 + 0.2 * sin(t * 1.0) + 0.1 * cos(t * PHI * 0.6);
+    kaliParam.y = 0.85 + 0.15 * sin(t * 0.7 * PHI) + 0.1 * cos(t * 1.1);
+    kaliParam.z = 0.65 + 0.18 * sin(t * 0.9) + 0.08 * cos(t * PHI * 0.8);
+
+    // Audio modulation of kali params (regression gated)
+    kaliParam.x += KALI_MOD_X * 0.04;
+    kaliParam.y += KALI_MOD_Y * 0.05;
+    kaliParam.z += KALI_MOD_Z;
+
+    // Drop jolts param into different region
+    float dropJolt = DROP_INTENSITY * (1.0 - CONFIDENCE) * 0.12;
+    kaliParam.x += sin(iTime * 3.7) * dropJolt;
+    kaliParam.y += cos(iTime * 2.3) * dropJolt;
+
+    // Clamp to stay in interesting range
+    kaliParam = clamp(kaliParam, vec3(0.3), vec3(1.4));
+
+    // --- VIEW TRANSFORM ---
+    float zoom = 2.0 + 0.3 * sin(t * 0.4) + ZOOM_MOD;
+    zoom = max(zoom, 1.0);
+    zoom -= DROP_INTENSITY * 0.15;
+
+    float angle = iTime * 0.02 + ROTATION_MOD;
+    float ca = cos(angle), sa = sin(angle);
+    uv = mat2(ca, -sa, sa, ca) * uv;
+    uv *= zoom;
+
+    // Pan
+    uv += vec2(PAN_MOD, PAN_MOD * 0.7);
+
+    // --- KALI SET ITERATION ---
+    vec3 p = vec3(uv, 0.5 + ENTROPY_LEVEL * 0.3);
+
+    // Orbit trap accumulators
+    float trapOrigin = 1e10;     // min distance to origin
+    float trapAxisX = 1e10;      // min distance to YZ plane
+    float trapAxisY = 1e10;      // min distance to XZ plane
+    float trapAxisZ = 1e10;      // min distance to XY plane
+    float accumGlow = 0.0;       // exponential accumulation for glow
+    float accumDepth = 0.0;      // weighted depth accumulation
+    float orbitEnergy = 0.0;     // total orbit energy
+
+    // Store early orbit positions for feedback warping
+    vec3 p1 = p, p2 = p;
+
+    for (int i = 0; i < MAX_ITER; i++) {
+        // The Kali fold: absolute value + inversion + offset
+        p = abs(p);
+        float d = dot(p, p);
+        d = max(d, 0.001); // prevent divide by zero
+        p = p / d - kaliParam;
+
+        // Orbit trap distances
+        float dist = length(p);
+        trapOrigin = min(trapOrigin, dist);
+        trapAxisX = min(trapAxisX, abs(p.x));
+        trapAxisY = min(trapAxisY, abs(p.y));
+        trapAxisZ = min(trapAxisZ, abs(p.z));
+
+        // Exponential glow accumulation: bright near the fold
+        float weight = 1.0 / (1.0 + float(i) * 0.5);
+        accumGlow += exp(-dist * 4.0) * weight;
+        accumDepth += dist * weight;
+        orbitEnergy += dot(p, p);
+
+        // Store early positions
+        if (i == 1) p1 = p;
+        if (i == 3) p2 = p;
+    }
+
+    orbitEnergy /= float(MAX_ITER);
+
+    // --- DEPTH MAPPING from orbit traps ---
+    // Close traps = near = red (low depth), far traps = far = blue (high depth)
+
+    // Normalize trap distances
+    float tOrigin = clamp(trapOrigin * 0.8, 0.0, 1.0);
+    float tEdge = clamp(min(trapAxisX, min(trapAxisY, trapAxisZ)) * 2.0, 0.0, 1.0);
+    float tGlow = clamp(accumGlow * 0.4, 0.0, 1.0);
+    float tOrbitAvg = clamp(accumDepth / float(MAX_ITER) * 0.3, 0.0, 1.0);
+
+    // Combine traps into depth
+    // Origin trap: tight orbits = red/near
+    // Edge trap: near-axis features = structural detail
+    // Glow: exponential accumulation provides smooth gradient
+    float depth = tOrigin * 0.2 + tEdge * 0.15 + (1.0 - tGlow) * 0.35 + tOrbitAvg * 0.3;
+
+    // S-curve for perceptual spread
+    depth = smoothstep(0.05, 0.95, depth);
+
+    // Drop pushes depth toward red (near)
+    depth = mix(depth, 0.0, DROP_INTENSITY * 0.4);
+
+    // --- CHROMADEPTH COLOR ---
+    vec3 col = chromadepth(depth);
+
+    // --- BRIGHTNESS from orbit structure ---
+    // Glow around fold lines
+    float foldGlow = accumGlow * 0.6;
+    foldGlow = clamp(foldGlow, 0.0, 1.0);
+
+    // Edge highlighting from trap proximity
+    float edgeBright = exp(-tEdge * 6.0) * 0.4;
+
+    float brightness = 0.45 + foldGlow * 0.35 + edgeBright;
+    brightness *= 1.0 + BASS_PUNCH * 0.08;
+    brightness = clamp(brightness, 0.1, 1.0);
+    col *= brightness;
+
+    // Edge glow from spectral flux on fractal boundaries
+    float edgeD = length(vec2(dFdx(depth), dFdy(depth)));
+    float edgeHighlight = smoothstep(0.0, 0.08, edgeD) * FLUX_EDGE * 0.25;
+    col += edgeHighlight * vec3(1.0, 0.95, 0.85);
+
+    col = clamp(col, 0.0, 1.0);
+
+    // --- FRAME FEEDBACK with subtle decay ---
+    // Warp feedback UV using orbit positions for fractal-structured persistence
+    float fbStrength = 0.04 * (1.0 + DROP_INTENSITY * 2.0);
+    fbStrength += BEAT_HIT * 0.015;
+
+    vec2 orbitWarp = vec2(
+        p1.x * 0.015 + p2.y * 0.008,
+        p1.y * 0.015 - p2.x * 0.008
+    ) * fbStrength;
+
+    // Slow rotation to prevent static feedback loops
+    float fbAngle = iTime * 0.008;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotatedUV = vec2(centered.x * fbc - centered.y * fbs,
+                          centered.x * fbs + centered.y * fbc) + 0.5;
+
+    vec2 fbUV = clamp(rotatedUV + orbitWarp, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    // Oklab blending for perceptually uniform feedback
+    vec3 colOk = rgb2oklab(col);
+    vec3 prevOk = rgb2oklab(prev);
+
+    // Decay previous frame
+    prevOk.x *= 0.96;   // luminance decay
+    prevOk.yz *= 0.98;  // slight chroma decay
+
+    // New frame dominates — sharp fractal detail is primary
+    float newAmount = 0.72;
+    newAmount += DROP_INTENSITY * 0.12;
+    newAmount -= CONFIDENCE * 0.08;
+    newAmount = clamp(newAmount, 0.55, 0.88);
+
+    vec3 blended = mix(prevOk, colOk, newAmount);
+
+    // Inject fresh chroma to prevent color death
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.6) {
+        blended.yz = mix(blended.yz, colOk.yz, 0.35);
+    }
+
+    col = oklab2rgb(blended);
+
+    // --- BEAT/DROP FLASH ---
+    col *= 1.0 + BEAT_HIT * 0.12;
+    col = mix(col, col * vec3(1.3, 0.8, 0.7), DROP_INTENSITY * 0.2);
+
+    // --- VIGNETTE ---
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-lyapunov.frag
+++ b/shaders/claude/chromadepth-lyapunov.frag
@@ -1,0 +1,312 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, lyapunov, fractal, chaos
+// ChromaDepth Lyapunov Fractal - Edge of Chaos Visualization
+// Stable regions (lambda << 0) = red/near (order pops forward)
+// Chaotic regions (lambda >> 0) = blue/far (chaos recedes)
+// Boundary (lambda ~ 0) = green (edge of chaos in the middle)
+// Designed for ChromaDepth 3D glasses: Red=closest, Blue=farthest, Black=neutral
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (swap constants for audio uniforms)
+// ============================================================================
+
+// --- STRING PATTERN COMPLEXITY ---
+// spectralEntropy controls how complex the alternation pattern is
+// Low entropy = simple "AB", high entropy = "AABBA" or longer
+#define PATTERN_COMPLEXITY (spectralEntropyNormalized)
+// #define PATTERN_COMPLEXITY 0.5
+
+// --- ZOOM: energy drives zoom into the fractal ---
+#define ZOOM_AMOUNT (1.0 + energyNormalized * 0.8)
+// #define ZOOM_AMOUNT 1.5
+
+// --- PAN: bass/treble drift the view in parameter space ---
+#define PAN_X (bassZScore * 0.08)
+// #define PAN_X 0.0
+
+#define PAN_Y (trebleZScore * 0.06)
+// #define PAN_Y 0.0
+
+// --- INITIAL X0: spectral centroid shifts the logistic map starting point ---
+#define X0_SHIFT (spectralCentroidZScore * 0.03)
+// #define X0_SHIFT 0.0
+
+// --- BEAT: brief jolt of the parameter space ---
+#define BEAT_SHIFT (beat ? 0.15 : 0.0)
+// #define BEAT_SHIFT 0.0
+
+// --- COLOR INTENSITY ---
+#define COLOR_BRIGHTNESS (0.9 + energyZScore * 0.15)
+// #define COLOR_BRIGHTNESS 0.9
+
+// --- FEEDBACK STRENGTH ---
+#define FEEDBACK_MIX (0.25 + midsZScore * 0.05)
+// #define FEEDBACK_MIX 0.25
+
+// --- BASS PUNCH on near/red regions ---
+#define BASS_PUNCH (bassZScore * 0.06)
+// #define BASS_PUNCH 0.0
+
+// --- TREBLE EDGE glow ---
+#define TREBLE_GLOW (max(trebleZScore, 0.0) * 0.2)
+// #define TREBLE_GLOW 0.0
+
+// --- TREND DETECTION ---
+#define ENERGY_TREND (energySlope * 15.0 * energyRSquared)
+// #define ENERGY_TREND 0.0
+
+#define BASS_TREND (bassSlope * 12.0 * bassRSquared)
+// #define BASS_TREND 0.0
+
+// --- ROUGHNESS adds visual texture ---
+#define ROUGHNESS_MOD (spectralRoughnessNormalized * 0.08)
+// #define ROUGHNESS_MOD 0.0
+
+// --- FLUX drives parameter space jitter ---
+#define FLUX_JITTER (spectralFluxZScore * 0.04)
+// #define FLUX_JITTER 0.0
+
+// --- PITCH shifts hue subtly ---
+#define PITCH_HUE_SHIFT (pitchClassNormalized * 0.06)
+// #define PITCH_HUE_SHIFT 0.0
+
+// --- Constants ---
+#define MAX_LYAPUNOV_ITER 28
+#define SETTLE_ITER 4
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// ALTERNATION STRING PATTERN
+// ============================================================================
+// Returns 0.0 (use parameter a) or 1.0 (use parameter b) for step i
+// Pattern complexity transitions from "AB" to "AABB" to "AABBA" etc.
+
+float getPatternValue(int step, float complexity) {
+    // Simple patterns encoded as sequences
+    // complexity 0.0 = "AB" (period 2)
+    // complexity 0.5 = "AABB" (period 4)
+    // complexity 1.0 = "AABBA" (period 5)
+
+    // Period-2: AB
+    float p2 = mod(float(step), 2.0) < 1.0 ? 0.0 : 1.0;
+
+    // Period-4: AABB
+    float m4 = mod(float(step), 4.0);
+    float p4 = m4 < 2.0 ? 0.0 : 1.0;
+
+    // Period-5: AABBA
+    float m5 = mod(float(step), 5.0);
+    float p5 = (m5 < 2.0 || m5 >= 4.0) ? 0.0 : 1.0;
+
+    // Blend between patterns based on complexity
+    if (complexity < 0.5) {
+        return mix(p2, p4, complexity * 2.0);
+    } else {
+        return mix(p4, p5, (complexity - 0.5) * 2.0);
+    }
+}
+
+// ============================================================================
+// LYAPUNOV EXPONENT CALCULATION
+// ============================================================================
+
+float lyapunovExponent(float a, float b, float x0, float complexity) {
+    float x = x0;
+    float lyap = 0.0;
+
+    // Settle the orbit first (skip transient)
+    for (int i = 0; i < SETTLE_ITER; i++) {
+        float pat = getPatternValue(i, complexity);
+        float r = mix(a, b, pat);
+        x = r * x * (1.0 - x);
+        x = clamp(x, 0.001, 0.999);
+    }
+
+    // Now compute the Lyapunov exponent
+    for (int i = 0; i < MAX_LYAPUNOV_ITER; i++) {
+        float pat = getPatternValue(i + SETTLE_ITER, complexity);
+        float r = mix(a, b, pat);
+        x = r * x * (1.0 - x);
+        x = clamp(x, 0.001, 0.999);
+
+        // Derivative of logistic map: r * (1 - 2x)
+        float deriv = abs(r * (1.0 - 2.0 * x));
+        lyap += log(max(deriv, 1e-10));
+    }
+
+    return lyap / float(MAX_LYAPUNOV_ITER);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    // --- PARAMETER SPACE WINDOW ---
+    // Classic Lyapunov fractal lives in (a,b) roughly [2, 4] x [2, 4]
+    // Center on the interesting region around (3.0, 3.5)
+    vec2 center = vec2(3.0, 3.4);
+
+    // Slow autonomous drift through parameter space
+    float t = iTime * 0.03;
+    center += vec2(
+        0.15 * sin(t * 1.1) + 0.08 * cos(t * 0.7),
+        0.12 * cos(t * 0.9) + 0.06 * sin(t * 1.3)
+    );
+
+    // Audio-driven pan
+    center += vec2(PAN_X, PAN_Y);
+
+    // Beat shift: brief jolt
+    center += vec2(
+        BEAT_SHIFT * sin(iTime * 7.3),
+        BEAT_SHIFT * cos(iTime * 5.1)
+    );
+
+    // Trend-based drift (steady builds move the view)
+    center += vec2(ENERGY_TREND * 0.02, BASS_TREND * 0.02);
+
+    // Flux jitter
+    center += vec2(
+        FLUX_JITTER * sin(iTime * 11.0),
+        FLUX_JITTER * cos(iTime * 9.0)
+    );
+
+    // Zoom
+    float zoom = ZOOM_AMOUNT;
+    float span = 1.8 / zoom;
+
+    // Map UV to (a, b) parameter space
+    float a = center.x + uv.x * span;
+    float b = center.y + uv.y * span;
+
+    // Clamp to valid logistic map range (r must be in [0, 4])
+    a = clamp(a, 0.5, 4.0);
+    b = clamp(b, 0.5, 4.0);
+
+    // Initial condition for the logistic map
+    float x0 = 0.5 + X0_SHIFT;
+    x0 = clamp(x0, 0.05, 0.95);
+
+    // Pattern complexity from audio
+    float complexity = clamp(PATTERN_COMPLEXITY, 0.0, 1.0);
+
+    // Add roughness-based texture to complexity
+    complexity = clamp(complexity + ROUGHNESS_MOD * sin(a * 5.0 + b * 3.0), 0.0, 1.0);
+
+    // --- COMPUTE LYAPUNOV EXPONENT ---
+    float lambda = lyapunovExponent(a, b, x0, complexity);
+
+    // --- MAP TO CHROMADEPTH ---
+    // lambda < 0: stable/ordered -> red (near, t ~ 0)
+    // lambda ~ 0: edge of chaos -> green (mid, t ~ 0.5)
+    // lambda > 0: chaotic -> blue/violet (far, t ~ 1.0)
+
+    // Normalize lambda to 0-1 range
+    // Typical range: about -2 to +2, but can vary
+    // Use a sigmoid-like mapping for smooth distribution
+    float depth = 1.0 / (1.0 + exp(-lambda * 2.5));
+
+    // Enhance contrast around the edge of chaos (lambda ~ 0)
+    // This makes the green boundary more visible
+    float edgeFactor = exp(-lambda * lambda * 3.0);
+
+    // Brightness: brightest at the boundary, darker in deep stable/chaotic regions
+    float brightness = 0.3 + 0.7 * (0.4 + 0.6 * edgeFactor);
+
+    // Deep stable regions (very negative lambda) get strong red
+    float stableIntensity = clamp(-lambda * 0.5, 0.0, 1.0);
+    // Deep chaotic regions get subtle structure from the exponent
+    float chaoticDetail = clamp(lambda * 0.3, 0.0, 1.0);
+
+    // Add pitch-based hue shift
+    depth = fract(depth + PITCH_HUE_SHIFT);
+
+    // Get the chromadepth color
+    vec3 col = chromadepth(depth);
+
+    // Modulate brightness
+    col *= brightness;
+    col *= clamp(COLOR_BRIGHTNESS, 0.3, 1.5);
+
+    // Bass punch: push stable/red regions brighter (they pop forward more)
+    col += chromadepth(0.0) * stableIntensity * max(BASS_PUNCH, 0.0) * 0.3;
+
+    // Treble glow on chaotic edges
+    float edgeGlow = edgeFactor * TREBLE_GLOW;
+    col += vec3(0.8, 1.0, 0.8) * edgeGlow * 0.4;
+
+    // Beat flash: brief brightness boost biased toward red
+    if (beat) {
+        col *= 1.15;
+        col.r *= 1.1;
+    }
+
+    // Clamp before feedback
+    col = clamp(col, 0.0, 1.0);
+
+    // --- FRAME FEEDBACK with gentle blur ---
+    // Sample previous frame with slight offset for blur effect
+    float fbAmount = clamp(FEEDBACK_MIX, 0.1, 0.45);
+
+    // Gentle blur: sample from nearby pixels
+    vec2 pixelSize = 1.0 / iResolution.xy;
+    float blurRadius = 1.5;
+
+    vec3 prev = vec3(0.0);
+    // 5-tap blur pattern (center + 4 cardinal directions)
+    prev += getLastFrameColor(screenUV).rgb * 0.4;
+    prev += getLastFrameColor(screenUV + vec2(pixelSize.x * blurRadius, 0.0)).rgb * 0.15;
+    prev += getLastFrameColor(screenUV - vec2(pixelSize.x * blurRadius, 0.0)).rgb * 0.15;
+    prev += getLastFrameColor(screenUV + vec2(0.0, pixelSize.y * blurRadius)).rgb * 0.15;
+    prev += getLastFrameColor(screenUV - vec2(0.0, pixelSize.y * blurRadius)).rgb * 0.15;
+
+    // Decay previous frame to prevent accumulation
+    prev *= 0.96;
+
+    // Blend in oklab for perceptual uniformity
+    vec3 colOk = rgb2oklab(col);
+    vec3 prevOk = rgb2oklab(prev);
+
+    // Decay chroma of previous frame slightly
+    prevOk.yz *= 0.98;
+
+    vec3 blended = mix(prevOk, colOk, 1.0 - fbAmount);
+
+    // Ensure fresh color dominates when chroma is dying
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.6) {
+        blended.yz = mix(blended.yz, colOk.yz, 0.4);
+    }
+
+    col = oklab2rgb(blended);
+
+    // --- VIGNETTE ---
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    // Black out regions outside the interesting parameter space
+    // (where a or b are near the edges of validity)
+    float edgeFade = smoothstep(0.5, 1.5, a) * smoothstep(4.0, 3.8, a)
+                   * smoothstep(0.5, 1.5, b) * smoothstep(4.0, 3.8, b);
+    col *= edgeFade;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-mandelbrot.frag
+++ b/shaders/claude/chromadepth-mandelbrot.frag
@@ -1,0 +1,300 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, fractal, mandelbrot
+// ChromaDepth Mandelbrot Deep Zoom — smooth coloring with orbit traps
+// Iteration count maps to chromadepth depth: boundary detail = red (near),
+// fast escape = blue/violet (far). Interior uses orbit traps for rich color.
+// Audio drives zoom, rotation, c-offset exploration, beat flash.
+// Frame feedback with orbit-warped sampling and gentle decay.
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// --- ZOOM: energy drives zoom depth ---
+#define ZOOM_POWER (3.0 + energyNormalized * 4.0)
+// #define ZOOM_POWER 5.0
+
+// --- ROTATION: pitchClass rotates the view ---
+#define VIEW_ROTATION (iTime * 0.03 + pitchClassNormalized * 1.5)
+// #define VIEW_ROTATION 0.0
+
+// --- C-OFFSET for mini-brot exploration via regression slopes ---
+#define C_OFFSET_REAL (bassSlope * 15.0 * bassRSquared)
+// #define C_OFFSET_REAL 0.0
+
+#define C_OFFSET_IMAG (spectralCentroidSlope * 12.0 * spectralCentroidRSquared)
+// #define C_OFFSET_IMAG 0.0
+
+// --- ZOOM TARGET drift: treble/bass steer the target ---
+#define TARGET_DRIFT_X (trebleZScore * 0.003)
+// #define TARGET_DRIFT_X 0.0
+
+#define TARGET_DRIFT_Y (bassZScore * 0.002)
+// #define TARGET_DRIFT_Y 0.0
+
+// --- COLOR modulation ---
+#define HUE_SHIFT (spectralEntropyNormalized * 0.08)
+// #define HUE_SHIFT 0.0
+
+#define BRIGHTNESS_MOD (0.85 + energyZScore * 0.15)
+// #define BRIGHTNESS_MOD 0.85
+
+// --- BEAT flash ---
+#define BEAT_FLASH (beat ? 1.25 : 1.0)
+// #define BEAT_FLASH 1.0
+
+// --- FLUX JITTER: spectral flux adds fine camera jitter ---
+#define FLUX_JITTER (spectralFluxZScore * 0.002)
+// #define FLUX_JITTER 0.0
+
+// --- ROUGHNESS: drives interior saturation ---
+#define ROUGHNESS_SAT (0.85 + spectralRoughnessNormalized * 0.15)
+// #define ROUGHNESS_SAT 0.9
+
+// --- CONFIDENCE for feedback ---
+#define TREND_CONFIDENCE (energyRSquared * 0.5 + bassRSquared * 0.3 + spectralCentroidRSquared * 0.2)
+// #define TREND_CONFIDENCE 0.5
+
+// --- MIDS for feedback warp ---
+#define MIDS_WARP (midsZScore * 0.01)
+// #define MIDS_WARP 0.0
+
+// --- ENERGY TREND for zoom pulsing ---
+#define ENERGY_TREND (energySlope * 10.0 * energyRSquared)
+// #define ENERGY_TREND 0.0
+
+// --- Max iterations (mobile safe) ---
+#define MAX_ITER 64
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+// 0.0 = red (closest), 0.33 = green (mid), 0.75 = blue/violet (farthest)
+// Black = neutral depth
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.75; // 0 -> red, 0.25 -> yellow, 0.33 -> green, 0.75 -> violet
+    float sat = 0.92 - t * 0.08;
+    float lit = 0.52 - t * 0.1;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// MANDELBROT DEEP ZOOM
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    // --- ZOOM TARGET ---
+    // Wander through interesting regions of the Mandelbrot set
+    // The Seahorse Valley at c ~ -0.75 + 0.1i has infinite mini-brots
+    float wanderT = iTime * 0.012;
+    vec2 target = vec2(
+        -0.7435669 + 0.0002 * sin(wanderT * 0.7) + TARGET_DRIFT_X,
+         0.1314023 + 0.00015 * cos(wanderT * 0.9) + TARGET_DRIFT_Y
+    );
+
+    // Apply c-offset from regression slopes for mini-brot exploration
+    float offsetScale = 0.001 / max(pow(2.0, ZOOM_POWER * 0.3), 1.0);
+    target.x += C_OFFSET_REAL * offsetScale;
+    target.y += C_OFFSET_IMAG * offsetScale;
+
+    // --- ZOOM ---
+    float zoom = pow(2.0, ZOOM_POWER + sin(wanderT * 1.3) * 0.5 + ENERGY_TREND * 0.3);
+    zoom = max(zoom, 1.0);
+
+    // --- ROTATION ---
+    float angle = VIEW_ROTATION;
+    float ca = cos(angle), sa = sin(angle);
+    uv = mat2(ca, -sa, sa, ca) * uv;
+
+    // --- MAP to complex plane ---
+    vec2 c = target + uv / zoom;
+
+    // Add flux jitter
+    c += vec2(FLUX_JITTER * sin(iTime * 7.3), FLUX_JITTER * cos(iTime * 5.7));
+
+    // --- MANDELBROT ITERATION with smooth coloring + orbit traps ---
+    vec2 z = vec2(0.0);
+    float smoothIter = 0.0;
+    float trapOrigin = 1e10;   // closest approach to origin
+    float trapLineX = 1e10;    // closest to x-axis
+    float trapLineY = 1e10;    // closest to y-axis
+    float trapCircle = 1e10;   // closest to unit circle
+    float orbitAngle = 0.0;    // accumulated angle
+    float orbitDist = 0.0;     // accumulated distance
+    bool escaped = false;
+
+    // Store orbit positions for feedback warping
+    vec2 z1 = z, z2 = z;
+
+    for (int i = 0; i < MAX_ITER; i++) {
+        // z = z^2 + c
+        z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+
+        float mag2 = dot(z, z);
+        float mag = sqrt(mag2);
+
+        // Store early orbit positions
+        if (i == 2) z1 = z;
+        if (i == 5) z2 = z;
+
+        // Orbit traps
+        trapOrigin = min(trapOrigin, mag);
+        trapLineX = min(trapLineX, abs(z.y));
+        trapLineY = min(trapLineY, abs(z.x));
+        trapCircle = min(trapCircle, abs(mag - 1.0));
+        orbitAngle += atan(z.y, z.x);
+        orbitDist += mag;
+
+        if (mag2 > 256.0) {
+            // Smooth iteration count (anti-banding)
+            smoothIter = float(i) - log2(log2(mag2)) + 4.0;
+            escaped = true;
+            break;
+        }
+        smoothIter = float(i);
+    }
+
+    float iterNorm = smoothIter / float(MAX_ITER);
+
+    // --- DEPTH MAPPING ---
+    float depth;
+    float brightness = 1.0;
+
+    if (escaped) {
+        // EXTERIOR: smooth iteration -> chromadepth depth
+        // Near boundary (many iterations) = mid-spectrum
+        // Fast escape (few iterations) = violet/far
+        float logIter = log(1.0 + smoothIter) / log(1.0 + float(MAX_ITER));
+
+        // Near boundary -> green/cyan (0.35-0.5), fast escape -> violet (0.75)
+        depth = mix(0.75, 0.35, pow(logIter, 0.45));
+
+        // Brightness: near boundary = bright, far = dark
+        brightness = mix(0.12, 0.8, pow(logIter, 0.5));
+    } else {
+        // INTERIOR: orbit traps -> rich chromadepth color variation
+        // Multiple independent traps for full-spectrum interior
+
+        float tOrigin = clamp(trapOrigin * 1.2, 0.0, 1.0);
+        float tLine = clamp(min(trapLineX, trapLineY) * 2.5, 0.0, 1.0);
+        float tCircle = clamp(trapCircle * 1.8, 0.0, 1.0);
+
+        // Angular orbit texture
+        float tAngle = fract(orbitAngle * 0.06);
+        float tAngle2 = abs(sin(orbitAngle * 0.15));
+
+        // Orbit average distance
+        float tOrbit = clamp(orbitDist / float(MAX_ITER) * 0.35, 0.0, 1.0);
+
+        // Final z position adds spatial variation
+        float zFinal = atan(z.y, z.x) / 6.283 + 0.5;
+        float zDist = clamp(length(z) * 0.4, 0.0, 1.0);
+
+        // Three independent depth signals
+        float geoDepth = tLine * 0.5 + tCircle * 0.5;
+        float orgDepth = tOrigin * 0.35 + zFinal * 0.35 + zDist * 0.3;
+        float texDepth = tAngle * 0.35 + tAngle2 * 0.35 + tOrbit * 0.3;
+
+        // Contrast from signal differences
+        float contrast = abs(geoDepth - orgDepth) + abs(texDepth - geoDepth) * 0.5;
+        float blend = geoDepth * 0.3 + orgDepth * 0.25 + texDepth * 0.25 + contrast * 0.2;
+
+        // S-curve for better spread
+        blend = smoothstep(0.05, 0.95, blend);
+
+        // Interior: red (0.0) through green (0.35) -- closest in chromadepth
+        depth = blend * 0.35;
+
+        // Interior brightness with variation
+        brightness = 0.45 + tAngle * 0.2 + (1.0 - tOrigin) * 0.2 + contrast * 0.15;
+    }
+
+    // --- CHROMADEPTH COLOR ---
+    float finalDepth = fract(depth + HUE_SHIFT);
+    vec3 col = chromadepth(finalDepth);
+
+    // Apply brightness and saturation
+    vec3 hsl = vec3(finalDepth * 0.75, ROUGHNESS_SAT, 0.52 - finalDepth * 0.1);
+    col = hsl2rgb(hsl) * brightness;
+
+    // Brightness modulation from energy
+    col *= clamp(BRIGHTNESS_MOD, 0.3, 1.3);
+
+    // Beat flash
+    col *= BEAT_FLASH;
+
+    // Edge glow on fractal boundaries
+    float edge = length(vec2(dFdx(depth), dFdy(depth)));
+    float edgeGlow = smoothstep(0.0, 0.05, edge) * 0.2;
+    col += edgeGlow * vec3(1.0, 0.9, 0.8);
+
+    col = clamp(col, 0.0, 1.0);
+
+    // --- FRAME FEEDBACK with orbit-warped sampling ---
+    // Warp strength: stronger near boundary
+    float fbStrength = escaped
+        ? 0.035 * pow(iterNorm, 0.35)
+        : 0.05 * (1.0 - trapOrigin * 0.4);
+
+    fbStrength += float(beat) * 0.015;
+
+    // Use orbit positions to warp the feedback UV (follow fractal structure)
+    vec2 orbitWarp = vec2(
+        z1.x * 0.015 + z2.y * 0.008,
+        z1.y * 0.015 - z2.x * 0.008
+    ) * fbStrength;
+
+    orbitWarp += vec2(MIDS_WARP, MIDS_WARP * 0.7);
+
+    // Slow rotation prevents static feedback loops
+    float fbAngle = iTime * 0.008;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotatedUV = vec2(
+        centered.x * fbc - centered.y * fbs,
+        centered.x * fbs + centered.y * fbc
+    ) + 0.5;
+
+    vec2 fbUV = clamp(rotatedUV + orbitWarp, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    // Oklab blending for perceptual uniformity
+    vec3 colOk = rgb2oklab(col);
+    vec3 prevOk = rgb2oklab(prev);
+
+    // Decay previous frame
+    prevOk.x *= 0.96;
+    prevOk.yz *= 0.98;
+
+    // New frame dominance
+    float newAmount = 0.72;
+    newAmount -= TREND_CONFIDENCE * 0.08; // steady trends = more persistence
+    newAmount = clamp(newAmount, 0.55, 0.88);
+
+    vec3 blended = mix(prevOk, colOk, newAmount);
+
+    // Inject fresh chroma to prevent color death
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.65) {
+        blended.yz = mix(blended.yz, colOk.yz, 0.35);
+    }
+
+    col = oklab2rgb(blended);
+
+    // Beat/drop color accent
+    col *= 1.0 + float(beat) * 0.12;
+
+    // --- VIGNETTE ---
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-mandelbulb.frag
+++ b/shaders/claude/chromadepth-mandelbulb.frag
@@ -1,0 +1,290 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, fractal, mandelbulb, raymarching
+// ChromaDepth Mandelbulb - Raymarched 3D Mandelbrot fractal
+// Red = nearest, Green = mid, Blue/Violet = farthest
+// Designed for ChromaDepth 3D glasses
+
+#define MAX_STEPS 35
+#define MAX_DIST 15.0
+#define SURF_DIST 0.003
+#define NORM_EPS 0.005
+#define POWER_ITERS 5
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// Power parameter: bass modulates fractal shape between 6-10
+#define POWER (8.0 + bassZScore * 2.0)
+// #define POWER 8.0
+
+// Camera orbit speed: spectral centroid drives rotation
+#define ORBIT_SPEED (0.08 + spectralCentroidZScore * 0.04)
+// #define ORBIT_SPEED 0.08
+
+// Camera distance breathing: energy pushes camera in/out
+#define CAM_BREATHE (energyZScore * 0.4)
+// #define CAM_BREATHE 0.0
+
+// Beat zoom punch: brief zoom on beat
+#define BEAT_ZOOM (beat ? 0.5 : 0.0)
+// #define BEAT_ZOOM 0.0
+
+// Rim light intensity: treble adds rim glow
+#define RIM_INTENSITY (0.3 + max(trebleZScore, 0.0) * 0.5)
+// #define RIM_INTENSITY 0.3
+
+// Hue shift from pitch class
+#define HUE_SHIFT (pitchClassNormalized * 0.08)
+// #define HUE_SHIFT 0.0
+
+// Bass brightness throb
+#define BASS_BRIGHT (0.95 + bassNormalized * 0.1)
+// #define BASS_BRIGHT 1.0
+
+// Energy-driven saturation boost
+#define SAT_BOOST (energyNormalized * 0.15)
+// #define SAT_BOOST 0.0
+
+// Spectral flux camera wobble
+#define CAM_WOBBLE (spectralFluxZScore * 0.03)
+// #define CAM_WOBBLE 0.0
+
+// Mids modulate vertical camera offset
+#define CAM_Y_OFFSET (midsZScore * 0.15)
+// #define CAM_Y_OFFSET 0.0
+
+// Spectral entropy adds surface detail via DE scale
+#define ENTROPY_DETAIL (spectralEntropyNormalized * 0.1)
+// #define ENTROPY_DETAIL 0.0
+
+// Beat hue punch toward red
+#define BEAT_HUE (beat ? -0.04 : 0.0)
+// #define BEAT_HUE 0.0
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// MANDELBULB DISTANCE ESTIMATOR
+// ============================================================================
+
+float mandelbulbDE(vec3 pos) {
+    vec3 z = pos;
+    float dr = 1.0;
+    float r = 0.0;
+    float power = POWER;
+
+    for (int i = 0; i < POWER_ITERS; i++) {
+        r = length(z);
+        if (r > 2.0) break;
+
+        // Convert to spherical coordinates
+        float theta = acos(z.z / max(r, 0.001));
+        float phi = atan(z.y, z.x);
+
+        // Power the radius
+        dr = pow(r, power - 1.0) * power * dr + 1.0;
+
+        // Scale and rotate the point
+        float zr = pow(r, power);
+        theta *= power;
+        phi *= power;
+
+        // Convert back to cartesian
+        z = zr * vec3(
+            sin(theta) * cos(phi),
+            sin(theta) * sin(phi),
+            cos(theta)
+        );
+        z += pos;
+    }
+
+    return 0.5 * log(r) * r / max(dr, 0.001);
+}
+
+// ============================================================================
+// CHEAP AMBIENT OCCLUSION (2 samples)
+// ============================================================================
+
+float cheapAO(vec3 p, vec3 n) {
+    float d1 = mandelbulbDE(p + n * 0.02);
+    float d2 = mandelbulbDE(p + n * 0.08);
+    return clamp(0.5 + (d1 + d2) * 8.0, 0.0, 1.0);
+}
+
+// ============================================================================
+// NORMAL CALCULATION
+// ============================================================================
+
+vec3 getNormal(vec3 p) {
+    vec2 e = vec2(NORM_EPS, 0.0);
+    return normalize(vec3(
+        mandelbulbDE(p + e.xyy) - mandelbulbDE(p - e.xyy),
+        mandelbulbDE(p + e.yxy) - mandelbulbDE(p - e.yxy),
+        mandelbulbDE(p + e.yyx) - mandelbulbDE(p - e.yyx)
+    ));
+}
+
+// ============================================================================
+// CEL SHADING (3-band)
+// ============================================================================
+
+float celShade(float d) {
+    if (d > 0.6) return 1.0;
+    if (d > 0.3) return 0.6;
+    return 0.3;
+}
+
+// ============================================================================
+// RAYMARCHING
+// ============================================================================
+
+float raymarch(vec3 ro, vec3 rd) {
+    float t = 0.0;
+
+    for (int i = 0; i < MAX_STEPS; i++) {
+        vec3 p = ro + rd * t;
+        float d = mandelbulbDE(p);
+
+        if (d < SURF_DIST) return t;
+        if (t > MAX_DIST) break;
+
+        t += d;
+    }
+
+    return MAX_DIST;
+}
+
+// ============================================================================
+// HASH
+// ============================================================================
+
+float hash(float n) {
+    return fract(sin(n) * 43758.5453);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    // Camera orbit around the Mandelbulb
+    float angle = iTime * ORBIT_SPEED;
+    float camY = 0.3 + sin(iTime * 0.06) * 0.2 + CAM_Y_OFFSET;
+    float camDist = 2.8 + sin(iTime * 0.09) * 0.3 - CAM_BREATHE - BEAT_ZOOM;
+    camDist = max(camDist, 1.8); // don't clip into the bulb
+
+    vec3 ro = vec3(
+        sin(angle) * camDist + CAM_WOBBLE * sin(iTime * 3.1),
+        camY,
+        cos(angle) * camDist + CAM_WOBBLE * cos(iTime * 2.7)
+    );
+
+    // Look at origin (center of Mandelbulb)
+    vec3 lookAt = vec3(0.0, 0.0, 0.0);
+    vec3 forward = normalize(lookAt - ro);
+    vec3 right = normalize(cross(vec3(0.0, 1.0, 0.0), forward));
+    vec3 up = cross(forward, right);
+
+    // FOV with beat zoom
+    float fov = 1.8 - BEAT_ZOOM * 0.3;
+    vec3 rd = normalize(uv.x * right + uv.y * up + fov * forward);
+
+    // Raymarch
+    float dist = raymarch(ro, rd);
+
+    // Background: deep blue/violet sky for far chromadepth
+    float skyGrad = clamp(rd.y * 0.5 + 0.5, 0.0, 1.0);
+    vec3 skyCol = chromadepth(mix(0.85, 1.0, skyGrad));
+    skyCol *= mix(0.15, 0.25, skyGrad); // keep sky dark
+
+    vec3 col = skyCol;
+
+    if (dist < MAX_DIST) {
+        vec3 p = ro + rd * dist;
+        vec3 n = getNormal(p);
+
+        // Single directional light
+        vec3 lightDir = normalize(vec3(0.6, 0.8, 0.4));
+        float diff = max(dot(n, lightDir), 0.0);
+
+        // Cel-shade the diffuse
+        float cel = celShade(diff);
+
+        // Cheap AO
+        float ao = cheapAO(p, n);
+
+        // Rim lighting (treble-driven intensity)
+        float rim = pow(1.0 - max(dot(n, -rd), 0.0), 3.0);
+        float rimLight = rim * RIM_INTENSITY;
+
+        // Map hit distance to chromadepth color
+        // Closer hits (small dist) = red, farther = green, farthest = blue
+        float depthT = clamp((dist - 1.5) / (MAX_DIST - 1.5), 0.0, 1.0);
+        depthT = pow(depthT, 0.7); // compress near range for more red/green detail
+
+        // Apply audio hue shifts
+        float hueOffset = HUE_SHIFT + BEAT_HUE;
+
+        // Build the chromadepth color
+        float hue = fract(depthT * 0.82 + hueOffset);
+        float sat = 0.95 - depthT * 0.1 + SAT_BOOST;
+        float lit = cel * (0.35 + (1.0 - depthT) * 0.15); // nearer is brighter
+
+        // Apply AO to lightness
+        lit *= ao;
+
+        col = hsl2rgb(vec3(hue, clamp(sat, 0.0, 1.0), clamp(lit, 0.05, 0.55)));
+
+        // Add rim light
+        vec3 rimCol = chromadepth(max(depthT - 0.15, 0.0)); // rim shifts toward red (nearer)
+        col += rimCol * rimLight * 0.5;
+
+        // Bass brightness
+        col *= BASS_BRIGHT;
+
+        // Beat flash
+        if (beat) {
+            col *= 1.15;
+        }
+
+        // Depth fog toward background color
+        float fog = exp(-dist * 0.12);
+        col = mix(skyCol, col, fog);
+    }
+
+    // Vignette
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.6;
+
+    // Frame feedback for subtle motion blur
+    vec4 prev = getLastFrameColor(screenUV);
+    col = mix(prev.rgb * 0.96, col, 0.7);
+
+    // Ensure saturation stays high for chromadepth
+    vec3 colHSL = rgb2hsl(col);
+    colHSL.y = min(colHSL.y * 1.1, 1.0);
+    colHSL.z = clamp(colHSL.z, 0.03, 0.55);
+    col = hsl2rgb(colHSL);
+
+    // Subtle dithering
+    float dither = (hash(dot(fragCoord, vec2(12.9898, 78.233)) + iTime) - 0.5) / 255.0;
+    col += dither;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-menger.frag
+++ b/shaders/claude/chromadepth-menger.frag
@@ -1,0 +1,272 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, fractal, menger, raymarching
+// ChromaDepth Menger Sponge - Fly through a fractal box tunnel
+// Red = closest, Green = mid, Blue/Violet = farthest, Black = neutral
+// Designed for ChromaDepth 3D glasses
+
+#define MAX_STEPS 40
+#define MAX_DIST 20.0
+#define SURF_DIST 0.002
+#define MENGER_ITER 4
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (swap constants for audio uniforms)
+// ============================================================================
+
+// Bass expands/contracts the sponge scale
+#define SPONGE_SCALE (1.0 + bassZScore * 0.08)
+// #define SPONGE_SCALE 1.0
+
+// Spectral entropy modulates the cross-shaped hole size
+#define HOLE_SIZE (1.05 + spectralEntropyNormalized * 0.25)
+// #define HOLE_SIZE 1.2
+
+// Energy drives camera speed
+#define CAM_SPEED (0.3 + energyNormalized * 0.5)
+// #define CAM_SPEED 0.5
+
+// Beat flashes brightness
+#define BEAT_FLASH (beat ? 1.35 : 1.0)
+// #define BEAT_FLASH 1.0
+
+// Treble adds edge glow
+#define EDGE_GLOW (trebleZScore * 0.15)
+// #define EDGE_GLOW 0.0
+
+// Spectral centroid shifts camera look direction
+#define LOOK_DRIFT (spectralCentroidZScore * 0.06)
+// #define LOOK_DRIFT 0.0
+
+// Mids influence the camera tilt
+#define CAM_TILT (midsZScore * 0.04)
+// #define CAM_TILT 0.0
+
+// Spectral flux drives subtle rotation of the sponge
+#define SPONGE_ROTATE (spectralFluxZScore * 0.03)
+// #define SPONGE_ROTATE 0.0
+
+// Bass slope for trend-aware brightness modulation
+#define BASS_TREND (bassSlope * 10.0 * bassRSquared)
+// #define BASS_TREND 0.0
+
+// Energy slope for anticipation effects
+#define ENERGY_TREND (energySlope * 15.0 * energyRSquared)
+// #define ENERGY_TREND 0.0
+
+// Pitch class for subtle hue offset
+#define HUE_OFFSET (pitchClassNormalized * 0.05)
+// #define HUE_OFFSET 0.0
+
+// Roughness for depth contrast
+#define DEPTH_CONTRAST (0.9 + spectralRoughnessNormalized * 0.2)
+// #define DEPTH_CONTRAST 1.0
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// MENGER SPONGE SDF
+// ============================================================================
+
+float sdBox(vec3 p, vec3 b) {
+    vec3 q = abs(p) - b;
+    return length(max(q, 0.0)) + min(max(q.x, max(q.y, q.z)), 0.0);
+}
+
+// Cross-shaped hole used to carve the Menger sponge
+float sdCross(vec3 p, float s) {
+    float holeW = s * HOLE_SIZE;
+    float a = sdBox(p, vec3(holeW, 999.0, holeW));
+    float b = sdBox(p, vec3(999.0, holeW, holeW));
+    float c = sdBox(p, vec3(holeW, holeW, 999.0));
+    return min(a, min(b, c));
+}
+
+float mengerSDF(vec3 p) {
+    // Apply audio-reactive scale
+    p /= SPONGE_SCALE;
+
+    // Optional subtle rotation from spectral flux
+    float ra = SPONGE_ROTATE;
+    float cra = cos(ra), sra = sin(ra);
+    p.xz = mat2(cra, -sra, sra, cra) * p.xz;
+
+    // Start with a box
+    float d = sdBox(p, vec3(1.0));
+
+    float s = 1.0; // current scale
+
+    for (int i = 0; i < MENGER_ITER; i++) {
+        // Scale factor for this iteration
+        s *= 3.0;
+        // Fold into positive octant and tile
+        vec3 q = mod(p * s + 1.5, 3.0) - 1.5;
+        // Subtract cross-shaped holes
+        float cross = sdCross(q, 1.0) / s;
+        d = max(d, -cross);
+    }
+
+    return d * SPONGE_SCALE;
+}
+
+// ============================================================================
+// RAYMARCHING
+// ============================================================================
+
+struct HitInfo {
+    float dist;
+    int steps;
+};
+
+HitInfo raymarch(vec3 ro, vec3 rd) {
+    float t = 0.0;
+    int steps = 0;
+    for (int i = 0; i < MAX_STEPS; i++) {
+        vec3 p = ro + rd * t;
+        float d = mengerSDF(p);
+        if (d < SURF_DIST) {
+            steps = i;
+            return HitInfo(t, steps);
+        }
+        if (t > MAX_DIST) break;
+        t += d;
+        steps = i;
+    }
+    return HitInfo(-1.0, steps);
+}
+
+// ============================================================================
+// NORMAL ESTIMATION
+// ============================================================================
+
+vec3 getNormal(vec3 p) {
+    float e = 0.003;
+    float d = mengerSDF(p);
+    return normalize(vec3(
+        mengerSDF(p + vec3(e, 0, 0)) - d,
+        mengerSDF(p + vec3(0, e, 0)) - d,
+        mengerSDF(p + vec3(0, 0, e)) - d
+    ));
+}
+
+// ============================================================================
+// CAMERA PATH - Flies through Menger tunnels
+// ============================================================================
+
+vec3 cameraPath(float t) {
+    // Sinusoidal path that weaves through the cross-shaped tunnels
+    // Stay near the center of the holes (which are along axes)
+    float x = sin(t * 0.17) * 0.4;
+    float y = cos(t * 0.13) * 0.3;
+    float z = t * 0.8; // move forward along z
+    return vec3(x, y, z);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    // Camera position along tunnel path
+    float camT = iTime * CAM_SPEED;
+    vec3 ro = cameraPath(camT);
+
+    // Look-at point slightly ahead on the path
+    vec3 lookAt = cameraPath(camT + 1.5);
+    lookAt.x += LOOK_DRIFT;
+    lookAt.y += CAM_TILT;
+
+    // Camera basis
+    vec3 forward = normalize(lookAt - ro);
+    vec3 right = normalize(cross(vec3(0, 1, 0), forward));
+    vec3 up = cross(forward, right);
+
+    // Ray direction with slight FOV
+    float fov = 1.2;
+    vec3 rd = normalize(uv.x * right + uv.y * up + fov * forward);
+
+    // Raymarch
+    HitInfo hit = raymarch(ro, rd);
+
+    vec3 col = vec3(0.0); // black background (neutral in chromadepth)
+
+    if (hit.dist > 0.0) {
+        vec3 p = ro + rd * hit.dist;
+        vec3 n = getNormal(p);
+
+        // --- DEPTH MAPPING ---
+        // Map hit distance to 0-1 for chromadepth
+        // Near hits = 0.0 (red), far hits = 1.0 (violet)
+        float depthT = clamp(hit.dist / MAX_DIST, 0.0, 1.0);
+
+        // Apply depth contrast from roughness
+        depthT = pow(depthT, DEPTH_CONTRAST);
+
+        // Apply hue offset from pitch class
+        float hueT = fract(depthT + HUE_OFFSET);
+
+        col = chromadepth(hueT);
+
+        // --- LIGHTING ---
+        // Single directional light
+        vec3 lightDir = normalize(vec3(0.5, 0.8, -0.3));
+        float diff = max(dot(n, lightDir), 0.0);
+
+        // Approximate ambient occlusion from step count
+        // More steps = tighter geometry = darker
+        float ao = 1.0 - float(hit.steps) / float(MAX_STEPS) * 0.7;
+        ao = max(ao, 0.15);
+
+        // Ambient + diffuse
+        float lighting = 0.2 + 0.8 * diff;
+        lighting *= ao;
+
+        col *= lighting;
+
+        // --- EDGE GLOW from treble ---
+        // Detect edges via step count (more steps near edges/corners)
+        float edgeFactor = float(hit.steps) / float(MAX_STEPS);
+        float glow = smoothstep(0.3, 0.8, edgeFactor) * max(EDGE_GLOW, 0.0);
+        col += glow * vec3(1.0, 0.9, 0.8);
+
+        // --- TREND-AWARE BRIGHTNESS ---
+        // During confident builds, subtly brighten
+        float trendBright = 1.0 + clamp(ENERGY_TREND, -0.1, 0.15);
+        trendBright += clamp(BASS_TREND, -0.05, 0.1);
+        col *= trendBright;
+
+        // --- DISTANCE FOG toward black (neutral depth) ---
+        float fog = exp(-hit.dist * 0.12);
+        col *= fog;
+    }
+
+    // --- BEAT FLASH ---
+    col *= BEAT_FLASH;
+
+    // --- FEEDBACK (subtle trail) ---
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec3 prev = getLastFrameColor(screenUV).rgb;
+    // Gentle feedback: mostly current frame, slight trail for motion blur
+    col = mix(prev * 0.95, col, 0.75);
+
+    // --- VIGNETTE (keeps edges dark for chromadepth) ---
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    // Clamp to prevent white-out
+    col = clamp(col, 0.0, 1.0);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-nebula.frag
+++ b/shaders/claude/chromadepth-nebula.frag
@@ -1,0 +1,339 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, nebula, volumetric, space
+// ChromaDepth Volumetric Nebula — Volume-marched 3D noise field
+// Red = foreground gas (closest), Green = mid-depth, Blue/Violet = deep interior
+// Background stars at violet depth. Front-to-back compositing with premultiplied alpha.
+//
+// ChromaDepth glasses: Red = near, Green = mid, Blue/Violet = far, Black = neutral
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// Density threshold: energy makes nebula thicker (louder = denser gas)
+#define DENSITY_THRESH (0.35 - energyNormalized * 0.2)
+// #define DENSITY_THRESH 0.25
+
+// Turbulence: spectral flux adds churn to the gas
+#define TURBULENCE (0.6 + spectralFluxZScore * 0.3)
+// #define TURBULENCE 0.6
+
+// Color temperature: spectral centroid shifts warm/cool balance
+#define COLOR_TEMP (spectralCentroidZScore * 0.08)
+// #define COLOR_TEMP 0.0
+
+// Rotation speed: bass drives the swirl
+#define ROT_SPEED (0.08 + bassZScore * 0.04)
+// #define ROT_SPEED 0.08
+
+// Beat brightness pulse
+#define BEAT_PULSE (beat ? 1.35 : 1.0)
+// #define BEAT_PULSE 1.0
+
+// Fine detail from treble
+#define FINE_DETAIL (0.3 + trebleZScore * 0.2)
+// #define FINE_DETAIL 0.3
+
+// Nebula scale breathing with energy
+#define NEBULA_SCALE (2.2 + energyZScore * 0.15)
+// #define NEBULA_SCALE 2.2
+
+// Entropy drives structural complexity
+#define STRUCTURE_WARP (spectralEntropyNormalized * 0.4)
+// #define STRUCTURE_WARP 0.2
+
+// Bass slope for slow drift
+#define DRIFT (bassSlope * 80.0 * bassRSquared)
+// #define DRIFT 0.0
+
+// Mids add mid-layer glow
+#define MID_GLOW (0.5 + midsZScore * 0.15)
+// #define MID_GLOW 0.5
+
+// Roughness adds grittiness to density
+#define GRIT (spectralRoughnessNormalized * 0.25)
+// #define GRIT 0.1
+
+// Pitch class shifts nebula hue accent
+#define HUE_ACCENT (pitchClassNormalized * 0.1)
+// #define HUE_ACCENT 0.0
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+#define MAX_STEPS 30
+#define MAX_DIST 8.0
+#define STEP_SIZE 0.27
+#define NOISE_OCTAVES 4
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// 3D HASH-BASED NOISE (no texture lookups)
+// ============================================================================
+
+vec3 hash3(vec3 p) {
+    p = vec3(
+        dot(p, vec3(127.1, 311.7, 74.7)),
+        dot(p, vec3(269.5, 183.3, 246.1)),
+        dot(p, vec3(113.5, 271.9, 124.6))
+    );
+    return -1.0 + 2.0 * fract(sin(p) * 43758.5453123);
+}
+
+float noise3d(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    vec3 u = f * f * (3.0 - 2.0 * f);
+
+    float a = dot(hash3(i + vec3(0.0, 0.0, 0.0)), f - vec3(0.0, 0.0, 0.0));
+    float b = dot(hash3(i + vec3(1.0, 0.0, 0.0)), f - vec3(1.0, 0.0, 0.0));
+    float c = dot(hash3(i + vec3(0.0, 1.0, 0.0)), f - vec3(0.0, 1.0, 0.0));
+    float d = dot(hash3(i + vec3(1.0, 1.0, 0.0)), f - vec3(1.0, 1.0, 0.0));
+    float e = dot(hash3(i + vec3(0.0, 0.0, 1.0)), f - vec3(0.0, 0.0, 1.0));
+    float g = dot(hash3(i + vec3(1.0, 0.0, 1.0)), f - vec3(1.0, 0.0, 1.0));
+    float h = dot(hash3(i + vec3(0.0, 1.0, 1.0)), f - vec3(0.0, 1.0, 1.0));
+    float k = dot(hash3(i + vec3(1.0, 1.0, 1.0)), f - vec3(1.0, 1.0, 1.0));
+
+    return mix(
+        mix(mix(a, b, u.x), mix(c, d, u.x), u.y),
+        mix(mix(e, g, u.x), mix(h, k, u.x), u.y),
+        u.z
+    );
+}
+
+// ============================================================================
+// FBM — 3-4 octaves of noise for nebula density
+// ============================================================================
+
+float fbm(vec3 p, float detail) {
+    float value = 0.0;
+    float amp = 0.5;
+    float freq = 1.0;
+    float total = 0.0;
+
+    for (int i = 0; i < NOISE_OCTAVES; i++) {
+        // Last octave is modulated by FINE_DETAIL
+        float octaveAmp = (i == NOISE_OCTAVES - 1) ? amp * detail : amp;
+        value += octaveAmp * noise3d(p * freq);
+        total += octaveAmp;
+        freq *= 2.1;
+        amp *= 0.5;
+    }
+
+    return value / max(total, 0.001);
+}
+
+// ============================================================================
+// ROTATION MATRIX
+// ============================================================================
+
+mat3 rotY(float a) {
+    float ca = cos(a), sa = sin(a);
+    return mat3(ca, 0.0, sa, 0.0, 1.0, 0.0, -sa, 0.0, ca);
+}
+
+mat3 rotX(float a) {
+    float ca = cos(a), sa = sin(a);
+    return mat3(1.0, 0.0, 0.0, 0.0, ca, -sa, 0.0, sa, ca);
+}
+
+// ============================================================================
+// NEBULA DENSITY FIELD
+// ============================================================================
+
+float nebulaDensity(vec3 p, float turb, float detail) {
+    // Slow swirl distortion
+    float swirl = iTime * ROT_SPEED;
+    p.xz += vec2(sin(p.y * 0.3 + swirl), cos(p.y * 0.3 + swirl)) * 0.4;
+
+    // Structural warp from entropy
+    p += sin(p.yzx * 0.7 + iTime * 0.05) * STRUCTURE_WARP;
+
+    // Base density from fbm
+    float n = fbm(p * NEBULA_SCALE, detail);
+
+    // Add turbulence layer
+    n += turb * noise3d(p * 3.5 + iTime * 0.1) * 0.3;
+
+    // Add grit from roughness
+    n += GRIT * noise3d(p * 6.0 - iTime * 0.08) * 0.15;
+
+    // Nebula shape: spherical falloff with noise carving
+    float r = length(p);
+    float shell = smoothstep(3.5, 1.0, r);  // fade out at edges
+
+    // Inner cavity (slightly hollow center for depth layering)
+    float cavity = smoothstep(0.3, 0.8, r);
+
+    float density = n * shell * cavity;
+
+    // Density threshold from energy
+    density = smoothstep(DENSITY_THRESH, DENSITY_THRESH + 0.35, density);
+
+    return density;
+}
+
+// ============================================================================
+// BACKGROUND STARS
+// ============================================================================
+
+vec3 stars(vec2 uv) {
+    vec3 col = vec3(0.0);
+
+    // Hash-based star field
+    vec2 cell = floor(uv * 80.0);
+    vec2 cellUV = fract(uv * 80.0) - 0.5;
+
+    // Star probability from hash
+    float h = fract(sin(dot(cell, vec2(127.1, 311.7))) * 43758.5453);
+
+    if (h > 0.97) {
+        // Star position jitter within cell
+        vec2 starPos = vec2(
+            fract(sin(dot(cell, vec2(269.5, 183.3))) * 43758.5453) - 0.5,
+            fract(sin(dot(cell, vec2(113.5, 271.9))) * 43758.5453) - 0.5
+        );
+        float d = length(cellUV - starPos);
+
+        // Star brightness varies
+        float brightness = fract(sin(dot(cell, vec2(74.7, 246.1))) * 43758.5453);
+        brightness = 0.4 + brightness * 0.6;
+
+        // Twinkle
+        float twinkle = sin(iTime * 1.5 + h * 6.283) * 0.2 + 0.8;
+        brightness *= twinkle;
+
+        // Sharp point star
+        float star = smoothstep(0.08, 0.0, d) * brightness;
+
+        // Stars are at violet depth (farthest in chromadepth)
+        col = chromadepth(0.9 + h * 0.1) * star;
+    }
+
+    return col;
+}
+
+// ============================================================================
+// MAIN — VOLUME MARCH WITH FRONT-TO-BACK COMPOSITING
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    // Camera setup
+    float camAngle = iTime * 0.03 + DRIFT * 0.01;
+    vec3 ro = vec3(
+        sin(camAngle) * 4.5,
+        sin(iTime * 0.02) * 0.5,
+        cos(camAngle) * 4.5
+    );
+    vec3 target = vec3(0.0);
+    vec3 forward = normalize(target - ro);
+    vec3 right = normalize(cross(forward, vec3(0.0, 1.0, 0.0)));
+    vec3 up = cross(right, forward);
+
+    float fov = 1.6;
+    vec3 rd = normalize(uv.x * right + uv.y * up + fov * forward);
+
+    // Precompute audio-driven parameters (avoid per-step re-evaluation)
+    float turb = clamp(TURBULENCE, 0.1, 1.5);
+    float detail = clamp(FINE_DETAIL, 0.1, 1.0);
+    float beatPulse = BEAT_PULSE;
+    float colorTemp = COLOR_TEMP;
+    float midGlow = clamp(MID_GLOW, 0.2, 1.0);
+    float hueAccent = HUE_ACCENT;
+
+    // ---- FRONT-TO-BACK VOLUME MARCH ----
+    vec4 accum = vec4(0.0); // premultiplied RGBA
+    float travelDist = 0.0;
+
+    // Start marching from near the nebula (skip empty space)
+    float tNear = max(length(ro) - 4.0, 0.5);
+    travelDist = tNear;
+
+    for (int i = 0; i < MAX_STEPS; i++) {
+        if (accum.a > 0.95) break;
+        if (travelDist > MAX_DIST) break;
+
+        vec3 p = ro + rd * travelDist;
+
+        float density = nebulaDensity(p, turb, detail);
+
+        if (density > 0.01) {
+            // Depth mapping: how far into the march are we?
+            // Normalized march progress: 0 = front, 1 = back
+            float depthNorm = clamp((travelDist - tNear) / (MAX_DIST - tNear), 0.0, 1.0);
+
+            // Also use radial distance from nebula center for depth variation
+            float radialDepth = clamp(length(p) / 3.5, 0.0, 1.0);
+
+            // Combine march depth and radial depth
+            float chromaT = mix(depthNorm, radialDepth, 0.4);
+
+            // Add noise-based variation to depth for more visual interest
+            float depthNoise = noise3d(p * 1.5) * 0.1;
+            chromaT = clamp(chromaT + depthNoise + colorTemp, 0.0, 1.0);
+
+            // Add hue accent from pitch class
+            chromaT = clamp(chromaT + hueAccent, 0.0, 1.0);
+
+            // Chromadepth color at this depth
+            vec3 gasColor = chromadepth(chromaT);
+
+            // Mid-depth glow enhancement (green region pops with mids)
+            float midBand = smoothstep(0.25, 0.5, chromaT) * smoothstep(0.75, 0.5, chromaT);
+            gasColor *= 1.0 + midBand * midGlow * 0.4;
+
+            // Internal illumination: brighter in denser regions
+            float illumination = 0.6 + density * 0.5;
+            gasColor *= illumination;
+
+            // Beat pulse brightens all gas
+            gasColor *= beatPulse;
+
+            // Premultiplied alpha compositing (front-to-back)
+            float alpha = density * STEP_SIZE * 2.5;
+            alpha = min(alpha, 1.0);
+
+            // Front-to-back: C_out = C_in + (1 - A_in) * C_sample * A_sample
+            accum.rgb += (1.0 - accum.a) * gasColor * alpha;
+            accum.a += (1.0 - accum.a) * alpha;
+        }
+
+        travelDist += STEP_SIZE;
+    }
+
+    // ---- BACKGROUND: stars at maximum chromadepth depth ----
+    vec3 bg = stars(uv * 0.5 + 0.5);
+
+    // Composite nebula over background
+    vec3 col = accum.rgb + (1.0 - accum.a) * bg;
+
+    // ---- FEEDBACK: subtle trail from previous frame ----
+    vec3 prev = getLastFrameColor(screenUV).rgb;
+    col = mix(prev * 0.92, col, 0.75);
+
+    // Prevent feedback accumulation to white
+    col = min(col, vec3(1.0));
+
+    // ---- VIGNETTE (keeps edges dark for chromadepth) ----
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-phoenix.frag
+++ b/shaders/claude/chromadepth-phoenix.frag
@@ -1,0 +1,333 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, fractal, phoenix
+// ChromaDepth Phoenix Fractal
+// z_{n+1} = z_n^2 + c + p * z_{n-1}
+// The "inertia" parameter p creates asymmetric, flowing patterns like bird wings.
+// ChromaDepth: Red = closest, Green = mid, Blue/Violet = farthest, Black = neutral.
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// --- WANDERING JULIA CONSTANT c ---
+// Slowly drifts through interesting regions of c-space
+#define WANDER_SPEED (1.0 + spectralEntropyNormalized * 0.6)
+// #define WANDER_SPEED 1.0
+
+// --- PHOENIX INERTIA p: spectralFlux slope gated by rSquared ---
+// Steady spectral flux trends = confident inertia changes
+// spectralFluxZScore gives direction, gated by how linear the trend is
+#define P_INERTIA (spectralFluxZScore * 0.12 * smoothstep(0.2, 0.7, energyRSquared))
+// #define P_INERTIA 0.0
+
+// Base inertia offset (phoenix fractal needs nonzero p for interesting shapes)
+#define P_BASE 0.32
+// #define P_BASE 0.32
+
+// --- ZOOM: energy drives zoom ---
+#define ZOOM_MOD (energyZScore * 0.15)
+// #define ZOOM_MOD 0.0
+
+// --- ROTATION: pitchClass rotates view ---
+#define ROTATION_AUDIO (pitchClassNormalized * 0.4)
+// #define ROTATION_AUDIO 0.0
+
+// --- BEAT: triggers p-space jump ---
+#define BEAT_JUMP (beat ? 1.0 : 0.0)
+// #define BEAT_JUMP 0.0
+
+// --- DROP DETECTION ---
+#define DROP_INTENSITY (max(-energyZScore, 0.0))
+// #define DROP_INTENSITY 0.0
+
+// --- INSTANT REACTIVITY ---
+#define BASS_PUNCH (bassZScore)
+// #define BASS_PUNCH 0.0
+
+#define TREBLE_EDGE (max(trebleZScore, 0.0))
+// #define TREBLE_EDGE 0.0
+
+#define ENERGY_LEVEL (energyNormalized)
+// #define ENERGY_LEVEL 0.5
+
+#define MIDS_MOD (midsZScore)
+// #define MIDS_MOD 0.0
+
+// --- TREND CONFIDENCE ---
+#define CONFIDENCE (energyRSquared * 0.4 + bassRSquared * 0.3 + spectralCentroidRSquared * 0.3)
+// #define CONFIDENCE 0.5
+
+// --- SPECTRAL COLOR MODULATION ---
+#define ROUGHNESS_MOD (spectralRoughnessNormalized)
+// #define ROUGHNESS_MOD 0.5
+
+#define CENTROID_DRIFT (spectralCentroidSlope * 12.0 * spectralCentroidRSquared)
+// #define CENTROID_DRIFT 0.0
+
+// --- CONSTANTS ---
+#define MAX_ITER 64
+#define PHI 1.61803398875
+
+// ============================================================================
+// CHROMADEPTH: full spectrum red -> violet via smooth HSL
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    float t = iTime * 0.035 * clamp(WANDER_SPEED, 0.5, 2.0);
+
+    // --- WANDERING PATH through c-space ---
+    // The phoenix fractal has interesting structure around c ~ -0.5 + 0.0i
+    // with small p values, and around c ~ -1.0 with larger p
+    float cReal = -0.56 + 0.18 * sin(t * 0.8) + 0.1 * cos(t * PHI * 0.6);
+    float cImag = 0.0 + 0.15 * sin(t * 0.6 * PHI) + 0.08 * cos(t * 1.1);
+
+    // Regression-driven drift of c
+    float cDriftReal = bassSlope * 18.0 * bassRSquared;
+    float cDriftImag = CENTROID_DRIFT;
+    cReal += cDriftReal * 0.05;
+    cImag += cDriftImag * 0.04;
+
+    // Drop jolts c into different territory
+    float dropJolt = DROP_INTENSITY * (1.0 - CONFIDENCE) * 0.12;
+    cReal += sin(iTime * 3.1) * dropJolt;
+    cImag += cos(iTime * 2.7) * dropJolt;
+
+    cReal = clamp(cReal, -1.2, 0.3);
+    cImag = clamp(cImag, -0.7, 0.7);
+    vec2 c = vec2(cReal, cImag);
+
+    // --- PHOENIX INERTIA PARAMETER p ---
+    // This is what makes phoenix fractals unique: memory of previous iterate
+    float pReal = P_BASE + P_INERTIA;
+    float pImag = 0.02 * sin(t * 0.3) + MIDS_MOD * 0.02;
+
+    // Beat triggers a sudden jump in p-space (brief dramatic reshaping)
+    float beatPhase = fract(iTime * 0.7);
+    pReal += BEAT_JUMP * sin(beatPhase * 6.283) * 0.15;
+    pImag += BEAT_JUMP * cos(beatPhase * 6.283) * 0.08;
+
+    pReal = clamp(pReal, -0.6, 0.8);
+    pImag = clamp(pImag, -0.4, 0.4);
+    vec2 p = vec2(pReal, pImag);
+
+    // --- VIEW TRANSFORM ---
+    float zoom = 1.6 + 0.2 * sin(t * 0.4) + ZOOM_MOD;
+    zoom = max(zoom, 0.9);
+    zoom -= DROP_INTENSITY * 0.12;
+
+    float angle = iTime * 0.02 + ROTATION_AUDIO;
+    float ca = cos(angle), sa = sin(angle);
+    uv = mat2(ca, -sa, sa, ca) * uv;
+    uv *= zoom;
+
+    // --- PHOENIX FRACTAL ITERATION ---
+    // z_{n+1} = z_n^2 + c + p * z_{n-1}
+    vec2 z = uv;
+    vec2 zPrev = vec2(0.0);  // z_{n-1} starts at origin
+    float smoothIter = 0.0;
+    bool escaped = false;
+
+    // Orbit traps
+    float trapMin = 1e10;       // closest to origin
+    float trapLineX = 1e10;     // closest to x-axis
+    float trapLineY = 1e10;     // closest to y-axis
+    float trapCircle = 1e10;    // closest to unit circle
+    float trapWing = 1e10;      // wing-shaped trap (phoenix specific)
+    float orbitAngle = 0.0;
+    float orbitDist = 0.0;
+
+    // Store early orbit positions for feedback warping
+    vec2 z1 = z, z2 = z, z3 = z;
+
+    for (int i = 0; i < MAX_ITER; i++) {
+        // Phoenix iteration: z_{n+1} = z_n^2 + c + p * z_{n-1}
+        vec2 zSquared = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y);
+        vec2 pTerm = vec2(p.x * zPrev.x - p.y * zPrev.y,
+                          p.x * zPrev.y + p.y * zPrev.x);
+        vec2 zNext = zSquared + c + pTerm;
+
+        zPrev = z;
+        z = zNext;
+
+        float mag2 = dot(z, z);
+        float mag = sqrt(mag2);
+
+        // Store early orbit positions
+        if (i == 1) z1 = z;
+        if (i == 3) z2 = z;
+        if (i == 5) z3 = z;
+
+        // Orbit traps
+        trapMin = min(trapMin, mag);
+        trapLineX = min(trapLineX, abs(z.y));
+        trapLineY = min(trapLineY, abs(z.x));
+        trapCircle = min(trapCircle, abs(mag - 1.0));
+
+        // Wing trap: asymmetric distance to a parabolic curve
+        // Phoenix fractals have inherent asymmetry; this trap highlights it
+        float wingDist = abs(z.y - 0.3 * z.x * z.x);
+        trapWing = min(trapWing, wingDist);
+
+        orbitAngle += atan(z.y, z.x);
+        orbitDist += mag;
+
+        if (mag2 > 256.0) {
+            smoothIter = float(i) - log2(log2(mag2)) + 4.0;
+            escaped = true;
+            break;
+        }
+        smoothIter = float(i);
+    }
+
+    float iterNorm = smoothIter / float(MAX_ITER);
+
+    // --- DEPTH MAPPING ---
+    float depth;
+    float brightness = 1.0;
+
+    if (escaped) {
+        // EXTERIOR: smooth iteration -> depth
+        float logIter = log(1.0 + smoothIter) / log(1.0 + float(MAX_ITER));
+
+        // Near boundary (high iter) = cyan/blue, fast escape = violet/dark
+        depth = mix(0.5, 1.0, 1.0 - pow(logIter, 0.45));
+
+        brightness = mix(0.15, 0.85, pow(logIter, 0.5));
+    } else {
+        // INTERIOR: orbit traps for rich chromadepth structure
+
+        float tOrigin = clamp(trapMin * 1.5, 0.0, 1.0);
+        float tLine = clamp(min(trapLineX, trapLineY) * 3.0, 0.0, 1.0);
+        float tCircle = clamp(trapCircle * 2.0, 0.0, 1.0);
+        float tWing = clamp(trapWing * 2.5, 0.0, 1.0);
+
+        // Angular orbit accumulation - varies across interior
+        float tAngle = fract(orbitAngle * 0.07);
+        float tAngle2 = abs(sin(orbitAngle * 0.18));
+
+        // Orbit average distance
+        float tOrbit = clamp(orbitDist / float(MAX_ITER) * 0.4, 0.0, 1.0);
+
+        // Final z position for spatial variation
+        float zFinal = atan(z.y, z.x) / 6.283 + 0.5;
+        float zDist = clamp(length(z) * 0.5, 0.0, 1.0);
+
+        // Three independent depth signals:
+
+        // Signal A: geometric traps - edges and axes
+        float geoDepth = tLine * 0.5 + tWing * 0.5;
+
+        // Signal B: organic traps + attractor - spatial variation
+        float orgDepth = tOrigin * 0.3 + tCircle * 0.3 + zFinal * 0.4;
+
+        // Signal C: angular + orbit - fine texture
+        float texDepth = tAngle * 0.3 + tAngle2 * 0.25 + tOrbit * 0.2 + zDist * 0.25;
+
+        // Combine with contrast enhancement
+        float contrast = abs(geoDepth - orgDepth) + abs(texDepth - orgDepth) * 0.5;
+        float blend = geoDepth * 0.25 + orgDepth * 0.25 + texDepth * 0.3 + contrast * 0.2;
+
+        // S-curve for spread
+        blend = smoothstep(0.05, 0.95, blend);
+
+        // Interior depth: red (0.0) through cyan (0.55)
+        depth = blend * 0.55;
+
+        // Interior brightness with more variation
+        brightness = 0.4 + tAngle * 0.2 + (1.0 - tOrigin) * 0.2 + tWing * 0.1 + contrast * 0.1;
+    }
+
+    // --- DROP EFFECT on depth ---
+    depth = mix(depth, 0.0, DROP_INTENSITY * 0.45);
+
+    // --- CHROMADEPTH COLOR ---
+    vec3 col = chromadepth(depth);
+
+    // Brightness modulation
+    col *= brightness;
+    col *= 1.0 + BASS_PUNCH * 0.08;
+    col = clamp(col, 0.0, 1.0);
+
+    // Edge glow from treble on fractal boundaries
+    float edge = length(vec2(dFdx(depth), dFdy(depth)));
+    float edgeGlow = smoothstep(0.0, 0.05, edge) * TREBLE_EDGE * 0.25;
+    col += edgeGlow * vec3(1.0, 0.95, 0.85);
+
+    // --- FEEDBACK: previous frame through orbit-warped UV ---
+    // Orbit positions define where the fractal "connects", creating recursive detail
+
+    float fbStrength = escaped
+        ? 0.035 * pow(iterNorm, 0.3)
+        : 0.05 * (1.0 - trapMin * 0.5);
+
+    fbStrength *= 1.0 + DROP_INTENSITY * 1.8;
+    fbStrength += BEAT_JUMP * 0.015;
+
+    // Use orbit positions z1, z2 to warp feedback UV
+    vec2 orbitWarp = vec2(
+        z1.x * 0.018 + z2.y * 0.008,
+        z1.y * 0.018 - z2.x * 0.008
+    ) * fbStrength;
+
+    // Slow rotation prevents static feedback loops
+    float fbAngle = iTime * 0.008;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotatedUV = vec2(centered.x * fbc - centered.y * fbs,
+                          centered.x * fbs + centered.y * fbc) + 0.5;
+
+    vec2 fbUV = clamp(rotatedUV + orbitWarp, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    // --- OKLAB BLENDING for perceptually uniform feedback ---
+    vec3 colOk = rgb2oklab(col);
+    vec3 prevOk = rgb2oklab(prev);
+
+    // Decay previous frame to prevent accumulation/white-out
+    prevOk.x *= 0.97;
+    prevOk.yz *= 0.99;
+
+    // New frame dominates - we want sharp fractal detail
+    float newAmount = 0.72;
+    newAmount += DROP_INTENSITY * 0.12;
+    newAmount -= CONFIDENCE * 0.08;
+    newAmount = clamp(newAmount, 0.55, 0.9);
+
+    vec3 blended = mix(prevOk, colOk, newAmount);
+
+    // Inject fresh chroma to prevent color death
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.7) {
+        blended.yz = mix(blended.yz, colOk.yz, 0.3);
+    }
+
+    col = oklab2rgb(blended);
+
+    // --- BEAT FLASH ---
+    col *= 1.0 + BEAT_JUMP * 0.12;
+    col = mix(col, col * vec3(1.3, 0.8, 0.7), DROP_INTENSITY * 0.2);
+
+    // --- VIGNETTE ---
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.75;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-plasma.frag
+++ b/shaders/claude/chromadepth-plasma.frag
@@ -1,0 +1,265 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, plasma, fractal
+// ChromaDepth Plasma Fractal — Multi-octave sine plasma with fractal depth layering
+// Low-frequency waves = red/close, high-frequency detail = blue/far
+// Each octave driven by a different audio domain for rich independent reactivity
+// Designed for ChromaDepth 3D glasses: Red = closest, Green = mid, Blue/Violet = farthest
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (swap constants for audio uniforms)
+// ============================================================================
+
+// --- OCTAVE 1: Bass — large red waves (closest) ---
+#define BASS_DRIVE (bassZScore * 0.4)
+// #define BASS_DRIVE 0.0
+
+#define BASS_AMPLITUDE (0.8 + bassNormalized * 0.4)
+// #define BASS_AMPLITUDE 1.0
+
+// --- OCTAVE 2: Mids — green medium waves (mid depth) ---
+#define MIDS_DRIVE (midsZScore * 0.3)
+// #define MIDS_DRIVE 0.0
+
+#define MIDS_AMPLITUDE (0.5 + energyNormalized * 0.3)
+// #define MIDS_AMPLITUDE 0.6
+
+// --- OCTAVE 3: Treble — cyan fine detail (far) ---
+#define TREBLE_DRIVE (trebleZScore * 0.25)
+// #define TREBLE_DRIVE 0.0
+
+#define TREBLE_AMPLITUDE (0.3 + trebleNormalized * 0.3)
+// #define TREBLE_AMPLITUDE 0.4
+
+// --- OCTAVE 4: Entropy — violet ultra-fine (farthest) ---
+#define ENTROPY_DRIVE (spectralCentroidZScore * 0.2)
+// #define ENTROPY_DRIVE 0.0
+
+#define ENTROPY_AMPLITUDE (0.2 + spectralEntropyNormalized * 0.25)
+// #define ENTROPY_AMPLITUDE 0.3
+
+// --- DOMAIN WARP: spectral flux warps UV space ---
+#define WARP_STRENGTH (0.15 + spectralFluxZScore * 0.08)
+// #define WARP_STRENGTH 0.15
+
+// --- OVERALL CONTRAST: energy drives contrast enhancement ---
+#define CONTRAST_BOOST (1.0 + energyZScore * 0.15)
+// #define CONTRAST_BOOST 1.0
+
+// --- FEEDBACK: frame persistence ---
+#define FEEDBACK_MIX (0.3 + energyNormalized * 0.1)
+// #define FEEDBACK_MIX 0.35
+
+// --- BEAT PULSE: brightness surge on beat ---
+#define BEAT_SURGE (beat ? 1.25 : 1.0)
+// #define BEAT_SURGE 1.0
+
+// --- TREND-BASED DRIFT: regression slopes drive slow evolution ---
+#define DRIFT_X (bassSlope * 15.0 * bassRSquared)
+// #define DRIFT_X 0.0
+
+#define DRIFT_Y (energySlope * 12.0 * energyRSquared)
+// #define DRIFT_Y 0.0
+
+// --- PITCH-BASED HUE SHIFT ---
+#define HUE_NUDGE (pitchClassNormalized * 0.06)
+// #define HUE_NUDGE 0.0
+
+// --- ROUGHNESS drives domain warp turbulence ---
+#define ROUGHNESS_TURB (spectralRoughnessNormalized * 0.12)
+// #define ROUGHNESS_TURB 0.06
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// PLASMA OCTAVES — each octave is a different spatial frequency
+// ============================================================================
+
+// Octave 1: large slow-moving sine waves (bass domain)
+float octave1(vec2 p, float time) {
+    float t = time * 0.15 + BASS_DRIVE;
+    float v = sin(p.x * 1.2 + t * 1.1);
+    v += sin(p.y * 1.0 - t * 0.9);
+    v += sin((p.x + p.y) * 0.7 + t * 0.7);
+    v += sin(length(p + vec2(sin(t * 0.3), cos(t * 0.4))) * 1.5);
+    return v * 0.25 * BASS_AMPLITUDE;
+}
+
+// Octave 2: medium frequency (mids domain)
+float octave2(vec2 p, float time) {
+    float t = time * 0.25 + MIDS_DRIVE;
+    float v = sin(p.x * 3.1 - t * 1.3);
+    v += sin(p.y * 2.8 + t * 1.1);
+    v += sin((p.x - p.y) * 2.5 + t * 0.8);
+    v += sin(length(p * 1.5 - vec2(cos(t * 0.5), sin(t * 0.6))) * 2.2);
+    return v * 0.25 * MIDS_AMPLITUDE;
+}
+
+// Octave 3: fine detail (treble domain)
+float octave3(vec2 p, float time) {
+    float t = time * 0.35 + TREBLE_DRIVE;
+    float v = sin(p.x * 6.3 + t * 1.7);
+    v += sin(p.y * 5.7 - t * 1.5);
+    v += sin((p.x + p.y * 1.3) * 5.0 - t * 1.2);
+    v += sin(length(p * 3.0 + vec2(sin(t * 0.7), cos(t * 0.8))) * 4.5);
+    return v * 0.25 * TREBLE_AMPLITUDE;
+}
+
+// Octave 4: ultra-fine detail (entropy domain)
+float octave4(vec2 p, float time) {
+    float t = time * 0.45 + ENTROPY_DRIVE;
+    float v = sin(p.x * 12.0 - t * 2.1);
+    v += sin(p.y * 11.0 + t * 1.9);
+    v += sin((p.x * 1.1 - p.y) * 10.0 + t * 1.6);
+    v += sin(length(p * 5.5 - vec2(cos(t * 0.9), sin(t * 1.1))) * 8.0);
+    return v * 0.25 * ENTROPY_AMPLITUDE;
+}
+
+// ============================================================================
+// DOMAIN WARP — distorts UV coordinates for organic flow
+// ============================================================================
+
+vec2 domainWarp(vec2 p, float time) {
+    float t = time * 0.1;
+    float strength = WARP_STRENGTH + ROUGHNESS_TURB;
+
+    // Two-pass warp for richer distortion
+    float wx = sin(p.y * 2.3 + t * 1.1) + sin(p.x * 1.7 - t * 0.8) * 0.7;
+    float wy = sin(p.x * 2.1 - t * 0.9) + sin(p.y * 1.9 + t * 1.2) * 0.7;
+
+    vec2 warped = p + vec2(wx, wy) * strength;
+
+    // Second pass with different frequencies
+    float wx2 = sin(warped.y * 3.5 + t * 1.5) * 0.4;
+    float wy2 = sin(warped.x * 3.2 - t * 1.3) * 0.4;
+
+    return warped + vec2(wx2, wy2) * strength * 0.5;
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    // Centered UV with aspect ratio correction
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    float time = iTime;
+
+    // Apply trend-based drift for slow evolution
+    vec2 drift = vec2(DRIFT_X, DRIFT_Y) * 0.02;
+    uv += drift;
+
+    // Domain warp the coordinates for organic plasma flow
+    vec2 wp = domainWarp(uv, time);
+
+    // --- COMPUTE ALL FOUR OCTAVES ---
+    float o1 = octave1(wp, time);           // large features (bass)
+    float o2 = octave2(wp, time);           // medium features (mids)
+    float o3 = octave3(wp, time);           // fine features (treble)
+    float o4 = octave4(wp, time);           // ultra-fine (entropy)
+
+    // --- DETERMINE DOMINANT OCTAVE FOR DEPTH ---
+    // The octave with the strongest absolute contribution at each pixel
+    // determines the chromadepth color (depth layer).
+    //
+    // Depth mapping:
+    //   Octave 1 dominant → depth ~0.0  (red, closest)
+    //   Octave 2 dominant → depth ~0.33 (green, mid)
+    //   Octave 3 dominant → depth ~0.60 (cyan, far)
+    //   Octave 4 dominant → depth ~0.85 (violet, farthest)
+
+    float a1 = abs(o1);
+    float a2 = abs(o2);
+    float a3 = abs(o3);
+    float a4 = abs(o4);
+
+    // Soft maximum: weighted blend based on relative strength
+    // This gives smooth depth transitions instead of hard octave boundaries
+    float total = a1 + a2 + a3 + a4 + 0.001;  // avoid division by zero
+    float w1 = a1 / total;
+    float w2 = a2 / total;
+    float w3 = a3 / total;
+    float w4 = a4 / total;
+
+    // Square the weights for sharper octave dominance (more distinct depth layers)
+    w1 *= w1;
+    w2 *= w2;
+    w3 *= w3;
+    w4 *= w4;
+    float wSum = w1 + w2 + w3 + w4 + 0.001;
+    w1 /= wSum;
+    w2 /= wSum;
+    w3 /= wSum;
+    w4 /= wSum;
+
+    float depth = w1 * 0.0 + w2 * 0.33 + w3 * 0.60 + w4 * 0.85;
+
+    // --- PLASMA INTENSITY ---
+    // Combined value from all octaves gives brightness variation
+    float plasma = o1 + o2 + o3 + o4;
+
+    // Contrast enhancement driven by energy
+    float contrast = CONTRAST_BOOST;
+    plasma *= contrast;
+
+    // Map plasma value to brightness (keep it positive, avoid white-out)
+    float brightness = 0.4 + 0.35 * sin(plasma * 3.14159);
+    brightness = clamp(brightness, 0.15, 0.85);
+
+    // Use plasma phase to subtly shift depth for extra variety
+    float depthShift = sin(plasma * 2.0) * 0.08;
+    depth = clamp(depth + depthShift + HUE_NUDGE, 0.0, 1.0);
+
+    // --- CHROMADEPTH COLOR ---
+    vec3 col = chromadepth(depth);
+    col *= brightness;
+
+    // --- BEAT SURGE ---
+    col *= BEAT_SURGE;
+
+    // --- FRAME FEEDBACK for plasma persistence ---
+    // Sample previous frame with slight UV offset for flowing trails
+    float fbAngle = time * 0.02;
+    float fbc = cos(fbAngle);
+    float fbs = sin(fbAngle);
+    vec2 centered = screenUV - 0.5;
+    vec2 fbUV = vec2(
+        centered.x * fbc - centered.y * fbs,
+        centered.x * fbs + centered.y * fbc
+    ) * 0.998 + 0.5;  // slight zoom-in to prevent edge artifacts
+
+    // Add plasma-based warp to feedback for organic trails
+    fbUV += vec2(sin(plasma * 1.5), cos(plasma * 1.3)) * 0.003;
+    fbUV = clamp(fbUV, 0.0, 1.0);
+
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    // Decay previous frame to prevent accumulation
+    prev *= 0.96;
+
+    // Blend current and previous
+    float fbMix = clamp(FEEDBACK_MIX, 0.1, 0.5);
+    col = mix(col, prev, fbMix);
+
+    // --- VIGNETTE (keeps edges dark for clean chromadepth) ---
+    vec2 vc = screenUV - 0.5;
+    float vignette = 1.0 - dot(vc, vc) * 0.7;
+    col *= vignette;
+
+    // Final clamp to prevent any white-out
+    col = clamp(col, 0.0, 1.0);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-reaction-diffusion.frag
+++ b/shaders/claude/chromadepth-reaction-diffusion.frag
@@ -1,0 +1,241 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, reaction-diffusion, organic
+// ChromaDepth Reaction-Diffusion -- Gray-Scott model via frame feedback
+// Chemical concentrations encoded in chromadepth color: U in hue (invertible),
+// V in lightness deviation. The display IS the chromadepth visualization.
+// Active spots (low U) = red/near, background (high U) = blue/far.
+// Audio: bass -> feed rate, spectralEntropy -> kill rate (pattern morphology),
+// energy -> diffusion, beats seed new spots, spectralCentroid -> diffusion balance.
+//
+// ChromaDepth: Red = closest, Green = mid, Blue/Violet = farthest, Black = neutral
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// --- FEED RATE: bass creates/destroys spots ---
+#define FEED_MOD (bassZScore * 0.006)
+// #define FEED_MOD 0.0
+
+// --- KILL RATE: spectralEntropy selects pattern type ---
+// Low entropy = spots, mid = stripes, high = labyrinthine
+#define KILL_MOD (spectralEntropyNormalized * 0.01 - 0.005)
+// #define KILL_MOD 0.0
+
+// --- DIFFUSION: energy controls diffusion rates ---
+#define DIFF_ENERGY (energyNormalized * 0.1)
+// #define DIFF_ENERGY 0.05
+
+// --- DIFFUSION BALANCE: spectralCentroid shifts Du/Dv ratio ---
+#define DIFF_BALANCE (spectralCentroidZScore * 0.015)
+// #define DIFF_BALANCE 0.0
+
+// --- BEAT: seeds new spots ---
+#define BEAT_SEED (beat ? 1.0 : 0.0)
+// #define BEAT_SEED 0.0
+
+// --- DROP DETECTION ---
+#define DROP_INTENSITY (max(-energyZScore, 0.0))
+// #define DROP_INTENSITY 0.0
+
+// --- VISUAL MODULATION ---
+#define BASS_PUNCH (bassZScore)
+// #define BASS_PUNCH 0.0
+
+#define PITCH_HUE (pitchClassNormalized)
+// #define PITCH_HUE 0.0
+
+#define FLUX_SPEED (spectralFluxZScore)
+// #define FLUX_SPEED 0.0
+
+// --- TREND-BASED ---
+#define ENERGY_TREND (energySlope * 10.0 * energyRSquared)
+// #define ENERGY_TREND 0.0
+
+#define BASS_TREND (bassSlope * 10.0 * bassRSquared)
+// #define BASS_TREND 0.0
+
+#define MIDS_MOD (midsZScore * 0.003)
+// #define MIDS_MOD 0.0
+
+// ============================================================================
+// CHROMADEPTH + STATE ENCODING
+// ============================================================================
+
+// The chromadepth function maps depth 0-1 to hue 0-0.82.
+// We use this as a reversible encoding: U -> hue, V -> lightness boost.
+// The resulting color IS the chromadepth visualization AND stores state.
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// Encode U,V into chromadepth-compatible HSL color
+// U -> hue (depth), V -> lightness boost above baseline
+vec3 encodeHSL(float U, float V) {
+    float depth = clamp(U, 0.0, 1.0);
+    float hue = depth * 0.82;
+    float sat = 0.95 - depth * 0.1;
+    float baseLit = 0.42 - depth * 0.12;
+    float lit = baseLit + V * 0.45;
+    return vec3(hue, sat, clamp(lit, 0.05, 0.95));
+}
+
+// Decode U,V from HSL
+vec2 decodeHSL(vec3 hsl) {
+    float U = clamp(hsl.x / 0.82, 0.0, 1.0);
+    float baseLit = 0.42 - U * 0.12;
+    float V = clamp((hsl.z - baseLit) / 0.45, 0.0, 1.0);
+    return vec2(U, V);
+}
+
+// Read U,V from previous frame pixel
+vec2 readConc(vec2 uv) {
+    vec3 rgb = getLastFrameColor(clamp(uv, 0.0, 1.0)).rgb;
+    vec3 hsl = rgb2hsl(rgb);
+    return decodeHSL(hsl);
+}
+
+// 5-point Laplacian (mobile-friendly)
+vec2 laplacian5(vec2 uv, vec2 px) {
+    vec2 c = readConc(uv);
+    vec2 sum = -4.0 * c;
+    sum += readConc(uv + vec2(px.x, 0.0));
+    sum += readConc(uv + vec2(-px.x, 0.0));
+    sum += readConc(uv + vec2(0.0, px.y));
+    sum += readConc(uv + vec2(0.0, -px.y));
+    return sum;
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec2 px = 1.0 / iResolution.xy;
+
+    // --- GRAY-SCOTT PARAMETERS ---
+    float f = 0.037 + FEED_MOD + BASS_TREND * 0.001 + MIDS_MOD;
+    float k = 0.06 + KILL_MOD + ENERGY_TREND * 0.0008;
+    f = clamp(f, 0.015, 0.07);
+    k = clamp(k, 0.045, 0.072);
+
+    // Diffusion rates: Du > Dv required for Turing instability
+    float Du = 0.21 + DIFF_ENERGY * 0.08 + DIFF_BALANCE * 0.4;
+    float Dv = 0.105 + DIFF_ENERGY * 0.04 - DIFF_BALANCE * 0.2;
+    Du = clamp(Du, 0.15, 0.32);
+    Dv = clamp(Dv, 0.06, 0.16);
+
+    // --- READ CURRENT STATE ---
+    vec2 conc = readConc(screenUV);
+    float U = conc.x;
+    float V = conc.y;
+
+    // --- INITIALIZATION ---
+    if (iFrame < 5) {
+        U = 1.0;
+        V = 0.0;
+
+        vec2 center = screenUV - 0.5;
+
+        // Central seed
+        if (length(center) < 0.07) {
+            U = 0.5;
+            V = 0.25;
+        }
+
+        // Ring of seeds
+        for (float a = 0.0; a < 6.28; a += 0.785) {
+            vec2 seedPos = vec2(cos(a), sin(a)) * 0.22;
+            if (length(center - seedPos) < 0.035) {
+                U = 0.5;
+                V = 0.25;
+            }
+        }
+
+        // Random seeds
+        float r = staticRandom(floor(screenUV * 25.0));
+        if (r > 0.92) {
+            float r2 = staticRandom(floor(screenUV * 25.0) + 100.0);
+            if (r2 > 0.5) {
+                U = 0.5;
+                V = 0.25;
+            }
+        }
+
+        vec3 hsl = encodeHSL(U, V);
+        fragColor = vec4(hsl2rgb(hsl), 1.0);
+        return;
+    }
+
+    // --- GRAY-SCOTT LAPLACIAN + UPDATE ---
+    vec2 lap = laplacian5(screenUV, px);
+
+    float uvv = U * V * V;
+    float dU = Du * lap.x - uvv + f * (1.0 - U);
+    float dV = Dv * lap.y + uvv - (f + k) * V;
+
+    U += dU;
+    V += dV;
+
+    // --- BEAT SEEDING ---
+    if (BEAT_SEED > 0.5) {
+        float r = random(screenUV * 80.0 + iTime);
+        float gridR = random(floor(screenUV * 20.0) + iTime * 0.1);
+        if (r > 0.995 && gridR > 0.6) {
+            U = 0.5;
+            V = 0.25;
+        }
+    }
+
+    // --- DROP: chemical disruption ---
+    if (DROP_INTENSITY > 0.3) {
+        float dropR = random(screenUV * 40.0 + iTime * 0.5);
+        float dropStrength = (DROP_INTENSITY - 0.3) * 1.43;
+        if (dropR > 1.0 - dropStrength * 0.03) {
+            U = mix(U, 0.5, dropStrength * 0.4);
+            V = mix(V, 0.25, dropStrength * 0.4);
+        }
+    }
+
+    // --- FLUX SEEDING ---
+    if (FLUX_SPEED > 0.4) {
+        float fluxR = random(screenUV * 60.0 - iTime);
+        if (fluxR > 0.998) {
+            V = min(V + 0.05, 1.0);
+        }
+    }
+
+    U = clamp(U, 0.0, 1.0);
+    V = clamp(V, 0.0, 1.0);
+
+    // --- ENCODE STATE AS CHROMADEPTH COLOR ---
+    vec3 hsl = encodeHSL(U, V);
+
+    // --- AUDIO VISUAL MODULATION ---
+    // NOTE: All modulation must be very subtle because the output color
+    // IS the simulation state. Any visual change feeds back into the
+    // decode on the next frame. We keep modulations tiny so the decode
+    // error is negligible relative to the Gray-Scott dynamics.
+
+    // Pitch class micro-shifts hue (U error: ~0.01)
+    hsl.x += PITCH_HUE * 0.008;
+
+    // Bass punch: tiny saturation boost for near colors
+    hsl.y += BASS_PUNCH * 0.015 * (1.0 - U);
+
+    hsl.x = mod(hsl.x + 1.0, 1.0);
+    hsl.y = clamp(hsl.y, 0.0, 1.0);
+    hsl.z = clamp(hsl.z, 0.05, 0.95);
+
+    vec3 col = hsl2rgb(hsl);
+    col = clamp(col, 0.0, 1.0);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-sierpinski.frag
+++ b/shaders/claude/chromadepth-sierpinski.frag
@@ -1,0 +1,343 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, fractal, sierpinski, raymarching
+// ChromaDepth 3D Sierpinski Tetrahedron - IFS fractal with cel-shading
+// Red = nearest, Green = mid, Blue/Violet = farthest, Black = neutral
+// Designed for ChromaDepth 3D glasses
+
+#define MAX_STEPS 40
+#define MAX_DIST 20.0
+#define SURF_DIST 0.002
+#define NORMAL_EPS 0.003
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// Fold parameter modulation: bass morphs the fractal structure
+#define FOLD_MOD (bassZScore * 0.08)
+// #define FOLD_MOD 0.0
+
+// Rotation speed: spectral centroid drives orbit speed
+#define ROT_SPEED (0.15 + spectralCentroidZScore * 0.06)
+// #define ROT_SPEED 0.15
+
+// Scale breathing: energy makes the fractal breathe in/out
+#define SCALE_BREATHE (1.0 + energyZScore * 0.06)
+// #define SCALE_BREATHE 1.0
+
+// Beat zoom punch: brief camera push on beat
+#define BEAT_PUNCH (beat ? 0.4 : 0.0)
+// #define BEAT_PUNCH 0.0
+
+// Treble edge glow: treble highlights fractal edges
+#define TREBLE_GLOW (max(trebleZScore, 0.0) * 0.25)
+// #define TREBLE_GLOW 0.0
+
+// Bass brightness throb
+#define BASS_BRIGHT (0.95 + bassNormalized * 0.1)
+// #define BASS_BRIGHT 1.0
+
+// Pitch class hue offset for chromadepth variation
+#define HUE_OFFSET (pitchClassNormalized * 0.04)
+// #define HUE_OFFSET 0.0
+
+// Spectral entropy adds jitter to fold offset (chaos → more organic)
+#define FOLD_JITTER (spectralEntropyNormalized * 0.03)
+// #define FOLD_JITTER 0.0
+
+// Energy trend: confident builds push camera closer
+#define ENERGY_TREND (energySlope * 10.0 * energyRSquared)
+// #define ENERGY_TREND 0.0
+
+// Mids modulate vertical camera drift
+#define VERT_DRIFT (midsZScore * 0.08)
+// #define VERT_DRIFT 0.0
+
+// Spectral flux drives fractal rotation wobble
+#define FLUX_WOBBLE (spectralFluxZScore * 0.04)
+// #define FLUX_WOBBLE 0.0
+
+// Roughness modulates cel-shading threshold
+#define CEL_SHIFT (spectralRoughnessNormalized * 0.1)
+// #define CEL_SHIFT 0.0
+
+// Bass slope for trend-aware fold animation
+#define BASS_TREND (bassSlope * 15.0 * bassRSquared)
+// #define BASS_TREND 0.0
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float depth) {
+    float t = clamp(depth, 0.0, 1.0);
+    float hue = t * 0.82; // red through violet
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// ROTATION MATRICES
+// ============================================================================
+
+mat2 rot2(float a) {
+    float c = cos(a), s = sin(a);
+    return mat2(c, -s, s, c);
+}
+
+// ============================================================================
+// SIERPINSKI TETRAHEDRON SDF (IFS folding)
+// ============================================================================
+
+// Tetrahedron vertices (regular tetrahedron centered at origin)
+const vec3 V0 = vec3(1.0, 1.0, 1.0);
+const vec3 V1 = vec3(1.0, -1.0, -1.0);
+const vec3 V2 = vec3(-1.0, 1.0, -1.0);
+const vec3 V3 = vec3(-1.0, -1.0, 1.0);
+
+// Returns: x = distance, y = fold count (for material)
+vec2 sierpinskiSDF(vec3 p) {
+    // Audio-modulated scale factor
+    float scale = 2.0 * SCALE_BREATHE;
+
+    // Fold offset modulated by bass
+    float foldOff = FOLD_MOD + FOLD_JITTER;
+
+    // Slow rotation of the fractal itself
+    float rotAngle = iTime * 0.08 + FLUX_WOBBLE;
+    p.xz *= rot2(rotAngle);
+    p.yz *= rot2(rotAngle * 0.7 + BASS_TREND * 0.02);
+
+    float foldCount = 0.0;
+
+    // IFS iteration: fold toward nearest vertex, scale, translate
+    for (int i = 0; i < 8; i++) {
+        // Fold across the planes between tetrahedron vertices
+        // Each fold reflects p toward the nearest vertex
+
+        // Fold 1: reflect across plane between V0 and V1
+        if (p.x + p.y < foldOff) p.xy = vec2(p.y, p.x) - foldOff * 0.5;
+
+        // Fold 2: reflect across plane between V0 and V2
+        if (p.x + p.z < foldOff) p.xz = vec2(p.z, p.x) - foldOff * 0.5;
+
+        // Fold 3: reflect across plane between V0 and V3
+        if (p.y + p.z < foldOff) p.yz = vec2(p.z, p.y) - foldOff * 0.5;
+
+        // Scale and translate (IFS contraction)
+        p = p * scale - (scale - 1.0);
+
+        foldCount += 1.0;
+    }
+
+    // Distance estimate: tetrahedron at final scale
+    // Use a simple tetrahedron distance at the iterated point
+    float d = (length(p) - 1.5) * pow(scale, -8.0);
+
+    return vec2(d, foldCount);
+}
+
+// ============================================================================
+// CHEAP AO (2-sample)
+// ============================================================================
+
+float cheapAO(vec3 p, vec3 n) {
+    float d1 = sierpinskiSDF(p + n * 0.08).x;
+    float d2 = sierpinskiSDF(p + n * 0.25).x;
+    return clamp(0.5 + (d1 + d2) * 3.0, 0.0, 1.0);
+}
+
+// ============================================================================
+// NORMAL CALCULATION
+// ============================================================================
+
+vec3 getNormal(vec3 p) {
+    vec2 e = vec2(NORMAL_EPS, 0.0);
+    return normalize(vec3(
+        sierpinskiSDF(p + e.xyy).x - sierpinskiSDF(p - e.xyy).x,
+        sierpinskiSDF(p + e.yxy).x - sierpinskiSDF(p - e.yxy).x,
+        sierpinskiSDF(p + e.yyx).x - sierpinskiSDF(p - e.yyx).x
+    ));
+}
+
+// ============================================================================
+// CEL SHADING (3-band quantization)
+// ============================================================================
+
+float celShade(float d) {
+    float shift = CEL_SHIFT;
+    if (d > 0.6 + shift) return 1.0;
+    if (d > 0.3 + shift * 0.5) return 0.65;
+    return 0.35;
+}
+
+// ============================================================================
+// RAYMARCHING
+// ============================================================================
+
+// Returns: x = distance traveled, y = fold count at hit
+vec3 raymarch(vec3 ro, vec3 rd) {
+    float t = 0.0;
+
+    for (int i = 0; i < MAX_STEPS; i++) {
+        vec3 p = ro + rd * t;
+        vec2 h = sierpinskiSDF(p);
+
+        if (h.x < SURF_DIST) {
+            return vec3(t, h.y, 1.0); // hit: distance, foldCount, hitFlag
+        }
+        if (t > MAX_DIST) break;
+
+        t += h.x * 0.85; // slight understepping for safety
+    }
+
+    return vec3(MAX_DIST, 0.0, 0.0); // miss
+}
+
+// ============================================================================
+// HASH (for dithering)
+// ============================================================================
+
+float hash(float n) {
+    return fract(sin(n) * 43758.5453);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    // ---- CAMERA ----
+    // Slow orbit around the fractal
+    float camAngle = iTime * ROT_SPEED;
+    float camHeight = 1.2 + sin(iTime * 0.09) * 0.5 + VERT_DRIFT;
+    float camRadius = 4.5 - ENERGY_TREND * 0.15;
+
+    // Beat punch: briefly push camera closer
+    camRadius -= BEAT_PUNCH;
+    camRadius = max(camRadius, 2.5); // don't clip into fractal
+
+    vec3 ro = vec3(
+        sin(camAngle) * camRadius,
+        camHeight,
+        cos(camAngle) * camRadius
+    );
+
+    vec3 lookAt = vec3(0.0, 0.2, 0.0);
+    vec3 forward = normalize(lookAt - ro);
+    vec3 right = normalize(cross(vec3(0.0, 1.0, 0.0), forward));
+    vec3 up = cross(forward, right);
+
+    // FOV with subtle energy breathing
+    float fov = 1.6 - energyNormalized * 0.08;
+    vec3 rd = normalize(uv.x * right + uv.y * up + fov * forward);
+
+    // ---- RAYMARCH ----
+    vec3 result = raymarch(ro, rd);
+    float dist = result.x;
+    float foldCount = result.y;
+    float hit = result.z;
+
+    // ---- BACKGROUND ----
+    // Dark gradient sky for chromadepth (farthest = deep violet/black)
+    float skyGrad = clamp(rd.y * 0.5 + 0.5, 0.0, 1.0);
+    vec3 skyCol = chromadepth(0.9 + skyGrad * 0.1); // deep blue-violet
+    skyCol *= mix(0.12, 0.04, skyGrad); // very dark
+
+    vec3 col = skyCol;
+
+    if (hit > 0.5) {
+        vec3 p = ro + rd * dist;
+        vec3 n = getNormal(p);
+
+        // ---- LIGHTING ----
+        vec3 lightDir = normalize(vec3(0.6, 0.9, 0.4));
+        vec3 fillDir = normalize(vec3(-0.3, 0.2, -0.6));
+
+        float diff = max(dot(n, lightDir), 0.0);
+        float fill = max(dot(n, fillDir), 0.0) * 0.25;
+        float cel = celShade(diff + fill);
+
+        // Ambient occlusion
+        float ao = cheapAO(p, n);
+
+        // Rim lighting for anime/toon pop
+        float rim = pow(1.0 - max(dot(n, -rd), 0.0), 3.0);
+        float rimMask = smoothstep(0.0, 0.4, dot(n, lightDir) + 0.3);
+        float rimLight = rim * rimMask * 0.3;
+
+        // Outline edge detection
+        float edge = 1.0 - max(dot(n, -rd), 0.0);
+        float outline = smoothstep(0.6, 0.75, edge);
+
+        // ---- CHROMADEPTH COLOR from ray distance ----
+        // Map distance: near (2.5) = red (0.0), far (MAX_DIST) = violet (1.0)
+        float depthT = clamp((dist - 2.0) / (MAX_DIST * 0.6), 0.0, 1.0);
+
+        // Add fold count as subtle depth variation within similar distances
+        float foldVariation = foldCount / 8.0 * 0.06;
+        depthT = clamp(depthT + foldVariation, 0.0, 1.0);
+
+        // Apply hue offset from audio
+        vec3 baseCol = chromadepth(depthT);
+
+        // Apply hue shift from pitchClass
+        vec3 hslCol = rgb2hsl(baseCol);
+        hslCol.x = fract(hslCol.x + HUE_OFFSET);
+
+        // Apply cel-shaded lightness
+        float lightness = hslCol.z * (0.4 + cel * 0.6);
+        lightness *= ao;
+        hslCol.z = clamp(lightness, 0.04, 0.58);
+
+        col = hsl2rgb(hslCol);
+
+        // Apply rim light
+        col += col * rimLight;
+
+        // Apply treble edge glow
+        float edgeGlow = smoothstep(0.0, 0.08, length(vec2(dFdx(depthT), dFdy(depthT))));
+        col += edgeGlow * TREBLE_GLOW * vec3(1.0, 0.95, 0.85);
+
+        // Apply outline darkening for cel look
+        col *= (1.0 - outline * 0.7);
+
+        // Bass brightness throb
+        col *= BASS_BRIGHT;
+
+        // Beat flash
+        if (beat) {
+            col *= 1.15;
+        }
+
+        // Depth fog toward background
+        float fog = exp(-dist * 0.08);
+        col = mix(skyCol, col, fog);
+    }
+
+    // ---- VIGNETTE ----
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    // ---- FRAME FEEDBACK (subtle motion trail) ----
+    vec4 prev = getLastFrameColor(screenUV);
+    col = mix(prev.rgb * 0.96, col, 0.8);
+
+    // ---- ENSURE SATURATION for chromadepth ----
+    vec3 finalHSL = rgb2hsl(col);
+    finalHSL.y = min(finalHSL.y * 1.1, 1.0);
+    finalHSL.z = clamp(finalHSL.z, 0.03, 0.58);
+    col = hsl2rgb(finalHSL);
+
+    // ---- DITHER to reduce banding ----
+    float dither = (hash(dot(fragCoord, vec2(12.9898, 78.233)) + iTime) - 0.5) / 255.0;
+    col += dither;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-spirograph.frag
+++ b/shaders/claude/chromadepth-spirograph.frag
@@ -1,0 +1,236 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, spirograph, geometric
+// ChromaDepth Spirograph - Nested epitrochoid/hypotrochoid curves as distance fields
+// Each layer at a different chromadepth depth: inner = red (near), outer = violet (far)
+// Frame feedback creates trailing spirograph patterns
+// ChromaDepth: Red = closest, Green = mid, Blue/Violet = farthest, Black = neutral
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (swap constants for audio uniforms)
+// ============================================================================
+
+// Number of petals / frequency parameter: spectral centroid shifts complexity
+#define PETAL_MOD (spectralCentroidZScore * 0.4)
+// #define PETAL_MOD 0.0
+
+// Inner/outer radius ratio: bass shifts the shape
+#define RADIUS_RATIO_MOD (bassZScore * 0.08)
+// #define RADIUS_RATIO_MOD 0.0
+
+// Pen distance modulation: treble shifts pen reach
+#define PEN_MOD (trebleZScore * 0.06)
+// #define PEN_MOD 0.0
+
+// Rotation speed: energy drives overall rotation
+#define ROTATION_SPEED (0.12 + energyNormalized * 0.15)
+// #define ROTATION_SPEED 0.12
+
+// Beat burst: triggers new curves via feedback persistence
+#define BEAT_BURST (beat ? 1.0 : 0.0)
+// #define BEAT_BURST 0.0
+
+// Glow intensity: spectral flux drives glow brightness
+#define GLOW_MOD (1.0 + spectralFluxZScore * 0.3)
+// #define GLOW_MOD 1.0
+
+// Overall scale: bass normalized breathes the pattern
+#define SCALE_BREATH (1.0 + bassNormalized * 0.1 - 0.05)
+// #define SCALE_BREATH 1.0
+
+// Color shift: pitch class rotates the depth palette
+#define DEPTH_SHIFT (pitchClassNormalized * 0.08)
+// #define DEPTH_SHIFT 0.0
+
+// Feedback decay: spectral entropy controls trail length
+#define TRAIL_PERSISTENCE (0.88 + spectralEntropyNormalized * 0.06)
+// #define TRAIL_PERSISTENCE 0.91
+
+// Pattern evolution rate: mids nudge evolution
+#define EVOLUTION_MOD (midsZScore * 0.02)
+// #define EVOLUTION_MOD 0.0
+
+// Line thickness: spectral roughness
+#define THICKNESS_MOD (1.0 + spectralRoughnessNormalized * 0.5)
+// #define THICKNESS_MOD 1.0
+
+// Bass punch brightness
+#define BASS_BRIGHTNESS (1.0 + bassZScore * 0.1)
+// #define BASS_BRIGHTNESS 1.0
+
+// Energy slope for trend detection
+#define ENERGY_TREND (energySlope * 10.0 * energyRSquared)
+// #define ENERGY_TREND 0.0
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+#define NUM_LAYERS 5
+#define SAMPLES_PER_CURVE 128
+#define PI 3.14159265359
+#define TAU 6.28318530718
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// SPIROGRAPH PARAMETRIC CURVES
+// ============================================================================
+
+// Epitrochoid: point on a circle of radius r rolling around
+// the outside of a circle of radius R, pen distance d from center
+// x(t) = (R+r)*cos(t) - d*cos((R+r)/r * t)
+// y(t) = (R+r)*sin(t) - d*sin((R+r)/r * t)
+
+vec2 spirographPoint(float t, float R, float r, float d, float phase) {
+    float rr = R + r;
+    float ratio = rr / max(r, 0.001);
+    return vec2(
+        rr * cos(t + phase) - d * cos(ratio * t + phase),
+        rr * sin(t + phase) - d * sin(ratio * t + phase)
+    );
+}
+
+// Approximate signed distance to a parametric spirograph curve
+// by sampling points along the curve and finding the minimum distance
+float spirographDist(vec2 p, float R, float r, float d, float phase) {
+    float minDist = 1e10;
+
+    for (int i = 0; i < SAMPLES_PER_CURVE; i++) {
+        float t = float(i) / float(SAMPLES_PER_CURVE) * TAU;
+        vec2 sp = spirographPoint(t, R, r, d, phase);
+        float dist = length(p - sp);
+        minDist = min(minDist, dist);
+    }
+
+    return minDist;
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    // Scale the coordinate system so curves fit nicely
+    float scale = 2.8 * SCALE_BREATH;
+    uv *= scale;
+
+    // Slow time evolution
+    float time = iTime * ROTATION_SPEED;
+    float evolve = iTime * 0.03 + EVOLUTION_MOD;
+
+    // Accumulate color from all layers
+    vec3 col = vec3(0.0);
+
+    for (int layer = 0; layer < NUM_LAYERS; layer++) {
+        float layerF = float(layer);
+        float layerNorm = layerF / float(NUM_LAYERS - 1); // 0 to 1
+
+        // Each layer has different spirograph parameters
+        // Innermost (layer 0) = simplest, outermost = most complex
+
+        // Base petal count increases with layer
+        float basePetals = 3.0 + layerF * 1.5;
+        float petals = basePetals + PETAL_MOD;
+        petals = max(petals, 2.0);
+
+        // Outer radius R (larger for outer layers)
+        float R = 0.3 + layerF * 0.12;
+
+        // Inner radius r derived from petal count
+        // The number of petals in a spirograph is related to R/r
+        float r = R / max(petals, 0.001);
+        r += RADIUS_RATIO_MOD * (0.5 + layerNorm * 0.5);
+        r = max(r, 0.01);
+
+        // Pen distance d (varies per layer)
+        float d = r * (0.6 + layerNorm * 0.4 + sin(evolve + layerF) * 0.15);
+        d += PEN_MOD * (1.0 + layerNorm);
+        d = max(d, 0.01);
+
+        // Phase offset per layer so they don't overlap at start
+        float phase = time * (1.0 + layerF * 0.15) + layerF * PI * 0.4;
+
+        // Add trend-based acceleration to inner layers
+        phase += ENERGY_TREND * 0.3 * (1.0 - layerNorm);
+
+        // Compute distance to this spirograph curve
+        float dist = spirographDist(uv, R, r, d, phase);
+
+        // Glow falloff from the curve
+        float thickness = (0.012 + layerNorm * 0.006) * THICKNESS_MOD;
+        float glow = thickness / (dist + thickness);
+        glow = pow(glow, 1.8); // sharpen the falloff
+        glow *= GLOW_MOD;
+
+        // Chromadepth color: inner layers = red (low t), outer = violet (high t)
+        float depthT = layerNorm;
+        depthT += DEPTH_SHIFT;
+        depthT = clamp(depthT, 0.0, 1.0);
+
+        vec3 layerColor = chromadepth(depthT);
+
+        // Add this layer's contribution
+        col += layerColor * glow;
+    }
+
+    // Apply brightness modulation
+    col *= clamp(BASS_BRIGHTNESS, 0.5, 1.5);
+
+    // Beat burst: flash brightness
+    col *= 1.0 + BEAT_BURST * 0.4;
+
+    // Clamp before feedback to prevent accumulation issues
+    col = clamp(col, 0.0, 1.0);
+
+    // --- FRAME FEEDBACK ---
+    // Sample previous frame with slight rotation for trailing spirograph effect
+    float fbAngle = iTime * 0.003;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotatedUV = vec2(
+        centered.x * fbc - centered.y * fbs,
+        centered.x * fbs + centered.y * fbc
+    ) + 0.5;
+
+    // Slight zoom-in on feedback to create trailing spiral
+    vec2 fbUV = (rotatedUV - 0.5) * 0.998 + 0.5;
+    fbUV = clamp(fbUV, 0.0, 1.0);
+
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    // Decay previous frame
+    float persistence = clamp(TRAIL_PERSISTENCE, 0.75, 0.96);
+    prev *= persistence;
+
+    // On beat, reduce persistence for sharper new patterns
+    if (beat) {
+        prev *= 0.7;
+    }
+
+    // Blend: new curves paint on top of faded trails
+    // Use additive for glow, then clamp
+    vec3 result = max(col, prev);
+
+    // Gentle vignette (keeps edges dark for chromadepth)
+    float vign = 1.0 - dot(centered, centered) * 0.8;
+    result *= max(vign, 0.0);
+
+    // Final clamp
+    result = clamp(result, 0.0, 1.0);
+
+    fragColor = vec4(result, 1.0);
+}

--- a/shaders/claude/chromadepth-tesseract.frag
+++ b/shaders/claude/chromadepth-tesseract.frag
@@ -1,0 +1,421 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, tesseract, 4d, geometric, raymarching
+// ChromaDepth 4D Tesseract Projection - Raymarched hypercube
+// The 3D projection of a rotating 4D hypercube rendered as edges and vertices
+// Inner cube = blue/far, outer cube = red/near through ChromaDepth glasses
+// Red = closest, Green = mid, Blue/Violet = farthest, Black = neutral
+
+#define MAX_STEPS 40
+#define MAX_DIST 20.0
+#define SURF_DIST 0.002
+#define PI 3.14159265
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (#define swap pattern)
+// ============================================================================
+
+// 4D rotation: XW plane driven by bass
+#define ROT_XW (iTime * 0.3 + bassZScore * 0.4)
+// #define ROT_XW (iTime * 0.3)
+
+// 4D rotation: YW plane driven by treble
+#define ROT_YW (iTime * 0.2 + trebleZScore * 0.3)
+// #define ROT_YW (iTime * 0.2)
+
+// 4D rotation: ZW plane driven by spectral centroid
+#define ROT_ZW (iTime * 0.15 + spectralCentroidZScore * 0.25)
+// #define ROT_ZW (iTime * 0.15)
+
+// Projection distance from 4D to 3D (energy scales it)
+#define PROJ_DIST (3.0 + energyNormalized * 0.8)
+// #define PROJ_DIST 3.0
+
+// Beat spin acceleration: accumulated extra rotation on beat
+#define BEAT_SPIN (beat ? 0.5 : 0.0)
+// #define BEAT_SPIN 0.0
+
+// Edge thickness modulated by mids
+#define EDGE_RADIUS (0.018 + midsZScore * 0.008)
+// #define EDGE_RADIUS 0.018
+
+// Vertex sphere radius
+#define VERT_RADIUS (0.04 + bassNormalized * 0.015)
+// #define VERT_RADIUS 0.04
+
+// Camera orbit
+#define CAM_ORBIT (iTime * 0.08 + spectralFluxZScore * 0.1)
+// #define CAM_ORBIT (iTime * 0.08)
+
+// Overall brightness from energy
+#define BRIGHTNESS (0.85 + energyZScore * 0.15)
+// #define BRIGHTNESS 0.85
+
+// Hue shift from pitch class
+#define HUE_SHIFT (pitchClassNormalized * 0.05)
+// #define HUE_SHIFT 0.0
+
+// Edge glow on beat
+#define BEAT_GLOW (beat ? 0.3 : 0.0)
+// #define BEAT_GLOW 0.0
+
+// Entropy wobble on vertices
+#define ENTROPY_WOBBLE (spectralEntropyNormalized * 0.02)
+// #define ENTROPY_WOBBLE 0.0
+
+// Camera zoom from spectral roughness
+#define CAM_ZOOM_MOD (spectralRoughnessNormalized * 0.3)
+// #define CAM_ZOOM_MOD 0.0
+
+// Trend-based slow rotation boost
+#define TREND_BOOST (energySlope * 10.0 * energyRSquared)
+// #define TREND_BOOST 0.0
+
+// Bass trend for projection distance modulation
+#define BASS_TREND (bassSlope * 8.0 * bassRSquared)
+// #define BASS_TREND 0.0
+
+// ============================================================================
+// CHROMADEPTH COLOR MAPPING
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// 4D ROTATION MATRICES (applied per-plane)
+// ============================================================================
+
+// Rotate in the XW plane
+vec4 rotXW(vec4 v, float a) {
+    float c = cos(a), s = sin(a);
+    return vec4(c * v.x + s * v.w, v.y, v.z, -s * v.x + c * v.w);
+}
+
+// Rotate in the YW plane
+vec4 rotYW(vec4 v, float a) {
+    float c = cos(a), s = sin(a);
+    return vec4(v.x, c * v.y + s * v.w, v.z, -s * v.y + c * v.w);
+}
+
+// Rotate in the ZW plane
+vec4 rotZW(vec4 v, float a) {
+    float c = cos(a), s = sin(a);
+    return vec4(v.x, v.y, c * v.z + s * v.w, -s * v.z + c * v.w);
+}
+
+// ============================================================================
+// TESSERACT GEOMETRY
+// ============================================================================
+
+// Accumulated beat spin (approximated via time-smoothed effect)
+float beatAccum() {
+    return BEAT_SPIN * sin(iTime * 5.0);
+}
+
+// Project a 4D point to 3D via perspective projection from W axis
+vec3 project4Dto3D(vec4 v, float d) {
+    float w = d / (d - v.w);
+    w = clamp(w, 0.3, 4.0); // prevent extreme projection
+    return v.xyz * w;
+}
+
+// The 16 vertices of a unit tesseract, rotated in 4D and projected to 3D
+// Stored in a fixed array via indexing
+vec4 tesseractVertex(int idx) {
+    // Each vertex is a combination of +/-1 in each of 4 dimensions
+    float x = ((idx & 1) == 0) ? -1.0 : 1.0;
+    float y = ((idx & 2) == 0) ? -1.0 : 1.0;
+    float z = ((idx & 4) == 0) ? -1.0 : 1.0;
+    float w = ((idx & 8) == 0) ? -1.0 : 1.0;
+    return vec4(x, y, z, w);
+}
+
+// Get rotated + projected vertex position
+vec3 getVertex(int idx, float axw, float ayw, float azw, float projD) {
+    vec4 v = tesseractVertex(idx);
+
+    // Apply 4D rotations
+    v = rotXW(v, axw);
+    v = rotYW(v, ayw);
+    v = rotZW(v, azw);
+
+    // Add slight wobble from entropy
+    v.xyz += ENTROPY_WOBBLE * sin(v.xyz * 3.0 + iTime);
+
+    // Project to 3D
+    return project4Dto3D(v, projD);
+}
+
+// ============================================================================
+// SDF PRIMITIVES
+// ============================================================================
+
+float sdSphere(vec3 p, float r) {
+    return length(p) - r;
+}
+
+float sdCapsule(vec3 p, vec3 a, vec3 b, float r) {
+    vec3 ab = b - a;
+    float t = clamp(dot(p - a, ab) / dot(ab, ab), 0.0, 1.0);
+    return length(p - a - ab * t) - r;
+}
+
+// ============================================================================
+// SCENE SDF - Tesseract edges and vertices
+// ============================================================================
+
+// We compute all 32 edges and 16 vertices of the tesseract.
+// Two vertices share an edge if they differ in exactly 1 coordinate.
+
+// Store projected vertices in globals to avoid recomputing
+vec3 verts[16];
+float vertW[16]; // original W coordinate (before projection) for depth coloring
+
+void computeVertices(float axw, float ayw, float azw, float projD) {
+    for (int i = 0; i < 16; i++) {
+        vec4 v4 = tesseractVertex(i);
+        v4 = rotXW(v4, axw);
+        v4 = rotYW(v4, ayw);
+        v4 = rotZW(v4, azw);
+        v4.xyz += ENTROPY_WOBBLE * sin(v4.xyz * 3.0 + iTime);
+        vertW[i] = v4.w;
+        verts[i] = project4Dto3D(v4, projD);
+    }
+}
+
+// Return distance to nearest edge and depth info
+// depth encodes which part of the tesseract (inner/outer)
+struct HitInfo {
+    float dist;
+    float depth; // 0 = near/red, 1 = far/blue
+};
+
+HitInfo tesseractSDF(vec3 p) {
+    float minDist = MAX_DIST;
+    float hitDepth = 0.5;
+
+    float edgeR = max(EDGE_RADIUS, 0.008);
+    float vertR = max(VERT_RADIUS, 0.02);
+
+    // Vertices (16 spheres)
+    for (int i = 0; i < 16; i++) {
+        float d = sdSphere(p - verts[i], vertR);
+        if (d < minDist) {
+            minDist = d;
+            // Depth based on the original W coordinate: w=-1 is "inner" (far/blue), w=+1 is "outer" (near/red)
+            hitDepth = 1.0 - (vertW[i] * 0.5 + 0.5); // map [-1,1] to [1,0] so positive w = red
+        }
+    }
+
+    // Edges: two vertices share an edge if they differ in exactly 1 bit
+    // That gives us 32 edges (16 * 4 / 2)
+    for (int i = 0; i < 16; i++) {
+        for (int bit = 0; bit < 4; bit++) {
+            int j = i ^ (1 << bit);
+            if (j > i) { // avoid double counting
+                float d = sdCapsule(p, verts[i], verts[j], edgeR);
+                if (d < minDist) {
+                    minDist = d;
+                    // Average depth of the two endpoint vertices
+                    float wi = vertW[i];
+                    float wj = vertW[j];
+                    float avgW = (wi + wj) * 0.5;
+                    hitDepth = 1.0 - (avgW * 0.5 + 0.5);
+                }
+            }
+        }
+    }
+
+    return HitInfo(minDist, hitDepth);
+}
+
+// Wrapper for raymarching (returns just distance)
+float sceneDist(vec3 p) {
+    return tesseractSDF(p).dist;
+}
+
+// ============================================================================
+// NORMAL CALCULATION
+// ============================================================================
+
+vec3 getNormal(vec3 p) {
+    vec2 e = vec2(0.003, 0.0);
+    return normalize(vec3(
+        sceneDist(p + e.xyy) - sceneDist(p - e.xyy),
+        sceneDist(p + e.yxy) - sceneDist(p - e.yxy),
+        sceneDist(p + e.yyx) - sceneDist(p - e.yyx)
+    ));
+}
+
+// ============================================================================
+// CEL SHADING
+// ============================================================================
+
+float celShade(float d) {
+    if (d > 0.65) return 1.0;
+    if (d > 0.35) return 0.7;
+    if (d > 0.15) return 0.45;
+    return 0.25;
+}
+
+// ============================================================================
+// RAYMARCHING
+// ============================================================================
+
+HitInfo raymarch(vec3 ro, vec3 rd) {
+    float t = 0.0;
+
+    for (int i = 0; i < MAX_STEPS; i++) {
+        vec3 p = ro + rd * t;
+        HitInfo h = tesseractSDF(p);
+
+        if (h.dist < SURF_DIST) {
+            return HitInfo(t, h.depth);
+        }
+        if (t > MAX_DIST) break;
+        t += h.dist * 0.85; // slight relaxation for stability
+    }
+
+    return HitInfo(MAX_DIST, 0.5);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    // Compute 4D rotation angles
+    float beatExtra = beatAccum();
+    float axw = ROT_XW + beatExtra + TREND_BOOST * 0.1;
+    float ayw = ROT_YW + beatExtra * 0.7;
+    float azw = ROT_ZW + beatExtra * 0.5;
+    float projD = PROJ_DIST + BASS_TREND * 0.1;
+    projD = clamp(projD, 2.0, 5.0);
+
+    // Precompute all 16 projected vertices
+    computeVertices(axw, ayw, azw, projD);
+
+    // Camera setup - orbit around the tesseract
+    float camAngle = CAM_ORBIT;
+    float camR = 5.5 - CAM_ZOOM_MOD;
+    camR = max(camR, 3.5);
+    float camY = 2.0 + sin(iTime * 0.05) * 0.5;
+    vec3 ro = vec3(sin(camAngle) * camR, camY, cos(camAngle) * camR);
+    vec3 lookAt = vec3(0.0, 0.0, 0.0);
+
+    // Camera matrix
+    vec3 forward = normalize(lookAt - ro);
+    vec3 right = normalize(cross(vec3(0.0, 1.0, 0.0), forward));
+    vec3 up = cross(forward, right);
+    float fov = 1.5;
+    vec3 rd = normalize(uv.x * right + uv.y * up + fov * forward);
+
+    // Raymarch
+    HitInfo result = raymarch(ro, rd);
+    float dist = result.dist;
+    float depth = result.depth;
+
+    // Background - dark gradient for chromadepth neutrality
+    vec3 col = vec3(0.0);
+    float skyGrad = clamp(rd.y * 0.5 + 0.5, 0.0, 1.0);
+    // Very dark background: deep violet fading to black
+    vec3 bgCol = hsl2rgb(vec3(0.75, 0.4, mix(0.02, 0.06, skyGrad)));
+
+    // Subtle grid floor for spatial reference
+    if (rd.y < -0.01) {
+        float floorT = -(ro.y + 2.5) / rd.y;
+        if (floorT > 0.0 && floorT < MAX_DIST) {
+            vec3 floorP = ro + rd * floorT;
+            float gx = abs(fract(floorP.x * 0.5) - 0.5);
+            float gz = abs(fract(floorP.z * 0.5 + iTime * 0.05) - 0.5);
+            float lineX = smoothstep(0.02, 0.0, gx);
+            float lineZ = smoothstep(0.02, 0.0, gz);
+            float grid = max(lineX, lineZ);
+            float gridFade = exp(-floorT * 0.15);
+            // Grid lines in deep blue/violet (far depth)
+            vec3 gridCol = chromadepth(0.85) * 0.3;
+            bgCol = mix(bgCol, gridCol, grid * gridFade * 0.5);
+        }
+    }
+
+    col = bgCol;
+
+    if (dist < MAX_DIST) {
+        vec3 p = ro + rd * dist;
+        vec3 n = getNormal(p);
+
+        // Lighting
+        vec3 lightDir = normalize(vec3(0.6, 0.8, 0.4));
+        vec3 fillDir = normalize(vec3(-0.3, 0.4, -0.6));
+        float diff = max(dot(n, lightDir), 0.0);
+        float fill = max(dot(n, fillDir), 0.0) * 0.25;
+        float cel = celShade(diff + fill);
+
+        // Rim light for edge pop
+        float rim = pow(1.0 - max(dot(n, -rd), 0.0), 3.0);
+        float rimLight = rim * 0.25;
+
+        // Outline
+        float edge = 1.0 - max(dot(n, -rd), 0.0);
+        float outline = smoothstep(0.6, 0.75, edge);
+
+        // Map depth to chromadepth color
+        // depth: 0 = near (red), 1 = far (blue)
+        // Also mix in actual ray distance for additional depth cue
+        float distDepth = clamp((dist - 2.0) / 8.0, 0.0, 1.0);
+        float combinedDepth = mix(depth, distDepth, 0.3);
+        combinedDepth = clamp(combinedDepth + HUE_SHIFT, 0.0, 1.0);
+
+        // Lightness from cel shading
+        float lightness = cel;
+
+        // Chromadepth color
+        float hue = combinedDepth * 0.82;
+        float sat = 0.95 - combinedDepth * 0.1;
+        float lit = (0.55 - combinedDepth * 0.12) * lightness;
+        lit = clamp(lit, 0.06, 0.55);
+        col = hsl2rgb(vec3(hue, sat, lit));
+
+        // Rim light adds brightness at edges
+        col += col * rimLight;
+
+        // Beat glow: flash edges brighter on beat
+        col += BEAT_GLOW * rim * chromadepth(combinedDepth) * 0.5;
+
+        // Outline darkening for cel look
+        col *= (1.0 - outline * 0.7);
+
+        // Apply overall brightness
+        col *= clamp(BRIGHTNESS, 0.4, 1.3);
+
+        // Distance fog toward background
+        float fog = exp(-dist * 0.08);
+        col = mix(bgCol, col, fog);
+    }
+
+    // Vignette
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.6;
+
+    // Frame feedback for subtle motion trail
+    vec4 prev = getLastFrameColor(screenUV);
+    col = mix(prev.rgb * 0.93, col, 0.7);
+
+    // Ensure saturation stays high for chromadepth
+    vec3 colHSL = rgb2hsl(col);
+    colHSL.y = min(colHSL.y * 1.1, 1.0);
+    colHSL.z = clamp(colHSL.z, 0.02, 0.55);
+    col = hsl2rgb(colHSL);
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/chromadepth-voronoi.frag
+++ b/shaders/claude/chromadepth-voronoi.frag
@@ -1,0 +1,319 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, 3d, voronoi, crystal
+// ChromaDepth Voronoi Crystal Cavern
+// Multi-layer Voronoi cells create crystal depth: large cells = red/near, small = blue/far
+// Glowing cell edges with sparkle, audio-reactive heights and animation
+// ChromaDepth: Red = closest, Green = mid, Blue/Violet = farthest, Black = neutral
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS (swap constants for audio uniforms)
+// ============================================================================
+
+// Cell height pulsing from bass
+#define BASS_PULSE (bassZScore * 0.3)
+// #define BASS_PULSE 0.0
+
+// Edge brightness from energy
+#define EDGE_BRIGHTNESS (1.0 + energyZScore * 0.4)
+// #define EDGE_BRIGHTNESS 1.0
+
+// Cell animation speed from spectral centroid
+#define ANIM_SPEED (1.0 + spectralCentroidZScore * 0.3)
+// #define ANIM_SPEED 1.0
+
+// Sparkle on edges from treble
+#define TREBLE_SPARKLE (max(trebleZScore, 0.0) * 0.6)
+// #define TREBLE_SPARKLE 0.0
+
+// Beat ripple trigger
+#define BEAT_RIPPLE (beat ? 1.0 : 0.0)
+// #define BEAT_RIPPLE 0.0
+
+// Pitch class modulates cell seed drift
+#define PITCH_DRIFT (pitchClassNormalized * 0.4)
+// #define PITCH_DRIFT 0.0
+
+// Energy level for overall brightness
+#define ENERGY_LEVEL (energyNormalized)
+// #define ENERGY_LEVEL 0.5
+
+// Spectral flux for edge shimmer
+#define FLUX_SHIMMER (spectralFluxZScore * 0.2)
+// #define FLUX_SHIMMER 0.0
+
+// Mids for mid-layer modulation
+#define MIDS_MOD (midsZScore * 0.15)
+// #define MIDS_MOD 0.0
+
+// Spectral entropy for cell distortion
+#define ENTROPY_WARP (spectralEntropyNormalized * 0.12)
+// #define ENTROPY_WARP 0.0
+
+// Roughness for edge thickness
+#define ROUGHNESS_EDGE (spectralRoughnessNormalized)
+// #define ROUGHNESS_EDGE 0.5
+
+// Bass slope for trend-aware morphing
+#define BASS_TREND (bassSlope * 10.0 * bassRSquared)
+// #define BASS_TREND 0.0
+
+// Energy slope for build detection
+#define ENERGY_TREND (energySlope * 15.0 * energyRSquared)
+// #define ENERGY_TREND 0.0
+
+// Feedback strength
+#define FB_AMOUNT 0.15
+
+// ============================================================================
+// CHROMADEPTH: full spectrum red -> violet via smooth HSL
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.1;
+    float lit = 0.55 - t * 0.12;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// HASH FUNCTIONS for Voronoi
+// ============================================================================
+
+vec2 hash2(vec2 p) {
+    p = vec2(dot(p, vec2(127.1, 311.7)),
+             dot(p, vec2(269.5, 183.3)));
+    return fract(sin(p) * 43758.5453);
+}
+
+float hash1(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+// ============================================================================
+// VORONOI with cell ID and edge distance
+// Returns: x = min dist to cell center, y = edge dist, z = cell height hash
+// cellID is output via the last parameter
+// ============================================================================
+
+vec4 voronoi(vec2 p, float timeScale, float seedOffset, out vec2 cellID) {
+    vec2 ip = floor(p);
+    vec2 fp = fract(p);
+
+    float minDist = 8.0;
+    float secondDist = 8.0;
+    vec2 bestCell = vec2(0.0);
+    float bestHeight = 0.0;
+
+    for (int j = -1; j <= 1; j++) {
+        for (int i = -1; i <= 1; i++) {
+            vec2 neighbor = vec2(float(i), float(j));
+            vec2 cell = ip + neighbor;
+
+            // Animated cell center with pitch drift
+            vec2 h = hash2(cell + seedOffset);
+            vec2 animOffset = vec2(
+                sin(iTime * timeScale * (h.x * 0.5 + 0.5) + h.y * 6.28),
+                cos(iTime * timeScale * (h.y * 0.5 + 0.5) + h.x * 6.28)
+            ) * 0.3;
+
+            vec2 cellPoint = neighbor + h + animOffset - fp;
+            float d = dot(cellPoint, cellPoint);
+
+            if (d < minDist) {
+                secondDist = minDist;
+                minDist = d;
+                bestCell = cell;
+                bestHeight = hash1(cell + seedOffset * 3.7);
+            } else if (d < secondDist) {
+                secondDist = d;
+            }
+        }
+    }
+
+    cellID = bestCell;
+    float dist = sqrt(minDist);
+    float edge = sqrt(secondDist) - dist;
+    return vec4(dist, edge, bestHeight, 0.0);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / iResolution.xy;
+
+    float t = iTime * 0.08 * ANIM_SPEED;
+
+    // Slow global rotation
+    float angle = t * 0.3;
+    float ca = cos(angle), sa = sin(angle);
+    uv = mat2(ca, -sa, sa, ca) * uv;
+
+    // Slight entropy-based warping
+    uv += vec2(sin(uv.y * 4.0 + t) * ENTROPY_WARP,
+               cos(uv.x * 4.0 + t * 1.3) * ENTROPY_WARP);
+
+    // ========================================================================
+    // THREE VORONOI LAYERS at different scales = depth
+    // ========================================================================
+
+    // Layer 1: LARGE cells = foreground (red, depth ~0.0-0.25)
+    vec2 cellID1;
+    float scale1 = 2.5;
+    vec4 v1 = voronoi(uv * scale1, ANIM_SPEED * 0.3, PITCH_DRIFT, cellID1);
+    float height1 = v1.z + BASS_PULSE * 0.5;
+    float edge1 = v1.y;
+
+    // Layer 2: MEDIUM cells = middle (green, depth ~0.3-0.55)
+    vec2 cellID2;
+    float scale2 = 5.0;
+    vec4 v2 = voronoi(uv * scale2 + vec2(t * 0.2, t * 0.15), ANIM_SPEED * 0.5, PITCH_DRIFT + 1.0, cellID2);
+    float height2 = v2.z + MIDS_MOD;
+    float edge2 = v2.y;
+
+    // Layer 3: TINY cells = background (blue/violet, depth ~0.6-1.0)
+    vec2 cellID3;
+    float scale3 = 10.0;
+    vec4 v3 = voronoi(uv * scale3 + vec2(-t * 0.1, t * 0.25), ANIM_SPEED * 0.7, PITCH_DRIFT + 2.0, cellID3);
+    float height3 = v3.z;
+    float edge3 = v3.y;
+
+    // ========================================================================
+    // DEPTH MAPPING: combine layers
+    // ========================================================================
+
+    // Each layer contributes to depth based on its scale
+    // Large cells dominate near (red), small cells dominate far (blue)
+    float depth1 = height1 * 0.25;                          // 0.0 - 0.25 range
+    float depth2 = 0.3 + height2 * 0.25 + MIDS_MOD * 0.1;  // 0.3 - 0.55 range
+    float depth3 = 0.6 + height3 * 0.4;                     // 0.6 - 1.0 range
+
+    // Blend layers: closer layers occlude farther ones based on cell height
+    // Higher cells in foreground = more red, lower = reveals green/blue behind
+    float layer1Strength = smoothstep(0.3, 0.7, height1 + BASS_PULSE * 0.3);
+    float layer2Strength = smoothstep(0.25, 0.65, height2) * (1.0 - layer1Strength * 0.6);
+    float layer3Strength = (1.0 - layer1Strength * 0.5) * (1.0 - layer2Strength * 0.4);
+
+    // Weighted depth
+    float totalWeight = layer1Strength + layer2Strength + layer3Strength + 0.001;
+    float depth = (depth1 * layer1Strength + depth2 * layer2Strength + depth3 * layer3Strength) / totalWeight;
+
+    // Bass trend pushes everything closer (more red) on rising bass
+    depth -= clamp(BASS_TREND, -0.15, 0.15);
+    // Energy build shifts toward foreground
+    depth -= clamp(ENERGY_TREND, -0.1, 0.1) * 0.5;
+
+    depth = clamp(depth, 0.0, 1.0);
+
+    // ========================================================================
+    // BEAT RIPPLE: radial wave on beat
+    // ========================================================================
+
+    float ripple = 0.0;
+    if (BEAT_RIPPLE > 0.5) {
+        float beatPhase = fract(iTime * 2.0);
+        float rippleRing = abs(length(uv) - beatPhase * 1.5);
+        ripple = smoothstep(0.15, 0.0, rippleRing) * (1.0 - beatPhase);
+        // Ripple pushes depth toward red briefly
+        depth = mix(depth, 0.0, ripple * 0.3);
+    }
+
+    // ========================================================================
+    // CHROMADEPTH COLOR
+    // ========================================================================
+
+    vec3 col = chromadepth(depth);
+
+    // ========================================================================
+    // EDGE GLOW: bright edges on cell boundaries
+    // ========================================================================
+
+    // Edge thickness varies with roughness
+    float edgeThreshold = 0.08 + ROUGHNESS_EDGE * 0.06;
+
+    // Combine edges from all layers with different weights
+    float edgeGlow1 = smoothstep(edgeThreshold, 0.0, edge1) * layer1Strength;
+    float edgeGlow2 = smoothstep(edgeThreshold * 0.7, 0.0, edge2) * layer2Strength;
+    float edgeGlow3 = smoothstep(edgeThreshold * 0.5, 0.0, edge3) * layer3Strength * 0.6;
+
+    float totalEdge = edgeGlow1 + edgeGlow2 + edgeGlow3;
+    totalEdge = clamp(totalEdge, 0.0, 1.0);
+
+    // Edge color: bright white-yellow glow, intensity from energy
+    vec3 edgeColor = vec3(1.0, 0.95, 0.8) * EDGE_BRIGHTNESS;
+    col = mix(col, edgeColor, totalEdge * 0.7);
+
+    // ========================================================================
+    // SPARKLE: treble-driven sparkle on edges
+    // ========================================================================
+
+    float sparkleHash = hash1(cellID1 * 17.3 + floor(iTime * 8.0));
+    float sparkle = step(0.85, sparkleHash) * TREBLE_SPARKLE * totalEdge;
+    col += sparkle * vec3(1.0, 1.0, 0.9);
+
+    // Additional sparkle from flux on layer 2 edges
+    float sparkleHash2 = hash1(cellID2 * 23.1 + floor(iTime * 12.0));
+    float sparkle2 = step(0.88, sparkleHash2) * max(FLUX_SHIMMER, 0.0) * edgeGlow2;
+    col += sparkle2 * vec3(0.9, 1.0, 1.0);
+
+    // ========================================================================
+    // CELL INTERIOR SHADING: crystal facet look
+    // ========================================================================
+
+    // Within each cell, use distance to center for a faceted gradient
+    float facet1 = smoothstep(0.0, 0.5, v1.x) * layer1Strength;
+    float facet2 = smoothstep(0.0, 0.4, v2.x) * layer2Strength;
+    float facet3 = smoothstep(0.0, 0.3, v3.x) * layer3Strength;
+
+    float facetDarken = 1.0 - (facet1 + facet2 + facet3) * 0.15;
+    col *= max(facetDarken, 0.5);
+
+    // ========================================================================
+    // BRIGHTNESS MODULATION
+    // ========================================================================
+
+    col *= 0.85 + ENERGY_LEVEL * 0.3;
+    col *= 1.0 + ripple * 0.4;
+
+    // ========================================================================
+    // FRAME FEEDBACK: gentle trails
+    // ========================================================================
+
+    // Slight UV offset for feedback motion
+    vec2 fbOffset = vec2(
+        sin(iTime * 0.3) * 0.003,
+        cos(iTime * 0.4) * 0.003
+    );
+    vec2 fbUV = clamp(screenUV + fbOffset, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    // Decay previous frame
+    prev *= 0.96;
+
+    // Blend: current frame dominates
+    float fbMix = FB_AMOUNT;
+    fbMix += BEAT_RIPPLE * 0.05;
+    fbMix = clamp(fbMix, 0.05, 0.3);
+    col = mix(prev, col, 1.0 - fbMix);
+
+    // Prevent feedback accumulation: if prev is brighter than current, reduce it
+    float prevLum = dot(prev, vec3(0.299, 0.587, 0.114));
+    float curLum = dot(col, vec3(0.299, 0.587, 0.114));
+    if (prevLum > curLum * 1.5 + 0.1) {
+        col = mix(col, col * 0.95, 0.3);
+    }
+
+    // ========================================================================
+    // VIGNETTE
+    // ========================================================================
+
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.7;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/graph/signal-tapestry.frag
+++ b/shaders/graph/signal-tapestry.frag
@@ -1,0 +1,344 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, graph, regression, oscilloscope, analytics, story
+// @favorite: true
+// ChromaDepth Music Story — 8-feature scrolling analytics dashboard
+// Each feature chosen for maximally distinct temporal behavior.
+// Z-score waveforms show the "now", slope fills show the "trend",
+// width driven by a complementary feature, glow by medians.
+// Stippled glows and hue-aging trails blend engineering with art.
+//
+// Temporal signatures:
+//   bass:        slow heavy swells (kicks, sub-bass)
+//   treble:      fast jittery spikes (hi-hats, cymbals)
+//   flux:        sharp transient bursts (any timbral change)
+//   entropy:     smooth slow wandering (noise vs tone)
+//   roughness:   gritty mid-speed (dissonance, distortion)
+//   crest:       peaky inverse-of-entropy (pure tones spike it)
+//   pitchClass:  discrete note steps (quantized jumps)
+//   skew:        asymmetric drift (dark vs bright tilt)
+
+// ============================================================================
+// FEATURE DEFINITIONS (8 independent features, each visually distinct)
+// Z=zScore, S=slope, R=rSquared, N=normalized, W=width, G=glow (median)
+// ============================================================================
+
+// --- Energy-correlated: subtract energyZScore to show CHARACTER not volume ---
+
+// Slow heavy swells — width: roughness, glow: energy median
+#define F0_Z (bassZScore - energyZScore)
+#define F0_S bassSlope
+#define F0_R bassRSquared
+#define F0_N bassNormalized
+#define F0_W spectralRoughnessNormalized
+#define F0_G energyMedian
+
+// Fast jittery spikes — width: crest, glow: centroid median
+#define F1_Z (trebleZScore - energyZScore)
+#define F1_S trebleSlope
+#define F1_R trebleRSquared
+#define F1_N trebleNormalized
+#define F1_W spectralCrestNormalized
+#define F1_G spectralCentroidMedian
+
+// Sharp transient bursts — width: energy, glow: mids median
+#define F2_Z (spectralFluxZScore - energyZScore * 0.5)
+#define F2_S spectralFluxSlope
+#define F2_R spectralFluxRSquared
+#define F2_N spectralFluxNormalized
+#define F2_W energyNormalized
+#define F2_G midsMedian
+
+// Gritty mid-speed — width: treble, glow: bass median
+#define F4_Z (spectralRoughnessZScore - energyZScore * 0.3)
+#define F4_S spectralRoughnessSlope
+#define F4_R spectralRoughnessRSquared
+#define F4_N spectralRoughnessNormalized
+#define F4_W trebleNormalized
+#define F4_G bassMedian
+
+// --- Energy-independent: measure shape/quality, not magnitude ---
+
+// Smooth slow wandering — width: bass, glow: spread median
+#define F3_Z spectralEntropyZScore
+#define F3_S spectralEntropySlope
+#define F3_R spectralEntropyRSquared
+#define F3_N spectralEntropyNormalized
+#define F3_W bassNormalized
+#define F3_G spectralSpreadMedian
+
+// Peaky inverse-of-entropy — width: entropy, glow: kurtosis median
+#define F5_Z spectralCrestZScore
+#define F5_S spectralCrestSlope
+#define F5_R spectralCrestRSquared
+#define F5_N spectralCrestNormalized
+#define F5_W spectralEntropyNormalized
+#define F5_G spectralKurtosisMedian
+
+// Discrete note steps — width: rolloff, glow: rolloff median
+#define F6_Z pitchClassZScore
+#define F6_S pitchClassSlope
+#define F6_R pitchClassRSquared
+#define F6_N pitchClassNormalized
+#define F6_W spectralRolloffNormalized
+#define F6_G spectralRolloffMedian
+
+// Asymmetric drift — width: centroid, glow: treble median
+#define F7_Z spectralSkewZScore
+#define F7_S spectralSkewSlope
+#define F7_R spectralSkewRSquared
+#define F7_N spectralSkewNormalized
+#define F7_W spectralCentroidNormalized
+#define F7_G trebleMedian
+
+// --- Globals ---
+#define BEAT_PULSE (beat ? 1.0 : 0.0)
+// #define BEAT_PULSE 0.0
+
+// --- Layout ---
+#define NUM_ROWS 8.0
+#define MARGIN 0.03
+#define GAP 0.005
+#define USABLE_H (1.0 - 2.0 * MARGIN - GAP * (NUM_ROWS - 1.0))
+#define ROW_H (USABLE_H / NUM_ROWS)
+#define ROW_Y(i) (MARGIN + ROW_H * 0.5 + (i) * (ROW_H + GAP))
+
+// ============================================================================
+// NOISE / STIPPLE
+// ============================================================================
+
+float hash21(vec2 p) {
+    p = fract(p * vec2(253.37, 471.53));
+    p += dot(p, p + 19.19);
+    return fract(p.x * p.y);
+}
+
+// Smooth value noise for organic texture
+float vnoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float a = hash21(i);
+    float b = hash21(i + vec2(1.0, 0.0));
+    float c = hash21(i + vec2(0.0, 1.0));
+    float d = hash21(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+// ============================================================================
+// CHROMADEPTH
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    return hsl2rgb(vec3(t * 0.82, 0.92 - t * 0.08, 0.52 - t * 0.1));
+}
+
+// ============================================================================
+// ROW RENDERER
+// ============================================================================
+
+vec4 drawRow(vec2 fc, vec2 res, float zScore, float slope, float rSq,
+             float norm, float widthMod, float glowMod, float rowCenter, float idx) {
+    float pixY = fc.y / res.y;
+    float halfH = ROW_H * 0.5;
+
+    // Expanded bounds for glow bleed between rows
+    if (pixY > rowCenter + halfH + 0.015 || pixY < rowCenter - halfH - 0.015)
+        return vec4(0.0);
+
+    float localY = (pixY - rowCenter) / ROW_H; // -0.5 to 0.5
+    vec3 col = vec3(0.0);
+    float a = 0.0;
+
+    // Stipple seed unique per row and pixel
+    float stip = hash21(fc + idx * 137.0);
+
+    // --- Row color (chromadepth, shifted by slope direction) ---
+    float depth = idx / NUM_ROWS;
+    float sShift = clamp(-slope * 8.0, -0.12, 0.12) * rSq;
+    vec3 rc = chromadepth(clamp(depth + sShift, 0.0, 1.0));
+
+    // --- Soft row boundary (gradient fade instead of hard line) ---
+    float edgeDist = (0.5 - abs(localY)) * ROW_H * res.y;
+    float edgeFade = smoothstep(0.0, 3.0, edgeDist);
+    // Stippled edge: some pixels fade earlier for organic feel
+    edgeFade = smoothstep(stip * 0.3, 1.0, edgeFade);
+
+    // --- Center reference (stippled dotted line) ---
+    float cPx = abs(localY) * ROW_H * res.y;
+    float cLine = smoothstep(0.7, 0.0, cPx) * 0.025;
+    // Stipple the center line into dots
+    cLine *= step(0.65, stip);
+    col += rc * 0.4 * cLine;
+    a = max(a, cLine);
+
+    // --- Normalized fill (stippled background showing overall level) ---
+    float normY = -0.5 + norm * 0.85;
+    if (localY < normY) {
+        // Stippled fill: denser near the fill edge, sparser deeper
+        float fillDensity = 0.15 + 0.25 * smoothstep(normY - 0.3, normY, localY);
+        float fillStip = step(1.0 - fillDensity, stip);
+        float fa = fillStip * 0.08;
+        col += rc * fa;
+        a = max(a, fa);
+    }
+
+    // --- Slope trend fill (stippled, from center toward slope direction) ---
+    float sv = clamp(slope * 18.0, -0.38, 0.38);
+    if ((sv > 0.0 && localY > 0.0 && localY < sv) ||
+        (sv < 0.0 && localY < 0.0 && localY > sv)) {
+        // Density increases with rSquared (confident = denser stipple)
+        float slopeDensity = rSq * 0.5;
+        float slopeStip = step(1.0 - slopeDensity, stip);
+        float sa = slopeStip * 0.2;
+        vec3 sc = (sv > 0.0)
+            ? chromadepth(max(depth - 0.12, 0.0))
+            : chromadepth(min(depth + 0.12, 1.0));
+        col += sc * sa;
+        a = max(a, sa);
+    }
+
+    // --- Confident trend accent (warm/cool particles at trend edge) ---
+    float trendSignal = rSq * min(abs(slope) * 20.0, 1.0);
+    if (trendSignal > 0.25) {
+        float accentY = clamp(sv, -0.42, 0.42);
+        float accentPx = abs(localY - accentY) * ROW_H * res.y;
+        float accent = smoothstep(4.0, 0.0, accentPx) * (trendSignal - 0.25) * 0.5;
+        // Stipple the accent for sparkle effect
+        accent *= 0.5 + stip * 0.8;
+        vec3 accentColor = (sv > 0.0) ? vec3(1.0, 0.75, 0.35) : vec3(0.35, 0.7, 1.0);
+        col += accentColor * accent;
+        a = max(a, accent);
+    }
+
+    // --- Z-SCORE LINE (main waveform with organic edge) ---
+    float zVal = clamp(zScore * 0.7, -0.45, 0.45);
+    float zPx = abs(localY - zVal) * ROW_H * res.y;
+
+    // Width driven by complementary feature
+    float lw = 0.6 + widthMod * 4.5 + abs(zScore) * 0.4;
+
+    // Organic edge: noise wiggles the line boundary
+    float edgeNoise = (stip - 0.5) * 1.2;
+    float line = smoothstep(lw + 1.0 + edgeNoise, max(lw - 0.5, 0.0), zPx);
+
+    // Stippled glow: median drives radius/intensity, noise breaks it into particles
+    float glowRadius = lw * (3.0 + glowMod * 10.0);
+    float glowIntensity = 0.03 + glowMod * 0.22;
+    float rawGlow = smoothstep(glowRadius, lw * 0.5, zPx);
+    // Stipple the glow: probability of a "particle" existing falls off with distance
+    float glowParticle = step(1.0 - rawGlow * rawGlow, stip);
+    float glow = glowParticle * rawGlow * glowIntensity;
+
+    // Glow color: shifts toward white when sustained, with slight hue variation per particle
+    float hueJitter = (stip - 0.5) * 0.06;
+    vec3 glowColor = chromadepth(clamp(depth + sShift + hueJitter, 0.0, 1.0));
+    glowColor = mix(glowColor, vec3(1.0), glowMod * 0.3);
+
+    // Core line color
+    vec3 lc = rc * (1.0 + abs(zScore) * 0.25);
+    lc *= 1.0 + clamp(trendSignal, 0.0, 0.2);
+
+    col += lc * line + glowColor * glow;
+    a = max(a, line + glow);
+
+    // Apply edge fade
+    col *= edgeFade;
+    a *= edgeFade;
+
+    return vec4(col, clamp(a, 0.0, 1.0));
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = fragCoord / res;
+
+    // --- SCROLLING ---
+    float px = floor(fragCoord.x);
+    float last = floor(res.x) - 1.0;
+
+    if (px < last) {
+        vec2 prevUV = vec2((fragCoord.x + 1.0) / res.x, uv.y);
+        vec4 prev = getLastFrameColor(prevUV);
+
+        // Trail decay
+        prev.rgb *= 0.9985;
+
+        // Hue aging: as pixels scroll left, shift hue slightly toward cool
+        // This creates a warm→cool time gradient across the screen
+        vec3 prevHSL = rgb2hsl(prev.rgb);
+        prevHSL.x = fract(prevHSL.x + 0.0006); // tiny hue drift per frame
+        prevHSL.y *= 0.9997;                     // very slowly desaturate
+        prev.rgb = hsl2rgb(prevHSL);
+
+        prev.rgb *= 1.0 + BEAT_PULSE * 0.004;
+
+        fragColor = prev;
+        return;
+    }
+
+    // --- DRAW NEW COLUMN (rightmost pixel) ---
+
+    // Subtle background: deep navy gradient instead of pure black
+    float bgGrad = uv.y * 0.012 + 0.003;
+    fragColor = vec4(vec3(0.0, 0.002, bgGrad), 1.0);
+
+    vec4 r;
+
+    r = drawRow(fragCoord, res, F0_Z, F0_S, F0_R, F0_N, F0_W, F0_G, ROW_Y(0.0), 0.0);
+    fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a);
+
+    r = drawRow(fragCoord, res, F1_Z, F1_S, F1_R, F1_N, F1_W, F1_G, ROW_Y(1.0), 1.0);
+    fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a);
+
+    r = drawRow(fragCoord, res, F2_Z, F2_S, F2_R, F2_N, F2_W, F2_G, ROW_Y(2.0), 2.0);
+    fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a);
+
+    r = drawRow(fragCoord, res, F3_Z, F3_S, F3_R, F3_N, F3_W, F3_G, ROW_Y(3.0), 3.0);
+    fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a);
+
+    r = drawRow(fragCoord, res, F4_Z, F4_S, F4_R, F4_N, F4_W, F4_G, ROW_Y(4.0), 4.0);
+    fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a);
+
+    r = drawRow(fragCoord, res, F5_Z, F5_S, F5_R, F5_N, F5_W, F5_G, ROW_Y(5.0), 5.0);
+    fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a);
+
+    r = drawRow(fragCoord, res, F6_Z, F6_S, F6_R, F6_N, F6_W, F6_G, ROW_Y(6.0), 6.0);
+    fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a);
+
+    r = drawRow(fragCoord, res, F7_Z, F7_S, F7_R, F7_N, F7_W, F7_G, ROW_Y(7.0), 7.0);
+    fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a);
+
+    // --- GLOBAL STORY DETECTION ---
+
+    int spikes = 0;
+    if (abs(F0_Z) > 0.6) spikes++;
+    if (abs(F1_Z) > 0.6) spikes++;
+    if (abs(F2_Z) > 0.6) spikes++;
+    if (abs(F3_Z) > 0.6) spikes++;
+    if (abs(F4_Z) > 0.6) spikes++;
+    if (abs(F5_Z) > 0.6) spikes++;
+    if (abs(F6_Z) > 0.6) spikes++;
+    if (abs(F7_Z) > 0.6) spikes++;
+
+    if (spikes >= 3) {
+        fragColor.rgb += vec3(0.04) * float(spikes) / 8.0;
+    }
+
+    // Average confident trend direction
+    float trend = (F0_S*F0_R + F1_S*F1_R + F2_S*F2_R + F3_S*F3_R
+                 + F4_S*F4_R + F5_S*F5_R + F6_S*F6_R + F7_S*F7_R) * 0.125;
+    float t = clamp(trend * 40.0, -1.0, 1.0);
+    fragColor.rgb += (t > 0.0) ? vec3(0.01, 0.003, 0.0) * t
+                                : vec3(0.0, 0.003, 0.01) * abs(t);
+
+    fragColor.rgb *= 1.0 + BEAT_PULSE * 0.1;
+
+    fragColor.rgb = clamp(fragColor.rgb, 0.0, 1.0);
+    fragColor.a = 1.0;
+}

--- a/shaders/wip/claude/chromadepth-regression-graph.frag
+++ b/shaders/wip/claude/chromadepth-regression-graph.frag
@@ -1,0 +1,293 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: chromadepth, graph, regression, fractal, julia, oscilloscope
+// ChromaDepth Regression Oscilloscope — Scrolling fractal-textured waveforms
+// Each line plots a regression slope over time, textured with a Julia set.
+// Line thickness = rSquared (confidence). Color = chromadepth from slope sign.
+// The Julia set c-constant IS the (slope, rSquared) pair, so the fractal
+// texture itself represents the regression data.
+
+// ============================================================================
+// FEATURE DEFINITIONS
+// ============================================================================
+
+#define F1_SLOPE   (energySlope)
+#define F1_RSQUARED (energyRSquared)
+#define F1_ZSCORE  (energyZScore)
+#define F1_NORM    (energyNormalized)
+
+#define F2_SLOPE   (bassSlope)
+#define F2_RSQUARED (bassRSquared)
+#define F2_ZSCORE  (bassZScore)
+#define F2_NORM    (bassNormalized)
+
+#define F3_SLOPE   (trebleSlope)
+#define F3_RSQUARED (trebleRSquared)
+#define F3_ZSCORE  (trebleZScore)
+#define F3_NORM    (trebleNormalized)
+
+#define F4_SLOPE   (spectralCentroidSlope)
+#define F4_RSQUARED (spectralCentroidRSquared)
+#define F4_ZSCORE  (spectralCentroidZScore)
+#define F4_NORM    (spectralCentroidNormalized)
+
+#define F5_SLOPE   (spectralFluxSlope)
+#define F5_RSQUARED (spectralFluxRSquared)
+#define F5_ZSCORE  (spectralFluxZScore)
+#define F5_NORM    (spectralFluxNormalized)
+
+#define F6_SLOPE   (spectralEntropySlope)
+#define F6_RSQUARED (spectralEntropyRSquared)
+#define F6_ZSCORE  (spectralEntropyZScore)
+#define F6_NORM    (spectralEntropyNormalized)
+
+// --- Global accents ---
+#define BEAT_HIT (beat ? 1.0 : 0.0)
+// #define BEAT_HIT 0.0
+
+#define DROP_INTENSITY (max(-energyZScore, 0.0))
+// #define DROP_INTENSITY 0.0
+
+// --- Constants ---
+#define NUM_LINES 6.0
+#define VERTICAL_SCALE 0.18
+#define BASE_WIDTH 6.0
+#define GLOW_RADIUS 12.0
+#define SMOOTH_W 1.0
+#define JULIA_ITER 12
+#define PHI 1.61803398875
+
+// ============================================================================
+// CHROMADEPTH
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.82;
+    float sat = 0.95 - t * 0.08;
+    float lit = 0.55 - t * 0.1;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// MINI JULIA SET — used as line texture
+// Returns 0.0 (inside set) to 1.0 (escaped quickly)
+// ============================================================================
+
+float juliaTexture(vec2 pos, vec2 c) {
+    vec2 z = pos;
+    float minDist = 100.0;
+    for (int i = 0; i < JULIA_ITER; i++) {
+        z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+        // Track orbit trap — distance to origin
+        minDist = min(minDist, length(z));
+        if (dot(z, z) > 4.0) {
+            // Smooth escape count
+            float smooth_i = float(i) - log2(log2(dot(z, z))) + 4.0;
+            return smooth_i / float(JULIA_ITER);
+        }
+    }
+    // Interior: use orbit trap for texture
+    return -minDist * 0.5;
+}
+
+// ============================================================================
+// DRAW A FRACTAL-TEXTURED LINE
+// Returns vec4(color, alpha)
+// ============================================================================
+
+vec4 drawFractalLine(vec2 fragCoord, vec2 res, float slope, float rSq, float zScore,
+                     float norm, float lineCenter, float time, float lineIdx) {
+    vec2 uv = fragCoord / res;
+
+    // Value position: zScore is the PRIMARY vertical driver (oscilloscope-style)
+    // Slope adds a slower trend offset. Baseline wiggle ensures never flat.
+    float baseWiggle = sin(time * (1.3 + lineIdx * 0.4) + lineIdx * PHI) * 0.06
+                     + sin(time * (2.7 + lineIdx * 0.7)) * 0.03;
+    float val = clamp(zScore * 0.8, -0.9, 0.9)
+              + clamp(slope * 10.0, -0.4, 0.4)
+              + (norm - 0.5) * 0.4
+              + baseWiggle;
+    float targetY = lineCenter + val * VERTICAL_SCALE;
+
+    // Distance from pixel to line center (in pixels)
+    float distPx = abs(fragCoord.y - targetY * res.y);
+
+    // Line width: rSquared controls thickness, norm adds some variation
+    float width = BASE_WIDTH * (0.5 + rSq * 1.0 + abs(zScore) * 0.8);
+
+    // Core line
+    float core = smoothstep(width + SMOOTH_W, max(width - SMOOTH_W, 0.0), distPx);
+
+    // Glow around the line
+    float glowR = GLOW_RADIUS * (0.3 + abs(zScore) * 0.5);
+    float glow = smoothstep(glowR, width * 0.5, distPx) * 0.08;
+
+    float alpha = core + glow;
+    if (alpha < 0.01) return vec4(0.0);
+
+    // --- JULIA SET TEXTURE within the line ---
+    // The fractal pattern lives along the line's length (time-based x)
+    // and perpendicular to it (pixel distance from center)
+    // Since we draw 1 column/frame, the x-coordinate advances with time
+    vec2 fractalUV = vec2(
+        time * 0.3 + lineIdx * PHI,
+        (fragCoord.y - targetY * res.y) * 0.25
+    );
+
+    // Z-score warps the fractal space — big audio moments distort the texture
+    fractalUV += vec2(zScore * 0.5, norm * 0.4);
+
+    // The Julia c-constant IS derived from the regression data!
+    // Wandering baseline ensures interesting fractals even with zero audio
+    float baseAngle = time * 0.07 + lineIdx * PHI;
+    vec2 juliaC = vec2(
+        -0.7 + 0.15 * sin(baseAngle) + clamp(slope * 12.0, -0.5, 0.5),
+        0.27 + 0.1 * cos(baseAngle * PHI) + clamp((rSq - 0.5) * 0.8, -0.4, 0.4)
+    );
+
+    float fractal = juliaTexture(fractalUV, juliaC);
+
+    // --- CHROMADEPTH COLOR ---
+    // Each line gets a base hue from its index (spread across the spectrum)
+    // Audio data shifts the hue dynamically around that base
+    float baseDepth = lineIdx / 6.0;  // 0.0 to 0.83 — spread across spectrum
+
+    // zScore shifts color: positive = warmer (toward red), negative = cooler (toward blue)
+    float zShift = -zScore * 0.15;
+
+    // Slope provides slower trend-based shift
+    float slopeShift = clamp(-slope * 8.0, -0.15, 0.15);
+
+    // Normalized value shifts within the hue range
+    float normShift = (norm - 0.5) * 0.1;
+
+    float depthVal = fract(baseDepth + zShift + slopeShift * rSq + normShift);
+
+    // Fractal also modulates depth for textured color
+    float fractalDepthShift = fractal * 0.08;
+    depthVal = clamp(depthVal + fractalDepthShift, 0.0, 1.0);
+
+    vec3 baseColor = chromadepth(depthVal);
+
+    // Fractal modulates brightness — creates the textured look
+    // Use abs(fractal) since negative = orbit trap interior
+    float fractalBright;
+    if (fractal >= 0.0) {
+        // Exterior: smooth gradient from slightly dark to bright
+        fractalBright = 0.5 + fractal * 0.7;
+    } else {
+        // Interior: orbit trap creates subtle dark/bright texture
+        fractalBright = 0.4 + abs(fractal) * 1.5;
+    }
+
+    // Apply fractal brightness and hue shift to color
+    vec3 lineHSL = rgb2hsl(baseColor);
+    // Fractal shifts hue slightly — creates colored texture bands
+    lineHSL.x = fract(lineHSL.x + fractal * 0.05);
+    lineHSL.y = clamp(lineHSL.y * (0.6 + rSq * 0.5), 0.4, 1.0);
+    lineHSL.z *= fractalBright;
+    lineHSL.z = clamp(lineHSL.z + core * 0.08, 0.06, 0.7);
+    vec3 color = hsl2rgb(lineHSL);
+
+    // Z-score intensity boost — brighter during anomalies
+    color *= 1.0 + abs(zScore) * 0.2;
+
+    // Alpha: fade with low confidence
+    alpha *= 0.5 + rSq * 0.5;
+
+    return vec4(color, clamp(alpha, 0.0, 1.0));
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = fragCoord / res;
+
+    // --- SCROLLING BACKGROUND ---
+    // Only draw new data on the rightmost pixel column
+    // Use floor to snap to exact pixel boundary — prevents fractional artifacts
+    float pixelX = floor(fragCoord.x);
+    float lastPixel = floor(res.x) - 1.0;
+
+    if (pixelX < lastPixel) {
+        vec2 prevUV = vec2((fragCoord.x + 1.0) / res.x, uv.y);
+        vec4 prev = getLastFrameColor(prevUV);
+
+        // Fade trails — subtle decay preserves color across screen
+        prev.rgb *= 0.998;
+
+        // Beat: subtle brightness pulse on trails
+        prev.rgb *= 1.0 + BEAT_HIT * 0.015;
+
+        fragColor = prev;
+        return;
+    }
+
+    // --- DRAW NEW COLUMN on rightmost edge ---
+    fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+
+    float time = iTime;
+
+    // Lines positioned from top to bottom with equal spacing
+    // Reversed order: line 6 at top, line 1 at bottom (entropy→energy)
+    // Offset from edges: 0.12 to 0.88 range for breathing room
+
+    // Lines spread evenly from 0.13 to 0.87 (spacing ~0.148)
+    // Top to bottom: entropy, flux, centroid, treble, bass, energy
+
+    // Line 6: Spectral Entropy (top)
+    vec4 l6 = drawFractalLine(fragCoord, res, F6_SLOPE, F6_RSQUARED, F6_ZSCORE,
+                              F6_NORM, 0.87, time, 5.0);
+    fragColor.rgb = mix(fragColor.rgb, l6.rgb, l6.a);
+
+    // Line 5: Spectral Flux
+    vec4 l5 = drawFractalLine(fragCoord, res, F5_SLOPE, F5_RSQUARED, F5_ZSCORE,
+                              F5_NORM, 0.72, time, 4.0);
+    fragColor.rgb = mix(fragColor.rgb, l5.rgb, l5.a);
+
+    // Line 4: Spectral Centroid
+    vec4 l4 = drawFractalLine(fragCoord, res, F4_SLOPE, F4_RSQUARED, F4_ZSCORE,
+                              F4_NORM, 0.58, time, 3.0);
+    fragColor.rgb = mix(fragColor.rgb, l4.rgb, l4.a);
+
+    // Line 3: Treble
+    vec4 l3 = drawFractalLine(fragCoord, res, F3_SLOPE, F3_RSQUARED, F3_ZSCORE,
+                              F3_NORM, 0.43, time, 2.0);
+    fragColor.rgb = mix(fragColor.rgb, l3.rgb, l3.a);
+
+    // Line 2: Bass
+    vec4 l2 = drawFractalLine(fragCoord, res, F2_SLOPE, F2_RSQUARED, F2_ZSCORE,
+                              F2_NORM, 0.28, time, 1.0);
+    fragColor.rgb = mix(fragColor.rgb, l2.rgb, l2.a);
+
+    // Line 1: Energy (bottom)
+    vec4 l1 = drawFractalLine(fragCoord, res, F1_SLOPE, F1_RSQUARED, F1_ZSCORE,
+                              F1_NORM, 0.13, time, 0.0);
+    fragColor.rgb = mix(fragColor.rgb, l1.rgb, l1.a);
+
+    // --- DROP DETECTION ---
+    int spiking = 0;
+    if (abs(F1_ZSCORE) > 0.8) spiking++;
+    if (abs(F2_ZSCORE) > 0.8) spiking++;
+    if (abs(F3_ZSCORE) > 0.8) spiking++;
+    if (abs(F4_ZSCORE) > 0.8) spiking++;
+    if (abs(F5_ZSCORE) > 0.8) spiking++;
+    if (abs(F6_ZSCORE) > 0.8) spiking++;
+
+    // Multi-feature spike: brighten everything
+    if (spiking >= 3) {
+        float intensity = float(spiking) / 6.0;
+        fragColor.rgb = mix(fragColor.rgb, vec3(1.0, 0.9, 0.8), intensity * 0.25);
+    }
+
+    // Drop tint — warm shift
+    fragColor.rgb = mix(fragColor.rgb, fragColor.rgb * vec3(1.1, 0.92, 0.88),
+                        DROP_INTENSITY * 0.05);
+
+    fragColor.rgb = clamp(fragColor.rgb, 0.0, 1.0);
+    fragColor.a = 1.0;
+}


### PR DESCRIPTION
## Summary

19 new ChromaDepth 3D shaders designed for ChromaDepth glasses (red = near, green = mid, blue/violet = far). All are mobile-optimized and audio-reactive.

## Shader Guide

| # | Shader | URL | Description |
|---|--------|-----|-------------|
| 1 | **Mandelbrot Deep Zoom** | [visuals.beadfamous.com/?shader=claude/chromadepth-mandelbrot](https://visuals.beadfamous.com/?shader=claude/chromadepth-mandelbrot&fullscreen=true) | Smooth Mandelbrot with auto-zoom, orbit traps for interior detail |
| 2 | **Sierpinski Tetrahedron** | [visuals.beadfamous.com/?shader=claude/chromadepth-sierpinski](https://visuals.beadfamous.com/?shader=claude/chromadepth-sierpinski&fullscreen=true) | 3D raymarched IFS fractal with cel-shading |
| 3 | **Menger Sponge** | [visuals.beadfamous.com/?shader=claude/chromadepth-menger](https://visuals.beadfamous.com/?shader=claude/chromadepth-menger&fullscreen=true) | Fly-through raymarched box fractal tunnels |
| 4 | **Fractal Kaleidoscope** | [visuals.beadfamous.com/?shader=claude/chromadepth-kaleidoscope](https://visuals.beadfamous.com/?shader=claude/chromadepth-kaleidoscope&fullscreen=true) | UV-folding kaleidoscope with Julia iteration, depth from fold layers |
| 5 | **Hyperbolic Poincaré Disk** | [visuals.beadfamous.com/?shader=claude/chromadepth-hyperbolic](https://visuals.beadfamous.com/?shader=claude/chromadepth-hyperbolic&fullscreen=true) | Hyperbolic tiling — tiles shrink toward edge = natural depth |
| 6 | **Burning Ship** | [visuals.beadfamous.com/?shader=claude/chromadepth-burning-ship](https://visuals.beadfamous.com/?shader=claude/chromadepth-burning-ship&fullscreen=true) | Burning Ship fractal with auto-zoom along the antenna |
| 7 | **Voronoi Crystal Cavern** | [visuals.beadfamous.com/?shader=claude/chromadepth-voronoi](https://visuals.beadfamous.com/?shader=claude/chromadepth-voronoi&fullscreen=true) | Multi-layer Voronoi cells with glowing edges |
| 8 | **Mandelbulb 3D** | [visuals.beadfamous.com/?shader=claude/chromadepth-mandelbulb](https://visuals.beadfamous.com/?shader=claude/chromadepth-mandelbulb&fullscreen=true) | 3D Mandelbrot fractal, raymarched with cel-shading |
| 9 | **Apollonian Gasket** | [visuals.beadfamous.com/?shader=claude/chromadepth-apollonian](https://visuals.beadfamous.com/?shader=claude/chromadepth-apollonian&fullscreen=true) | Nested sphere fractal via inversion — large spheres near, tiny far |
| 10 | **Plasma Fractal** | [visuals.beadfamous.com/?shader=claude/chromadepth-plasma](https://visuals.beadfamous.com/?shader=claude/chromadepth-plasma&fullscreen=true) | Multi-octave plasma, each frequency band = different depth |
| 11 | **Spirograph** | [visuals.beadfamous.com/?shader=claude/chromadepth-spirograph](https://visuals.beadfamous.com/?shader=claude/chromadepth-spirograph&fullscreen=true) | Nested epitrochoid curves with trailing persistence |
| 12 | **Kali Set** | [visuals.beadfamous.com/?shader=claude/chromadepth-kali](https://visuals.beadfamous.com/?shader=claude/chromadepth-kali&fullscreen=true) | Kali fractal filigree with orbit trap depth |
| 13 | **Volumetric Nebula** | [visuals.beadfamous.com/?shader=claude/chromadepth-nebula](https://visuals.beadfamous.com/?shader=claude/chromadepth-nebula&fullscreen=true) | Volume-marched nebula, front gas red, deep blue, background stars |
| 14 | **Coral Reef** | [visuals.beadfamous.com/?shader=claude/chromadepth-coral](https://visuals.beadfamous.com/?shader=claude/chromadepth-coral&fullscreen=true) | Raymarched underwater coral with caustics and bioluminescence |
| 15 | **4D Tesseract** | [visuals.beadfamous.com/?shader=claude/chromadepth-tesseract](https://visuals.beadfamous.com/?shader=claude/chromadepth-tesseract&fullscreen=true) | Projected 4D hypercube rotating in 4th dimension |
| 16 | **Phoenix Fractal** | [visuals.beadfamous.com/?shader=claude/chromadepth-phoenix](https://visuals.beadfamous.com/?shader=claude/chromadepth-phoenix&fullscreen=true) | Phoenix fractal with inertia parameter, asymmetric flowing shapes |
| 17 | **Wave Interference** | [visuals.beadfamous.com/?shader=claude/chromadepth-interference](https://visuals.beadfamous.com/?shader=claude/chromadepth-interference&fullscreen=true) | Moiré wave patterns — constructive = red/near, destructive = blue/far |
| 18 | **Geodesic Sphere** | [visuals.beadfamous.com/?shader=claude/chromadepth-geodesic](https://visuals.beadfamous.com/?shader=claude/chromadepth-geodesic&fullscreen=true) | Nested geodesic shells, outer = red, inner = blue |
| 19 | **Lyapunov Fractal** | [visuals.beadfamous.com/?shader=claude/chromadepth-lyapunov](https://visuals.beadfamous.com/?shader=claude/chromadepth-lyapunov&fullscreen=true) | Edge of chaos — ordered regions pop forward, chaos recedes |

## All shaders feature:
- ChromaDepth 3D depth mapping (red = near, blue = far)
- `@fullscreen: true` and `@mobile: true` metadata
- `#define` swap pattern for audio parameters
- Audio-reactive parameters using z-scores, normalized values, and regression slopes
- Frame feedback effects
- Beat detection responses
- Vignette and color clamping

## Test plan
- [ ] Load each shader via the URLs above
- [ ] Verify chromadepth gradient works with ChromaDepth glasses
- [ ] Test all 19 on mobile devices
- [ ] Verify audio reactivity with microphone input

@redaphid Here's the full collection! 19 chromadepth shaders spanning fractals (Mandelbrot, Julia/Phoenix, Burning Ship, Mandelbulb, Sierpinski, Menger, Apollonian, Kali, Lyapunov), geometric (Tesseract, Geodesic, Hyperbolic tiling, Kaleidoscope, Spirograph), organic (Coral reef, Nebula, Voronoi crystals), and mathematical (Wave interference, Plasma). Each maps depth to the chromadepth spectrum differently. Click any URL in the table above to try them on Cloudflare!

🤖 Generated with [Claude Code](https://claude.com/claude-code)