### PR TITLE
fix: improve rapid tap detection on iOS

### DIFF
--- a/index.css
+++ b/index.css
@@ -8,6 +8,7 @@ body {
   justify-content: center;
   align-items: center;
   user-select: none;
+  touch-action: manipulation; /* Disable double-tap-to-zoom so rapid taps work on iOS */
   background-color: #000000;
 }
 canvas {

--- a/index.html
+++ b/index.html
@@ -73,9 +73,9 @@
       }
       window.location.href = 'https://instagram.com/redaphid'
     }
-    // click works on desktop, touchend works on mobile (click is delayed/swallowed on canvas)
+    // click works on desktop, touchstart works on mobile (fires before gesture recognizers can swallow it)
     document.addEventListener('click', onTap)
-    document.addEventListener('touchend', onTap)
+    document.addEventListener('touchstart', onTap)
     </script>
     <script type="module" src="./src/worker-communication.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- Adds `touch-action: manipulation` CSS to prevent iOS from interpreting rapid taps as double-tap-to-zoom gestures
- Switches from `touchend` to `touchstart` so taps register before iOS gesture recognizers can interfere

## Context
The 9-tap system (for PWA install / Instagram easter egg) doesn't work on iPhones. The most likely cause is iOS's double-tap-to-zoom swallowing rapid touch events. `touch-action: manipulation` is the [documented fix](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) for disabling double-tap-to-zoom while preserving pinch-zoom and panning.

## Test plan
- [ ] Test on an iPhone: tap rapidly 9 times — should open Instagram
- [ ] Verify desktop Chrome still works (click events)
- [ ] Verify Android still works (touchstart events)

Preview: [fix-iphone-instagram](https://fix-iphone-instagram.paper-cranes-visuals.pages.dev/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)