### PR TITLE
feat: Cloudflare relay for remote control

### DIFF
--- a/src/remote/WebSocketClient.js
+++ b/src/remote/WebSocketClient.js
@@ -1,3 +1,24 @@
+const DEFAULT_RELAY_HOST = 'paper-cranes-remote.redaphid.workers.dev'
+
+/**
+ * Get the WebSocket URL for remote control.
+ * Uses the Cloudflare relay when a `room` param is present,
+ * otherwise falls back to the local dev server.
+ */
+const getWsUrl = () => {
+  const params = new URLSearchParams(window.location.search)
+  const room = params.get('room')
+
+  if (room) {
+    const relayHost = params.get('relay') || DEFAULT_RELAY_HOST
+    return `wss://${relayHost}/ws/${encodeURIComponent(room)}`
+  }
+
+  // Fallback: local dev server (existing behavior)
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${window.location.host}/ws`
+}
+
 /**
  * Robust WebSocket client with auto-reconnect
  */
@@ -16,9 +37,8 @@ export class WebSocketClient {
 
     this.isIntentionallyClosed = false
 
-    // Connect to same origin WebSocket at /ws path
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const wsUrl = `${protocol}//${window.location.host}/ws`
+    const wsUrl = getWsUrl()
+    console.log('[Remote] Connecting to', wsUrl)
 
     try {
       this.socket = new WebSocket(wsUrl)


### PR DESCRIPTION
## Summary

- When `?room=my-show` is in the URL, the WebSocket client connects to the Cloudflare Durable Object relay (`wss://paper-cranes-remote.redaphid.workers.dev/ws/<room>`) instead of the local dev server
- Without `?room`, behavior is completely unchanged (local `/ws` fallback for dev)
- Optional `?relay=custom-host` param to override the relay host
- Only `src/remote/WebSocketClient.js` is modified — no changes to RemoteController, RemoteDisplay, ParamsManager, or any page entry points

## Usage

```
# Display at venue
https://visuals.beadfamous.com/?shader=plasma&remote=display&room=my-show

# Controller on phone
https://visuals.beadfamous.com/list.html?remote=control&room=my-show
```

## Backend

The relay service lives in a separate repo ([paper-cranes-remote](https://github.com/redaphid/paper-cranes-remote)) — a Cloudflare Worker + Durable Object that broadcasts WebSocket messages between clients in the same room.

## Test plan

- [ ] Verify `?remote=display&room=test` connects to the relay
- [ ] Verify `?remote=control&room=test` can send commands through the relay
- [ ] Verify no `?room` param still uses local dev server WebSocket
- [ ] Verify `?relay=localhost:8787` override works for local relay testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)