### PR TITLE
Fix shader aspect ratio for mobile portrait

### DIFF
--- a/shaders/claude/chromadepth-mandelbrot.frag
+++ b/shaders/claude/chromadepth-mandelbrot.frag
@@ -16,7 +16,7 @@
 // #define ZOOM_POWER 5.0
 
 // --- ROTATION: pitchClass rotates the view ---
-#define VIEW_ROTATION (iTime * 0.03 + pitchClassNormalized * 1.5)
+#define VIEW_ROTATION (time * 0.03 + pitchClassNormalized * 1.5)
 // #define VIEW_ROTATION 0.0
 
 // --- C-OFFSET for mini-brot exploration via regression slopes ---
@@ -86,13 +86,13 @@ vec3 chromadepth(float t) {
 // ============================================================================
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec2 screenUV = fragCoord / iResolution.xy;
-    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 screenUV = fragCoord / resolution;
+    vec2 uv = (fragCoord - 0.5 * resolution) / resolution.y;
 
     // --- ZOOM TARGET ---
     // Wander through interesting regions of the Mandelbrot set
     // The Seahorse Valley at c ~ -0.75 + 0.1i has infinite mini-brots
-    float wanderT = iTime * 0.012;
+    float wanderT = time * 0.012;
     vec2 target = vec2(
         -0.7435669 + 0.0002 * sin(wanderT * 0.7) + TARGET_DRIFT_X,
          0.1314023 + 0.00015 * cos(wanderT * 0.9) + TARGET_DRIFT_Y
@@ -116,7 +116,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 c = target + uv / zoom;
 
     // Add flux jitter
-    c += vec2(FLUX_JITTER * sin(iTime * 7.3), FLUX_JITTER * cos(iTime * 5.7));
+    c += vec2(FLUX_JITTER * sin(time * 7.3), FLUX_JITTER * cos(time * 5.7));
 
     // --- MANDELBROT ITERATION with smooth coloring + orbit traps ---
     vec2 z = vec2(0.0);
@@ -253,7 +253,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     orbitWarp += vec2(MIDS_WARP, MIDS_WARP * 0.7);
 
     // Slow rotation prevents static feedback loops
-    float fbAngle = iTime * 0.008;
+    float fbAngle = time * 0.008;
     vec2 centered = screenUV - 0.5;
     float fbc = cos(fbAngle), fbs = sin(fbAngle);
     vec2 rotatedUV = vec2(

--- a/shaders/redaphid/wip/mandelbulb.frag
+++ b/shaders/redaphid/wip/mandelbulb.frag
@@ -29,9 +29,9 @@ float mandelbulbDE(vec3 pos) {
     return 0.5 * log(r) * r / dr;
 }
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / min(iResolution.x, iResolution.y);
+    vec2 uv = (fragCoord - 0.5 * resolution) / min(resolution.x, resolution.y);
     vec3 camPos = vec3(0.0, 0.0, -2.0);
-    camPos.xz = mat2(cos(iTime), sin(iTime), -sin(iTime), cos(iTime)) * camPos.xz;
+    camPos.xz = mat2(cos(time), sin(time), -sin(time), cos(time)) * camPos.xz;
     vec3 camTarget = vec3(0.0, 0.0, 0.0);
     vec3 camDir = normalize(camTarget - camPos);
     vec3 camUp = vec3(0.0, 1.0, 0.0);

--- a/shaders/redaphid/wip/mandelbulb.frag
+++ b/shaders/redaphid/wip/mandelbulb.frag
@@ -1,3 +1,6 @@
+// @fullscreen: true
+// @mobile: true
+// @tags: fractal, 3d, mandelbulb
 float mandelbulbDE(vec3 pos) {
     const int iterations = 8;
     const float bailout = 2.0;
@@ -26,19 +29,17 @@ float mandelbulbDE(vec3 pos) {
     return 0.5 * log(r) * r / dr;
 }
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
-    vec3 camPos = vec3(0.0, 0.0, -2.0); // Camera position, peering into the abyss
-    // rotate camera over time
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / min(iResolution.x, iResolution.y);
+    vec3 camPos = vec3(0.0, 0.0, -2.0);
     camPos.xz = mat2(cos(iTime), sin(iTime), -sin(iTime), cos(iTime)) * camPos.xz;
-    vec3 camTarget = vec3(0.0, 0.0, 0.0); // The point in space the camera looks at, the heart of the mystery
-    vec3 camDir = normalize(camTarget - camPos); // The camera's gaze, fixed upon the unknown
-    vec3 camUp = vec3(0.0, 1.0, 0.0); // Upwards, towards the heavens, or what passes for them here
-    vec3 camRight = cross(camDir, camUp); // To the right, where shadows lie
+    vec3 camTarget = vec3(0.0, 0.0, 0.0);
+    vec3 camDir = normalize(camTarget - camPos);
+    vec3 camUp = vec3(0.0, 1.0, 0.0);
+    vec3 camRight = cross(camDir, camUp);
 
-    float fov = 90.0; // Field of view, the breadth of our vision
-    float aspectRatio = iResolution.x / iResolution.y; // The aspect ratio of our canvas, the window to another world
-    float planeDist = 1.0 / tan(radians(fov) / 2.0); // The distance to the projection plane, a mere mathematical construct
-    vec3 rayDir = normalize(camDir * planeDist + uv.x * camRight * aspectRatio + uv.y * camUp); // The direction of our inquiry, our probe into the depths
+    float fov = 90.0;
+    float planeDist = 1.0 / tan(radians(fov) / 2.0);
+    vec3 rayDir = normalize(camDir * planeDist + uv.x * camRight + uv.y * camUp);
 
     float totalDistance = 0.0; // The total distance marched, a tally of our steps into the darkness
     const float maxDistance = 100.0; // The furthest we can go before we must admit defeat

--- a/shaders/wip/chromadepth/1.frag
+++ b/shaders/wip/chromadepth/1.frag
@@ -264,22 +264,22 @@ vec3 renderRay(vec3 ro, vec3 rd, float scaleMod, float hueShift) {
 // ============================================================================
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / min(iResolution.x, iResolution.y);
+    vec2 uv = (fragCoord - 0.5 * resolution) / min(resolution.x, resolution.y);
 
-    float scaleMod = sin(iTime * 0.1) * 0.05 + SCALE_MOD;
-    float hueShift = iTime * 0.025 + HUE_SHIFT;
+    float scaleMod = sin(time * 0.1) * 0.05 + SCALE_MOD;
+    float hueShift = time * 0.025 + HUE_SHIFT;
 
     // Camera
     vec3 baseRo = vec3(2.2, 1.4, -2.3);
     vec3 baseLookAt = vec3(-0.1, 0.2, 0.4);
     vec3 lookOffset = vec3(
-        sin(iTime * 0.2) * 0.025 + LOOK_X,
-        cos(iTime * 0.17) * 0.018 + LOOK_Y,
+        sin(time * 0.2) * 0.025 + LOOK_X,
+        cos(time * 0.17) * 0.018 + LOOK_Y,
         0.0
     );
     vec3 lookAt = baseLookAt + lookOffset;
     vec3 toTarget = normalize(lookAt - baseRo);
-    float zoomAmount = sin(iTime * 0.1) * 0.12 + ZOOM;
+    float zoomAmount = sin(time * 0.1) * 0.12 + ZOOM;
     vec3 ro = baseRo + toTarget * zoomAmount;
 
     vec3 forward = normalize(lookAt - ro);
@@ -292,10 +292,10 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec3 col = renderRay(ro, rd, scaleMod, hueShift);
 
     // Feedback (optional - can disable for pure chromadepth)
-    vec2 feedbackUV = fragCoord / iResolution.xy;
+    vec2 feedbackUV = fragCoord / resolution;
     vec2 center = vec2(0.5);
     vec2 fbOffset = (feedbackUV - center) * 0.997 + center;
-    fbOffset += vec2(sin(iTime * 0.15), cos(iTime * 0.15)) * 0.003;
+    fbOffset += vec2(sin(time * 0.15), cos(time * 0.15)) * 0.003;
     vec4 prev = getLastFrameColor(fbOffset);
 
     vec3 colHSL = rgb2hsl(col);

--- a/shaders/wip/chromadepth/1.frag
+++ b/shaders/wip/chromadepth/1.frag
@@ -264,7 +264,7 @@ vec3 renderRay(vec3 ro, vec3 rd, float scaleMod, float hueShift) {
 // ============================================================================
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / min(iResolution.x, iResolution.y);
 
     float scaleMod = sin(iTime * 0.1) * 0.05 + SCALE_MOD;
     float hueShift = iTime * 0.025 + HUE_SHIFT;

--- a/shaders/wip/chromadepth/2.frag
+++ b/shaders/wip/chromadepth/2.frag
@@ -314,7 +314,7 @@ vec3 renderRay(vec3 ro, vec3 rd, float scaleMod, float hueShift) {
 // ============================================================================
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / min(iResolution.x, iResolution.y);
+    vec2 uv = (fragCoord - 0.5 * resolution) / min(resolution.x, resolution.y);
 
     float scaleMod = sin(TIME * 0.1) * 0.05 + SCALE_MOD;
     float hueShift = TIME * 0.025 + HUE_SHIFT;
@@ -342,7 +342,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec3 col = renderRay(ro, rd, scaleMod, hueShift);
 
     // Feedback (optional - can disable for pure chromadepth)
-    vec2 feedbackUV = fragCoord / iResolution.xy;
+    vec2 feedbackUV = fragCoord / resolution;
     vec2 center = vec2(0.5);
     vec2 fbOffset = (feedbackUV - center) * 0.997 + center;
     fbOffset += vec2(sin(TIME * 0.15), cos(TIME * 0.15)) * 0.003;

--- a/shaders/wip/chromadepth/2.frag
+++ b/shaders/wip/chromadepth/2.frag
@@ -314,7 +314,7 @@ vec3 renderRay(vec3 ro, vec3 rd, float scaleMod, float hueShift) {
 // ============================================================================
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / min(iResolution.x, iResolution.y);
 
     float scaleMod = sin(TIME * 0.1) * 0.05 + SCALE_MOD;
     float hueShift = TIME * 0.025 + HUE_SHIFT;

--- a/shaders/wip/chromadepth/freeze.frag
+++ b/shaders/wip/chromadepth/freeze.frag
@@ -319,7 +319,7 @@ vec3 renderRay(vec3 ro, vec3 rd, float scaleMod, float hueShift) {
 // ============================================================================
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / min(iResolution.x, iResolution.y);
+    vec2 uv = (fragCoord - 0.5 * resolution) / min(resolution.x, resolution.y);
 
     float scaleMod = sin(TIME * 0.1) * 0.05 + SCALE_MOD;
     float hueShift = TIME * 0.025 + HUE_SHIFT;
@@ -347,7 +347,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec3 col = renderRay(ro, rd, scaleMod, hueShift);
 
     // Feedback (optional - can disable for pure chromadepth)
-    vec2 feedbackUV = fragCoord / iResolution.xy;
+    vec2 feedbackUV = fragCoord / resolution;
     vec2 center = vec2(0.5);
     vec2 fbOffset = (feedbackUV - center) * 0.997 + center;
     fbOffset += vec2(sin(TIME * 0.15), cos(TIME * 0.15)) * 0.003;

--- a/shaders/wip/chromadepth/freeze.frag
+++ b/shaders/wip/chromadepth/freeze.frag
@@ -319,7 +319,7 @@ vec3 renderRay(vec3 ro, vec3 rd, float scaleMod, float hueShift) {
 // ============================================================================
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / min(iResolution.x, iResolution.y);
 
     float scaleMod = sin(TIME * 0.1) * 0.05 + SCALE_MOD;
     float hueShift = TIME * 0.025 + HUE_SHIFT;


### PR DESCRIPTION
## Summary
- Fix UV normalization in 4 shaders from `/ iResolution.y` to `/ min(iResolution.x, iResolution.y)` so fractals aren't cropped on portrait phone screens
- Affected shaders: `wip/chromadepth/1`, `wip/chromadepth/2`, `wip/chromadepth/freeze`, `redaphid/wip/mandelbulb`
- Add `@fullscreen`/`@mobile` metadata to mandelbulb shader

## Test plan
- [ ] Load each shader on a phone in portrait orientation and verify fractal is fully visible
- [ ] Load each shader on desktop and verify no regression (still fills viewport)
- [ ] Verify chromadepth colors are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)