### PR TITLE
Enforce pnpm as the only package manager

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -22,11 +22,15 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             # Build and publish VS Code extension
+            - uses: pnpm/action-setup@v4
+              with:
+                  version: latest
+
             - name: Install dependencies
-              run: cd ./vscode-extension && npm clean-install
+              run: cd ./vscode-extension && pnpm install --frozen-lockfile
 
             - name: Build extension
-              run: cd ./vscode-extension && npm run build
+              run: cd ./vscode-extension && pnpm build
 
             - name: Publish to VS Code Marketplace
               run: cd ./vscode-extension && npx vsce publish -p ${{ secrets.VSCE_PAT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,7 @@ window.cranes.manualFeatures.fft_size = 8192
 The system supports controlling a remote display from another device (phone, laptop, etc.) via WebSocket.
 
 ### Setup
-1. Start the dev server with WebSocket support: `npm run dev`
+1. Start the dev server with WebSocket support: `pnpm dev`
 2. Open the **display** (TV/projector): `http://localhost:6969/?remote=display`
 3. Open the **controller** (phone/laptop):
    - List page: `http://localhost:6969/list.html?remote=control`
@@ -422,8 +422,8 @@ paramsManager.setShader(code)      // Syncs shader to remote
 
 ### Local Development
 ```bash
-npm install
-npm run dev  # Serves on localhost:6969
+pnpm install
+pnpm dev  # Serves on localhost:6969
 ```
 
 ### Creating Visualizations

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The other half of the project is a sort of "art project" where you make bead bra
 
 If you've done web development before, the following steps should be pretty familiar.
 
-1. `npm install`
-2. `npm run dev`
+1. `pnpm install`
+2. `pnpm dev`
 
 This will serve beadfamous on localhost:6969
 

--- a/docs/MAKING_A_NEW_SHADER.md
+++ b/docs/MAKING_A_NEW_SHADER.md
@@ -518,7 +518,7 @@ float smin(float a, float b, float k) {
 ### Local Development
 
 ```bash
-npm run dev  # Starts server on localhost:6969
+pnpm dev  # Starts server on localhost:6969
 ```
 
 Access your shader: `http://localhost:6969/?shader=your-shader-name`

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "format": "eslint --fix .",
     "delete": "node scripts/delete-shader.js",
-    "delete:interactive": "node scripts/delete-shader.js --interactive"
+    "delete:interactive": "node scripts/delete-shader.js --interactive",
+    "preinstall": "npx only-allow pnpm"
   },
   "author": "hypnodroid",
   "license": "UNLICENSED",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/src/audio/AudioProcessor.js",
   "scripts": {
-    "start": "npm run dev",
+    "start": "pnpm dev",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "vite build",
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Adds a `preinstall` script (`npx only-allow pnpm`) to `package.json` that prevents installing dependencies with `npm` or `yarn`

## Test plan
- [ ] Run `pnpm install` — should succeed
- [ ] Run `npm install` — should fail with an error message
- [ ] Run `yarn install` — should fail with an error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)