### PR TITLE
Fix visual restarts on page load from resolution scaling

### DIFF
--- a/src/Visualizer.js
+++ b/src/Visualizer.js
@@ -75,7 +75,7 @@ const calculateResolutionRatio = (frameTime, renderTimes, lastResolutionRatio) =
     const avgFrameTime = renderTimes.reduce((a, b) => a + b) / renderTimes.length
 
     if (avgFrameTime > 50) return Math.max(0.5, lastResolutionRatio - 0.5)
-    if (avgFrameTime < 20 && lastResolutionRatio < 1) return Math.min(1, lastResolutionRatio + 0.1)
+    if (avgFrameTime < 20 && lastResolutionRatio < 1) return Math.min(1, lastResolutionRatio + 0.25)
     return lastResolutionRatio
 }
 
@@ -167,7 +167,10 @@ export const makeVisualizer = async ({ canvas, initialImageUrl, fullscreen }) =>
         const currentTime = performance.now()
         const frameTime = currentTime - lastRender
 
-        const resolutionRatio = calculateResolutionRatio(frameTime, renderTimes, lastResolutionRatio)
+        // Skip resolution scaling during warmup to avoid shader compilation skewing the average
+        const resolutionRatio = frameNumber < 60
+            ? lastResolutionRatio
+            : calculateResolutionRatio(frameTime, renderTimes, lastResolutionRatio)
 
         // Check if canvas display size changed (window resize)
         resizeCanvasToDisplaySize(gl.canvas, lastResolutionRatio)
@@ -205,7 +208,6 @@ export const makeVisualizer = async ({ canvas, initialImageUrl, fullscreen }) =>
             gl.viewport(0, 0, gl.canvas.width, gl.canvas.height)
             lastCanvasWidth = gl.canvas.width
             lastCanvasHeight = gl.canvas.height
-            useInitialTextureAsPrev = true
         }
 
         lastRender = currentTime


### PR DESCRIPTION
## Summary

- **Warmup grace period**: Skip resolution scaling for the first 60 frames (~1s) to prevent shader compilation overhead from triggering a false resolution drop
- **No more hard restarts on resize**: Removed `useInitialTextureAsPrev = true` from the canvas resize handler — framebuffers still clear to black, but the shader continues from a dark frame instead of resetting to the placeholder image
- **Faster ramp-up**: Resolution increases by 0.25 instead of 0.1, recovering in 2 steps (0.5 → 0.75 → 1.0) instead of 5

### What was happening

For expensive shaders (raymarching, fractals), the first frame includes shader compilation (50-200ms), which inflates the 20-frame average past the 50ms threshold. This triggers a resolution drop from 1.0 → 0.5, which resizes the canvas, clears both framebuffers, and forces the shader to restart from the placeholder image. Then as the shader runs fast at low resolution, it ramps back up 0.1 at a time — each step triggering another restart. Up to 6 visual restarts before stabilizing.

## Test plan

- [ ] Load an expensive shader (raymarching/fractal) and verify no visual restarts
- [ ] Load a simple shader and verify no change in behavior
- [ ] Resize the browser window and verify the shader recovers smoothly (brief dark frame, not placeholder image)
- [ ] Test on a slow device to verify resolution scaling still kicks in after warmup

🤖 Generated with [Claude Code](https://claude.com/claude-code)