### PR TITLE
Fix black screen on mobile from audio init failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,25 +86,25 @@ const setupCanvasEvents = (canvas) => {
     canvas.addEventListener('mouseleave', resetTouch);
 };
 
+const noAudio = { getFeatures: () => ({}) }
+
 const setupAudio = async () => {
     // if we have a query param that says 'noaudio=true', just return a dummy audio processor
     if (params.get('noaudio') === 'true' || params.get('embed') === 'true') {
-        return {
-            getFeatures: () => ({
-            })
-        }
+        return noAudio
     }
-    // get the default audio input
-    const devices = await navigator.mediaDevices.enumerateDevices();
-    const audioInputs = devices.filter(device => device.kind === 'audioinput');
-    const defaultAudioInput = audioInputs[0].deviceId
 
     try {
+        // get the default audio input
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const audioInputs = devices.filter(device => device.kind === 'audioinput');
+        const defaultAudioInput = audioInputs[0]?.deviceId
+
         // Get microphone access first
         await navigator.mediaDevices.getUserMedia({
             audio: {
                 ...audioConfig,
-                ...(audioInputs.length > 1 ? { deviceId: { exact: defaultAudioInput } } : {})
+                ...(audioInputs.length > 1 && defaultAudioInput ? { deviceId: { exact: defaultAudioInput } } : {})
             }
         });
         const audioContext = new AudioContext();
@@ -122,6 +122,7 @@ const setupAudio = async () => {
         return audioProcessor;
     } catch (err) {
         console.error('Audio initialization failed:', err);
+        return noAudio
     }
 };
 

--- a/src/Visualizer.js
+++ b/src/Visualizer.js
@@ -106,6 +106,19 @@ export const makeVisualizer = async ({ canvas, initialImageUrl, fullscreen }) =>
         }
     })
 
+    if (!gl) {
+        console.error('WebGL2 not available')
+        return () => {}
+    }
+
+    // Recover from GPU context loss (common on mobile)
+    canvas.addEventListener('webglcontextlost', (e) => {
+        e.preventDefault()
+    })
+    canvas.addEventListener('webglcontextrestored', () => {
+        window.location.reload()
+    })
+
     if (fullscreen) {
         const width = window.innerWidth
         const height = window.innerHeight


### PR DESCRIPTION
When setupAudio() failed (mic permission denied/delayed), it returned undefined. The render loop then crashed every frame on audio.getFeatures(), permanently preventing any visuals from appearing.

- Move enumerateDevices/deviceId access inside try/catch (was outside it)
- Return noAudio fallback from catch block instead of undefined
- Add optional chaining on audioInputs[0]?.deviceId
- Add WebGL2 null check and context loss/restore handlers