### PR TITLE
feat: pop-out editor into separate window

### DIFF
--- a/edit.css
+++ b/edit.css
@@ -372,3 +372,16 @@ input[type="number"] {
 #existing-features-editor {
   margin-top: 6px;
 }
+
+/* Editor popped out state */
+body.editor-popped-out #monaco-editor {
+  display: none;
+}
+
+body.editor-popped-out #save-and-publish {
+  display: none;
+}
+
+body.editor-popped-out #visualizer-container {
+  width: 100vw;
+}

--- a/edit.html
+++ b/edit.html
@@ -20,6 +20,7 @@
             Publish
         </button>
         <button id="reset">Reset</button>
+        <button id="popout" title="Pop out editor to separate window">Pop Out</button>
     </div>
     <div id="monaco-editor"></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs/loader.min.js"></script>

--- a/editor-popup.html
+++ b/editor-popup.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>Paper Cranes - Editor</title>
+    <link rel="stylesheet" data-name="vs/editor/editor.main"
+        href="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs/editor/editor.main.min.css">
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            height: 100vh;
+            overflow: hidden;
+            background: #1e1e1e;
+            font-family: system-ui, -apple-system, sans-serif;
+        }
+
+        #toolbar {
+            display: flex;
+            gap: 8px;
+            padding: 6px 12px;
+            background: #252526;
+            border-bottom: 1px solid #3c3c3c;
+            align-items: center;
+            height: 24px;
+        }
+
+        #toolbar button {
+            padding: 3px 10px;
+            font-size: 12px;
+            cursor: pointer;
+            background: #0e639c;
+            color: white;
+            border: none;
+            border-radius: 3px;
+        }
+
+        #toolbar button:hover {
+            background: #1177bb;
+        }
+
+        #connection-status {
+            margin-left: auto;
+            font-size: 11px;
+            color: #666;
+        }
+
+        #connection-status.connected {
+            color: #22c55e;
+        }
+
+        #monaco-editor {
+            width: 100%;
+            height: calc(100vh - 36px);
+        }
+    </style>
+</head>
+
+<body>
+    <div id="toolbar">
+        <button id="save">Save (Ctrl+S)</button>
+        <span id="connection-status">Connecting...</span>
+    </div>
+    <div id="monaco-editor"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs/loader.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs/editor/editor.main.js"></script>
+    <script type="module" src="./editor-popup.js"></script>
+    <script type="module" src="./src/monaco.js"></script>
+</body>
+
+</html>

--- a/editor-popup.js
+++ b/editor-popup.js
@@ -1,0 +1,48 @@
+// BroadcastChannel for communicating with the main editor window
+const channel = new BroadcastChannel('paper-cranes-editor')
+
+const updateStatus = (text, connected = true) => {
+    const el = document.getElementById('connection-status')
+    if (!el) return
+    el.textContent = text
+    el.className = connected ? 'connected' : ''
+}
+
+// Create a paramsManager shim that broadcasts shader changes to the main window
+window.paramsManager = {
+    setShader(code) {
+        localStorage.setItem('cranes-manual-code', code)
+        channel.postMessage({ type: 'shader-update', code })
+        updateStatus('Saved')
+        setTimeout(() => updateStatus('Connected'), 1500)
+    },
+    set() {},
+    setMany() {},
+    delete() {},
+    getAll() { return {} },
+}
+
+// Set up minimal cranes object so monaco.js error checking works
+window.cranes = window.cranes || { shader: null, error: null }
+
+// Listen for messages from the main window
+channel.addEventListener('message', (e) => {
+    if (e.data.type === 'editor-sync') {
+        const editor = window.monaco?.editor?.getEditors?.()?.[0]
+        if (editor && e.data.code) {
+            editor.pushUndoStop()
+            editor.setValue(e.data.code)
+            editor.pushUndoStop()
+        }
+        updateStatus('Connected')
+    }
+})
+
+// Tell the main window we're ready
+channel.postMessage({ type: 'popup-ready' })
+updateStatus('Connected')
+
+// Notify when closing
+window.addEventListener('beforeunload', () => {
+    channel.postMessage({ type: 'popup-closed' })
+})

--- a/src/monaco.js
+++ b/src/monaco.js
@@ -595,7 +595,7 @@ async function init() {
         editor.pushUndoStop()
     }
 
-    document.querySelector('#save').addEventListener('click', save)
+    document.querySelector('#save')?.addEventListener('click', save)
 
     // Add keyboard event listeners
     document.addEventListener('keydown', (e) => {
@@ -622,7 +622,7 @@ async function init() {
         }
     })
 
-    document.querySelector('#reset').addEventListener('click', () => {
+    document.querySelector('#reset')?.addEventListener('click', () => {
         localStorage.removeItem('cranes-manual-code');
         window.location.reload();
     });
@@ -652,7 +652,7 @@ async function init() {
         return code
     }
 
-    document.querySelector('#publish').addEventListener('click', () => {
+    document.querySelector('#publish')?.addEventListener('click', () => {
         const shaderCode = getShaderWithInstructions(editor.getValue())
         const filename = getFilename(shaderCode)
         const repoName = getRepoName(shaderCode)

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,6 +28,7 @@ export default defineConfig({
         edit: resolve(import.meta.dirname, 'edit.html'),
         list: resolve(import.meta.dirname, 'list.html'),
         analyze: resolve(import.meta.dirname, 'analyze.html'),
+        'editor-popup': resolve(import.meta.dirname, 'editor-popup.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary

- Adds a "Pop Out" button to the editor toolbar (and Ctrl+Shift+E shortcut) that opens the Monaco editor in a separate browser window
- When popped out, the main window's visualizer expands to fullscreen and the inline editor hides
- The popped-out editor sends shader changes back to the main window via BroadcastChannel, so edits update the visualization in real-time
- Closing the popup automatically restores the inline editor with the latest code

### Changes
- **New files**: `editor-popup.html` / `editor-popup.js` — standalone editor window with Monaco and BroadcastChannel communication
- **edit.html/js/css** — pop-out button, BroadcastChannel handler, `.editor-popped-out` layout styles
- **src/monaco.js** — optional chaining on `querySelector` calls so it works safely in the popup context
- **vite.config.js** — added `editor-popup` as a build entry point

| Page | Link |
|------|------|
| Edit page | [preview](https://pop-out-editor.paper-cranes-visuals.pages.dev/edit.html) |

## Test plan

- [ ] Open `/edit.html` and verify the "Pop Out" button appears in the toolbar
- [ ] Click "Pop Out" — editor opens in new window, main window goes fullscreen with visualizer
- [ ] Edit shader in popup and press Ctrl+S — verify main window visualization updates
- [ ] Close the popup window — verify inline editor restores with the latest code
- [ ] Test Ctrl+Shift+E shortcut triggers pop-out
- [ ] Clicking "Pop Out" again while popup is open should focus the existing popup
- [ ] Verify remote control mode (`?remote=control`) still works alongside pop-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)