### PR TITLE
Add persistent seed uniform for per-user uniqueness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,7 @@ vec3 position = vec3(CIRCLE_RADIUS, 0.1, 0.1);
 ```
 
 ### Available Uniforms
+- `seed` - Persistent per-user random float (0-1), stored in localStorage. Override with `?seed=0.42`
 - All audio features (see above)
 - `iTime` - Time in seconds
 - `iResolution` - Screen resolution

--- a/index.js
+++ b/index.js
@@ -1,25 +1,12 @@
 import { AudioProcessor } from './src/audio/AudioProcessor.js'
 import { makeVisualizer } from './src/Visualizer.js'
 import { getInitialShader } from './src/shaderLoader.js'
+import { seed } from './src/seed.js'
 
 const events = ['touchstart', 'touchmove', 'touchstop', 'keydown', 'mousedown', 'resize']
 let ranMain = false
 let startTime = 0
 const params = new URLSearchParams(window.location.search)
-
-const getSeed = () => {
-    const paramSeed = params.get('seed')
-    if (paramSeed !== null) return parseFloat(paramSeed)
-
-    const stored = localStorage.getItem('seed')
-    if (stored !== null) return parseFloat(stored)
-
-    const seed = Math.random()
-    localStorage.setItem('seed', seed.toString())
-    return seed
-}
-
-const seed = getSeed()
 
 const getVisualizerDOMElement = () => {
     if (!window.visualizer) {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,20 @@ let ranMain = false
 let startTime = 0
 const params = new URLSearchParams(window.location.search)
 
+const getSeed = () => {
+    const paramSeed = params.get('seed')
+    if (paramSeed !== null) return parseFloat(paramSeed)
+
+    const stored = localStorage.getItem('seed')
+    if (stored !== null) return parseFloat(stored)
+
+    const seed = Math.random()
+    localStorage.setItem('seed', seed.toString())
+    return seed
+}
+
+const seed = getSeed()
+
 const getVisualizerDOMElement = () => {
     if (!window.visualizer) {
         window.visualizer = document.getElementById('visualizer')
@@ -137,7 +151,8 @@ const parseUrlParams = (searchParams) => {
 
 export const getCranesState = () => {
     return {
-        ...window.cranes.measuredAudioFeatures, // Audio features (lowest precedence)
+        seed,                                   // Persistent per-user seed (lowest precedence)
+        ...window.cranes.measuredAudioFeatures, // Audio features
         ...window.cranes.controllerFeatures,    // Controller-computed features
         ...parseUrlParams(params),              // URL parameters (parsed as numbers or strings)
         ...window.cranes.manualFeatures,        // Manual features

--- a/src/seed.js
+++ b/src/seed.js
@@ -1,0 +1,17 @@
+const STORAGE_KEY = 'seed'
+
+const params = new URLSearchParams(window.location.search)
+
+const findOrCreate = () => {
+    const paramSeed = params.get(STORAGE_KEY)
+    if (paramSeed !== null) return parseFloat(paramSeed)
+
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored !== null) return parseFloat(stored)
+
+    const seed = Math.random()
+    localStorage.setItem(STORAGE_KEY, seed.toString())
+    return seed
+}
+
+export const seed = findOrCreate()


### PR DESCRIPTION
## Summary

- Generates a random float (0–1) on first page visit and persists it in `localStorage`
- Exposes it as a `seed` uniform available to all shaders
- Overridable via `?seed=0.42` URL param for debugging or sharing a specific variation
- Two people at the same show now see related but distinct visuals

### Shader usage
```glsl
uniform float seed;
vec3 color = hsl2rgb(vec3(hue + seed, sat, lum)); // unique palette per device
float angle = seed * TAU;                          // unique geometry offset
```

## Test plan

- [ ] Load a page — confirm `localStorage.getItem('seed')` returns a float 0–1
- [ ] Reload — confirm same seed value persists
- [ ] Add `?seed=0.75` — confirm that value is used instead of stored one
- [ ] Use `seed` uniform in a shader and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)