### PR TITLE
feat: ChromaDepth heart shaders for Nella

### DIFF
--- a/shaders/nella/heart/cobalt-glow.frag
+++ b/shaders/nella/heart/cobalt-glow.frag
@@ -1,0 +1,285 @@
+// @fullscreen: true
+// @mobile: true
+// @favorite: true
+// @tags: heart, chromadepth, 3d, fractal, kali, love, pulse, blue
+// ChromaDepth Kali Heart — Cobalt Glow
+// Deep cobalt blue background with a radial glow gradient — brighter
+// blue-violet radiates outward from behind the heart like a halo,
+// fading to deep dark cobalt at the edges. The heart sits in a pool
+// of its own warm light against the cold blue void. All oklab.
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS
+// ============================================================================
+
+#define HEART_BREATH (1.0 + bassZScore * 0.08)
+#define KALI_X (0.78 + trebleZScore * 0.02)
+#define KALI_Y (0.82 + spectralCentroidSlope * 12.0 * spectralCentroidRSquared * 0.04)
+#define KALI_Z (0.68 + spectralEntropyNormalized * 0.2)
+#define INNER_ZOOM (2.5 + energyNormalized * 1.5)
+#define INNER_ROT (iTime * 0.06 + pitchClassNormalized * 0.4)
+#define EDGE_GLOW_STRENGTH (0.3 + max(spectralFluxZScore, 0.0) * 0.4)
+#define BRIGHT_MOD (0.8 + energyZScore * 0.15)
+#define BEAT_THROB (beat ? 1.06 : 1.0)
+#define BEAT_FLASH (beat ? 1.2 : 1.0)
+#define DROP_INTENSITY (max(-energyZScore, 0.0))
+#define HUE_SHIFT (spectralSpreadNormalized * 0.08)
+#define ROUGHNESS_SAT (0.88 + spectralRoughnessNormalized * 0.12)
+#define TREND_CONFIDENCE (energyRSquared * 0.5 + bassRSquared * 0.3 + spectralCentroidRSquared * 0.2)
+#define PAN_MOD (midsZScore * 0.02)
+
+// ============================================================================
+// BACKGROUND HEARTS
+// ============================================================================
+#define ENERGY_TREND_SIGNAL clamp(energySlope * 12.0 * energyRSquared, -1.0, 1.0)
+#define BASS_PRESENCE bassNormalized
+#define FLUX_TREND clamp(spectralFluxSlope * 10.0 * spectralFluxRSquared, 0.0, 1.0)
+#define TEXTURE_LEVEL (spectralRoughnessNormalized * 0.5 + spectralEntropyNormalized * 0.5)
+#define BASS_CHARACTER (bassZScore - energyZScore * 0.7)
+#define BG_BASE 0.12
+#define BG_INTENSITY (BG_BASE \
+    + clamp(ENERGY_TREND_SIGNAL, 0.0, 0.35) \
+    + BASS_PRESENCE * 0.15 \
+    + FLUX_TREND * 0.2 \
+    + TEXTURE_LEVEL * 0.1 \
+    + max(BASS_CHARACTER, 0.0) * 0.12)
+#define BG_HEART_GRID 5.0
+#define BG_HEART_SIZE (0.07 + BASS_PRESENCE * 0.04)
+#define BG_DRIFT (0.04 + FLUX_TREND * 0.06)
+#define HEART_WARMTH spectralRoughnessNormalized
+#define HEART_ROT_MOD spectralCentroidNormalized
+
+// Halo glow: energy drives the blue halo brightness behind the heart
+#define HALO_BRIGHTNESS (0.3 + energyNormalized * 0.25)
+// #define HALO_BRIGHTNESS 0.4
+
+// Halo size: mids widen the glow pool
+#define HALO_SIZE (0.6 + midsNormalized * 0.3)
+// #define HALO_SIZE 0.75
+
+#define PI 3.14159265359
+#define KALI_ITER 10
+#define PHI 1.61803398875
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+float dot2(vec2 v) { return dot(v, v); }
+
+mat2 rot2(float a) {
+    float s = sin(a), c = cos(a);
+    return mat2(c, -s, s, c);
+}
+
+float hash21(vec2 p) {
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+}
+
+vec2 hash22(vec2 p) {
+    return vec2(hash21(p), hash21(p + 17.3));
+}
+
+float sdHeart(vec2 p) {
+    p.x = abs(p.x);
+    p.y += 0.6;
+    if (p.y + p.x > 1.0)
+        return sqrt(dot2(p - vec2(0.25, 0.75))) - sqrt(2.0) / 4.0;
+    return sqrt(min(dot2(p - vec2(0.0, 1.0)),
+                dot2(p - 0.5 * max(p.x + p.y, 0.0)))) * sign(p.x - p.y);
+}
+
+// ============================================================================
+// CHROMADEPTH (oklab)
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = 0.4 + t * 4.5;
+    float L = 0.72 - t * 0.15;
+    float C = 0.2 - t * 0.04;
+    return max(oklab2rgb(vec3(L, C * cos(hue), C * sin(hue))), vec3(0.0));
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    // Heart transform
+    vec2 heartUV = uv;
+    heartUV.y += 0.05;
+    float heartScale = 0.55 * HEART_BREATH * BEAT_THROB;
+    heartUV /= max(heartScale, 0.01);
+    float heartD = sdHeart(heartUV);
+
+    // Deep cobalt background with radial halo glow behind the heart
+    float distFromCenter = length(uv - vec2(0.0, 0.05)); // centered on heart
+
+    // Edge cobalt: deep dark blue
+    vec3 bgEdge = vec3(0.1, -0.02, -0.08); // deep cobalt in oklab
+
+    // Halo: brighter blue-violet radiating from heart center
+    float haloFalloff = smoothstep(HALO_SIZE, 0.0, distFromCenter);
+    float haloStrength = haloFalloff * haloFalloff * HALO_BRIGHTNESS;
+    vec3 bgHalo = vec3(0.25, 0.0, -0.1); // brighter blue-violet
+
+    vec3 bgOk = mix(bgEdge, bgHalo, haloStrength);
+    // Beat gently brightens the halo
+    bgOk.x += float(beat) * 0.02 * haloFalloff;
+
+    vec3 col = max(oklab2rgb(bgOk), vec3(0.0));
+
+    if (heartD < 0.0) {
+        // === INSIDE THE HEART: Kali fractal ===
+        vec2 fracUV = heartUV * 0.7;
+        float fAngle = INNER_ROT;
+        float fca = cos(fAngle), fsa = sin(fAngle);
+        fracUV = mat2(fca, -fsa, fsa, fca) * fracUV;
+        fracUV *= INNER_ZOOM;
+        fracUV += vec2(PAN_MOD, PAN_MOD * 0.7);
+
+        float wt = iTime * 0.025;
+        vec3 kaliParam = vec3(
+            KALI_X + 0.12 * sin(wt * 1.0) + 0.06 * cos(wt * PHI * 0.5),
+            KALI_Y + 0.1 * sin(wt * 0.7 * PHI),
+            KALI_Z + 0.08 * sin(wt * 0.9) + 0.05 * cos(wt * PHI * 0.7)
+        );
+
+        float dropJolt = DROP_INTENSITY * (1.0 - TREND_CONFIDENCE) * 0.1;
+        kaliParam.x += sin(iTime * 3.7) * dropJolt;
+        kaliParam.y += cos(iTime * 2.3) * dropJolt;
+        kaliParam = clamp(kaliParam, vec3(0.35), vec3(1.35));
+
+        vec3 p = vec3(fracUV, 0.5 + spectralEntropyNormalized * 0.2);
+        float trapOrigin = 1e10;
+        float trapAxis = 1e10;
+        float accumGlow = 0.0;
+        float accumDepth = 0.0;
+
+        for (int i = 0; i < KALI_ITER; i++) {
+            p = abs(p);
+            float d = max(dot(p, p), 0.001);
+            p = p / d - kaliParam;
+            float dist = length(p);
+            trapOrigin = min(trapOrigin, dist);
+            trapAxis = min(trapAxis, min(abs(p.x), min(abs(p.y), abs(p.z))));
+            float weight = 1.0 / (1.0 + float(i) * 0.5);
+            accumGlow += exp(-dist * 4.0) * weight;
+            accumDepth += dist * weight;
+        }
+
+        float tOrigin = clamp(trapOrigin * 0.8, 0.0, 1.0);
+        float tEdge = clamp(trapAxis * 2.0, 0.0, 1.0);
+        float tGlow = clamp(accumGlow * 0.4, 0.0, 1.0);
+        float tOrbit = clamp(accumDepth / float(KALI_ITER) * 0.3, 0.0, 1.0);
+
+        float depth = tOrigin * 0.2 + tEdge * 0.15 + (1.0 - tGlow) * 0.35 + tOrbit * 0.3;
+        depth = smoothstep(0.05, 0.95, depth);
+        depth = mix(depth, 0.0, DROP_INTENSITY * 0.35);
+        depth = fract(depth + HUE_SHIFT);
+
+        col = chromadepth(depth);
+        float foldGlow = clamp(accumGlow * 0.6, 0.0, 1.0);
+        float edgeBright = exp(-tEdge * 6.0) * 0.35;
+        float brightness = 0.4 + foldGlow * 0.35 + edgeBright;
+        brightness *= clamp(BRIGHT_MOD, 0.3, 1.2);
+        col *= brightness;
+
+        float fEdge = length(vec2(dFdx(depth), dFdy(depth)));
+        col += smoothstep(0.0, 0.07, fEdge) * 0.15 * vec3(1.0, 0.95, 0.88);
+
+        float edgeFade = smoothstep(0.0, -0.06, heartD);
+        col *= edgeFade;
+        col *= BEAT_FLASH;
+
+    } else {
+        // === OUTSIDE: cobalt + halo + edge glow + background hearts ===
+
+        // Edge glow (warm, pops forward against cold blue)
+        float glowDist = smoothstep(0.15, 0.0, heartD);
+        col += chromadepth(0.05) * glowDist * EDGE_GLOW_STRENGTH;
+        col *= 1.0 + float(beat) * 0.15;
+
+        float pulse = sin(iTime * 2.0 + heartD * 10.0) * 0.5 + 0.5;
+        col += chromadepth(0.1) * glowDist * pulse * 0.06;
+
+        // Background hearts
+        float intensity = clamp(BG_INTENSITY, 0.0, 1.0);
+        float heartBright = mix(0.06, 0.5, intensity);
+
+        float cellSize = 1.0 / max(BG_HEART_GRID, 1.0);
+        vec2 driftUV = uv + vec2(0.0, iTime * BG_DRIFT);
+        vec2 cellID = floor(driftUV / cellSize);
+        vec2 cellUV = fract(driftUV / cellSize) - 0.5;
+
+        vec3 heartCol = vec3(0.0);
+        for (float dx = -1.0; dx <= 1.0; dx++) {
+            for (float dy = -1.0; dy <= 1.0; dy++) {
+                vec2 neighbor = cellID + vec2(dx, dy);
+                float rnd = hash21(neighbor);
+                vec2 jitter = hash22(neighbor * 7.1) - 0.5;
+                float hSize = mix(0.35, 0.85, rnd) * BG_HEART_SIZE / max(cellSize, 0.001);
+                float hRot = (rnd - 0.5) * 1.0 + HEART_ROT_MOD * 0.4 + sin(iTime * 0.3 + rnd * 6.28) * 0.1;
+
+                vec2 hPos = cellUV - vec2(dx, dy) - jitter * 0.6;
+                hPos = rot2(hRot) * hPos;
+                hPos /= max(hSize, 0.01);
+                float hd = sdHeart(hPos);
+
+                if (hd < 0.0) {
+                    float hAngle = mix(1.1, 1.7, mix(rnd, 1.0 - HEART_WARMTH, 0.4));
+                    float perHeartBright = heartBright * mix(0.7, 1.0, rnd);
+                    float L = mix(0.15, 0.7, perHeartBright);
+                    float C = 0.15 + perHeartBright * 0.08;
+                    vec3 hCol = max(oklab2rgb(vec3(L, C * cos(hAngle), C * sin(hAngle))), vec3(0.0));
+                    float fill = smoothstep(0.0, -0.18, hd);
+                    hCol *= fill * (1.0 + float(beat) * 0.08);
+                    heartCol = max(heartCol, hCol);
+                } else if (hd < 0.05) {
+                    float glow = smoothstep(0.05, 0.0, hd) * 0.1 * heartBright;
+                    vec3 glowCol = max(oklab2rgb(vec3(0.5, 0.12 * cos(1.3), 0.12 * sin(1.3))), vec3(0.0));
+                    heartCol = max(heartCol, glowCol * glow);
+                }
+            }
+        }
+        col = max(col, heartCol);
+    }
+
+    col = clamp(col, 0.0, 1.0);
+
+    // Frame feedback with oklab
+    float fbAngle = iTime * 0.005;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotUV = vec2(centered.x * fbc - centered.y * fbs,
+                      centered.x * fbs + centered.y * fbc) + 0.5;
+    vec2 fbUV = clamp(rotUV, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    vec3 colOk = rgb2oklab(col);
+    vec3 prevOk = rgb2oklab(prev);
+    prevOk.x *= 0.95;
+    prevOk.yz *= 0.97;
+    float newAmount = 0.7 - TREND_CONFIDENCE * 0.07;
+    newAmount = clamp(newAmount, 0.55, 0.85);
+    vec3 blended = mix(prevOk, colOk, newAmount);
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.6)
+        blended.yz = mix(blended.yz, colOk.yz, 0.35);
+
+    col = oklab2rgb(blended);
+
+    // Vignette — deepens to near-black cobalt at edges
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.65;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/nella/heart/deep-navy.frag
+++ b/shaders/nella/heart/deep-navy.frag
@@ -1,0 +1,274 @@
+// @fullscreen: true
+// @mobile: true
+// @favorite: true
+// @tags: heart, chromadepth, 3d, fractal, kali, love, pulse, blue
+// ChromaDepth Kali Heart — Deep Navy
+// Rich solid deep navy background pushes far back in chromadepth.
+// Heart fractal pops forward in red/gold. Background hearts glow warm
+// against the cold deep blue. Oklab throughout.
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS
+// ============================================================================
+
+#define HEART_BREATH (1.0 + bassZScore * 0.08)
+#define KALI_X (0.78 + trebleZScore * 0.02)
+#define KALI_Y (0.82 + spectralCentroidSlope * 12.0 * spectralCentroidRSquared * 0.04)
+#define KALI_Z (0.68 + spectralEntropyNormalized * 0.2)
+#define INNER_ZOOM (2.5 + energyNormalized * 1.5)
+#define INNER_ROT (iTime * 0.06 + pitchClassNormalized * 0.4)
+#define EDGE_GLOW_STRENGTH (0.3 + max(spectralFluxZScore, 0.0) * 0.4)
+#define BRIGHT_MOD (0.8 + energyZScore * 0.15)
+#define BEAT_THROB (beat ? 1.06 : 1.0)
+#define BEAT_FLASH (beat ? 1.2 : 1.0)
+#define DROP_INTENSITY (max(-energyZScore, 0.0))
+#define HUE_SHIFT (spectralSpreadNormalized * 0.08)
+#define ROUGHNESS_SAT (0.88 + spectralRoughnessNormalized * 0.12)
+#define TREND_CONFIDENCE (energyRSquared * 0.5 + bassRSquared * 0.3 + spectralCentroidRSquared * 0.2)
+#define PAN_MOD (midsZScore * 0.02)
+
+// ============================================================================
+// BACKGROUND HEARTS
+// ============================================================================
+#define ENERGY_TREND_SIGNAL clamp(energySlope * 12.0 * energyRSquared, -1.0, 1.0)
+#define BASS_PRESENCE bassNormalized
+#define FLUX_TREND clamp(spectralFluxSlope * 10.0 * spectralFluxRSquared, 0.0, 1.0)
+#define TEXTURE_LEVEL (spectralRoughnessNormalized * 0.5 + spectralEntropyNormalized * 0.5)
+#define BASS_CHARACTER (bassZScore - energyZScore * 0.7)
+#define BG_BASE 0.12
+#define BG_INTENSITY (BG_BASE \
+    + clamp(ENERGY_TREND_SIGNAL, 0.0, 0.35) \
+    + BASS_PRESENCE * 0.15 \
+    + FLUX_TREND * 0.2 \
+    + TEXTURE_LEVEL * 0.1 \
+    + max(BASS_CHARACTER, 0.0) * 0.12)
+#define BG_HEART_GRID 5.0
+#define BG_HEART_SIZE (0.07 + BASS_PRESENCE * 0.04)
+#define BG_DRIFT (0.04 + FLUX_TREND * 0.06)
+#define HEART_WARMTH spectralRoughnessNormalized
+#define HEART_ROT_MOD spectralCentroidNormalized
+
+// Deep navy background in oklab
+// L=0.13, blue hue ~4.7 rad in oklch → a≈-0.01, b≈-0.06
+#define BG_DEEP vec3(0.13, -0.01, -0.06)
+// Slightly brighter blue near the heart edge for depth gradient
+#define BG_NEAR vec3(0.18, -0.015, -0.08)
+
+#define PI 3.14159265359
+#define KALI_ITER 10
+#define PHI 1.61803398875
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+float dot2(vec2 v) { return dot(v, v); }
+
+mat2 rot2(float a) {
+    float s = sin(a), c = cos(a);
+    return mat2(c, -s, s, c);
+}
+
+float hash21(vec2 p) {
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+}
+
+vec2 hash22(vec2 p) {
+    return vec2(hash21(p), hash21(p + 17.3));
+}
+
+float sdHeart(vec2 p) {
+    p.x = abs(p.x);
+    p.y += 0.6;
+    if (p.y + p.x > 1.0)
+        return sqrt(dot2(p - vec2(0.25, 0.75))) - sqrt(2.0) / 4.0;
+    return sqrt(min(dot2(p - vec2(0.0, 1.0)),
+                dot2(p - 0.5 * max(p.x + p.y, 0.0)))) * sign(p.x - p.y);
+}
+
+// ============================================================================
+// CHROMADEPTH (oklab based)
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    // Oklch: hue sweeps red → violet
+    float hue = 0.4 + t * 4.5;
+    float L = 0.72 - t * 0.15;
+    float C = 0.2 - t * 0.04;
+    return max(oklab2rgb(vec3(L, C * cos(hue), C * sin(hue))), vec3(0.0));
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    // Heart transform
+    vec2 heartUV = uv;
+    heartUV.y += 0.05;
+    float heartScale = 0.55 * HEART_BREATH * BEAT_THROB;
+    heartUV /= max(heartScale, 0.01);
+    float heartD = sdHeart(heartUV);
+
+    // Deep navy background — always present, gradient toward heart
+    float distFromCenter = length(uv);
+    float nearHeart = smoothstep(0.8, 0.1, distFromCenter);
+    vec3 bgOk = mix(BG_DEEP, BG_NEAR, nearHeart * 0.5);
+    // Subtle treble-reactive shimmer in the blue
+    bgOk.x += trebleNormalized * 0.02;
+    vec3 col = max(oklab2rgb(bgOk), vec3(0.0));
+
+    if (heartD < 0.0) {
+        // === INSIDE THE HEART: Kali fractal ===
+        vec2 fracUV = heartUV * 0.7;
+        float fAngle = INNER_ROT;
+        float fca = cos(fAngle), fsa = sin(fAngle);
+        fracUV = mat2(fca, -fsa, fsa, fca) * fracUV;
+        fracUV *= INNER_ZOOM;
+        fracUV += vec2(PAN_MOD, PAN_MOD * 0.7);
+
+        float wt = iTime * 0.025;
+        vec3 kaliParam = vec3(
+            KALI_X + 0.12 * sin(wt * 1.0) + 0.06 * cos(wt * PHI * 0.5),
+            KALI_Y + 0.1 * sin(wt * 0.7 * PHI),
+            KALI_Z + 0.08 * sin(wt * 0.9) + 0.05 * cos(wt * PHI * 0.7)
+        );
+
+        float dropJolt = DROP_INTENSITY * (1.0 - TREND_CONFIDENCE) * 0.1;
+        kaliParam.x += sin(iTime * 3.7) * dropJolt;
+        kaliParam.y += cos(iTime * 2.3) * dropJolt;
+        kaliParam = clamp(kaliParam, vec3(0.35), vec3(1.35));
+
+        vec3 p = vec3(fracUV, 0.5 + spectralEntropyNormalized * 0.2);
+        float trapOrigin = 1e10;
+        float trapAxis = 1e10;
+        float accumGlow = 0.0;
+        float accumDepth = 0.0;
+
+        for (int i = 0; i < KALI_ITER; i++) {
+            p = abs(p);
+            float d = max(dot(p, p), 0.001);
+            p = p / d - kaliParam;
+            float dist = length(p);
+            trapOrigin = min(trapOrigin, dist);
+            trapAxis = min(trapAxis, min(abs(p.x), min(abs(p.y), abs(p.z))));
+            float weight = 1.0 / (1.0 + float(i) * 0.5);
+            accumGlow += exp(-dist * 4.0) * weight;
+            accumDepth += dist * weight;
+        }
+
+        float tOrigin = clamp(trapOrigin * 0.8, 0.0, 1.0);
+        float tEdge = clamp(trapAxis * 2.0, 0.0, 1.0);
+        float tGlow = clamp(accumGlow * 0.4, 0.0, 1.0);
+        float tOrbit = clamp(accumDepth / float(KALI_ITER) * 0.3, 0.0, 1.0);
+
+        float depth = tOrigin * 0.2 + tEdge * 0.15 + (1.0 - tGlow) * 0.35 + tOrbit * 0.3;
+        depth = smoothstep(0.05, 0.95, depth);
+        depth = mix(depth, 0.0, DROP_INTENSITY * 0.35);
+        depth = fract(depth + HUE_SHIFT);
+
+        col = chromadepth(depth);
+        float foldGlow = clamp(accumGlow * 0.6, 0.0, 1.0);
+        float edgeBright = exp(-tEdge * 6.0) * 0.35;
+        float brightness = 0.4 + foldGlow * 0.35 + edgeBright;
+        brightness *= clamp(BRIGHT_MOD, 0.3, 1.2);
+        col *= brightness;
+
+        float fEdge = length(vec2(dFdx(depth), dFdy(depth)));
+        col += smoothstep(0.0, 0.07, fEdge) * 0.15 * vec3(1.0, 0.95, 0.88);
+
+        float edgeFade = smoothstep(0.0, -0.06, heartD);
+        col *= edgeFade;
+        col *= BEAT_FLASH;
+
+    } else {
+        // === OUTSIDE: deep navy + edge glow + background hearts ===
+
+        // Edge glow (red/orange, pops forward against blue)
+        float glowDist = smoothstep(0.15, 0.0, heartD);
+        col += chromadepth(0.05) * glowDist * EDGE_GLOW_STRENGTH;
+        col *= 1.0 + float(beat) * 0.15;
+
+        float pulse = sin(iTime * 2.0 + heartD * 10.0) * 0.5 + 0.5;
+        col += chromadepth(0.1) * glowDist * pulse * 0.06;
+
+        // Background hearts
+        float intensity = clamp(BG_INTENSITY, 0.0, 1.0);
+        float heartBright = mix(0.06, 0.5, intensity);
+
+        float cellSize = 1.0 / max(BG_HEART_GRID, 1.0);
+        vec2 driftUV = uv + vec2(0.0, iTime * BG_DRIFT);
+        vec2 cellID = floor(driftUV / cellSize);
+        vec2 cellUV = fract(driftUV / cellSize) - 0.5;
+
+        vec3 heartCol = vec3(0.0);
+        for (float dx = -1.0; dx <= 1.0; dx++) {
+            for (float dy = -1.0; dy <= 1.0; dy++) {
+                vec2 neighbor = cellID + vec2(dx, dy);
+                float rnd = hash21(neighbor);
+                vec2 jitter = hash22(neighbor * 7.1) - 0.5;
+                float hSize = mix(0.35, 0.85, rnd) * BG_HEART_SIZE / max(cellSize, 0.001);
+                float hRot = (rnd - 0.5) * 1.0 + HEART_ROT_MOD * 0.4 + sin(iTime * 0.3 + rnd * 6.28) * 0.1;
+
+                vec2 hPos = cellUV - vec2(dx, dy) - jitter * 0.6;
+                hPos = rot2(hRot) * hPos;
+                hPos /= max(hSize, 0.01);
+                float hd = sdHeart(hPos);
+
+                if (hd < 0.0) {
+                    float hAngle = mix(1.1, 1.7, mix(rnd, 1.0 - HEART_WARMTH, 0.4));
+                    float perHeartBright = heartBright * mix(0.7, 1.0, rnd);
+                    float L = mix(0.15, 0.7, perHeartBright);
+                    float C = 0.15 + perHeartBright * 0.08;
+                    vec3 hCol = max(oklab2rgb(vec3(L, C * cos(hAngle), C * sin(hAngle))), vec3(0.0));
+                    float fill = smoothstep(0.0, -0.18, hd);
+                    hCol *= fill * (1.0 + float(beat) * 0.08);
+                    heartCol = max(heartCol, hCol);
+                } else if (hd < 0.05) {
+                    float glow = smoothstep(0.05, 0.0, hd) * 0.1 * heartBright;
+                    vec3 glowCol = max(oklab2rgb(vec3(0.5, 0.12 * cos(1.3), 0.12 * sin(1.3))), vec3(0.0));
+                    heartCol = max(heartCol, glowCol * glow);
+                }
+            }
+        }
+        col = max(col, heartCol);
+    }
+
+    col = clamp(col, 0.0, 1.0);
+
+    // Frame feedback with oklab
+    float fbAngle = iTime * 0.005;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotUV = vec2(centered.x * fbc - centered.y * fbs,
+                      centered.x * fbs + centered.y * fbc) + 0.5;
+    vec2 fbUV = clamp(rotUV, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    vec3 colOk = rgb2oklab(col);
+    vec3 prevOk = rgb2oklab(prev);
+    prevOk.x *= 0.95;
+    prevOk.yz *= 0.97;
+    float newAmount = 0.7 - TREND_CONFIDENCE * 0.07;
+    newAmount = clamp(newAmount, 0.55, 0.85);
+    vec3 blended = mix(prevOk, colOk, newAmount);
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.6)
+        blended.yz = mix(blended.yz, colOk.yz, 0.35);
+
+    col = oklab2rgb(blended);
+
+    // Vignette — darkens to near-black at edges
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.6;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/nella/heart/fractal-bloom.frag
+++ b/shaders/nella/heart/fractal-bloom.frag
@@ -1,0 +1,252 @@
+// @fullscreen: true
+// @mobile: true
+// @favorite: true
+// @tags: heart, chromadepth, 3d, fractal, bloom, love
+// ChromaDepth Heart Bloom - Hearts spiral outward along Mandelbrot orbits
+// Each heart has fractal-noise interiors with chromadepth depth mapping.
+// Hearts near center = red (pop forward), outer = blue (recede).
+// Oklab frame feedback creates luminous trailing persistence.
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS
+// ============================================================================
+
+// Heart size: energy makes hearts breathe
+#define HEART_SCALE (0.18 + energyNormalized * 0.08)
+// #define HEART_SCALE 0.22
+
+// Spiral speed: mids drive movement
+#define SPIRAL_SPEED (0.15 + midsNormalized * 0.1)
+// #define SPIRAL_SPEED 0.2
+
+// Fractal c drift: bass reshapes Mandelbrot paths
+#define MANDEL_DRIFT (bassZScore * 0.03)
+// #define MANDEL_DRIFT 0.0
+
+// Color rotation: spectral centroid shifts hue offset
+#define HUE_DRIFT (spectralCentroidNormalized * 0.12)
+// #define HUE_DRIFT 0.0
+
+// Heart rotation: spectral entropy spins individual hearts
+#define HEART_SPIN (spectralEntropyNormalized * 3.14159)
+// #define HEART_SPIN 0.0
+
+// Interior noise: spectral roughness drives fractal complexity inside hearts
+#define NOISE_INTENSITY (0.6 + spectralRoughnessNormalized * 0.4)
+// #define NOISE_INTENSITY 0.8
+
+// Beat pulse: hearts flash brighter
+#define BEAT_FLASH (beat ? 1.25 : 1.0)
+// #define BEAT_FLASH 1.0
+
+// Drop: push everything toward red on energy drops
+#define DROP_SHIFT (max(-energyZScore, 0.0) * 0.06)
+// #define DROP_SHIFT 0.0
+
+// Spread: treble widens the spiral
+#define SPREAD (1.0 + trebleZScore * 0.15)
+// #define SPREAD 1.0
+
+// Feedback confidence
+#define TREND_CONFIDENCE (energyRSquared * 0.5 + bassRSquared * 0.3 + spectralCentroidRSquared * 0.2)
+// #define TREND_CONFIDENCE 0.5
+
+// Flux for glow edges
+#define FLUX_GLOW (max(spectralFluxZScore, 0.0))
+// #define FLUX_GLOW 0.0
+
+#define PI 3.14159265359
+#define HEART_COUNT 12.0
+#define LINE_COUNT 3.0
+#define MAX_ITER 8
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+float dot2(vec2 v) { return dot(v, v); }
+
+mat2 rot(float a) {
+    float s = sin(a), c = cos(a);
+    return mat2(c, -s, s, c);
+}
+
+float sdHeart(vec2 p) {
+    p.x = abs(p.x);
+    p.y += 0.6;
+    if (p.y + p.x > 1.0)
+        return sqrt(dot2(p - vec2(0.25, 0.75))) - sqrt(2.0) / 4.0;
+    return sqrt(min(dot2(p - vec2(0.0, 1.0)),
+                dot2(p - 0.5 * max(p.x + p.y, 0.0)))) * sign(p.x - p.y);
+}
+
+// Simple fractal noise for heart interiors
+float fractalNoise(vec2 p, float t) {
+    float noise = 0.0;
+    float amp = 1.0;
+    float freq = 1.0;
+    for (int i = 0; i < 4; i++) {
+        noise += (sin(p.x * freq + t * 0.3) * cos(p.y * freq * 1.1 + t * 0.2)) * amp;
+        freq *= 2.1;
+        amp *= 0.5;
+    }
+    return noise * 0.5 + 0.5;
+}
+
+// Mandelbrot path for heart positions
+void mandelbrotPath(float t, float lineIdx, out vec2 pos, out float scale, out float rotation) {
+    float angle = lineIdx * PI * 2.0 / LINE_COUNT + iTime * 0.08;
+    float radius = 0.5 + 0.2 * sin(angle * 2.0 + iTime * 0.15);
+    vec2 c = vec2(cos(angle), sin(angle)) * radius;
+    c.x += MANDEL_DRIFT;
+
+    vec2 z = vec2(0.0);
+    float lastLen = 0.0;
+
+    for (int i = 0; i < MAX_ITER; i++) {
+        z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+        if (float(i) >= t * float(MAX_ITER)) {
+            pos = z * 0.4 * SPREAD;
+            scale = (length(z) - lastLen) * 1.5 + 0.6;
+            rotation = atan(z.y, z.x) * 2.0 + t * PI * 3.0;
+            return;
+        }
+        lastLen = length(z);
+    }
+    pos = z * 0.4 * SPREAD;
+    scale = 0.6;
+    rotation = atan(z.y, z.x) * 2.0;
+}
+
+// ============================================================================
+// CHROMADEPTH: red = near, violet = far
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.75;
+    float sat = 0.92 - t * 0.07;
+    float lit = 0.5 - t * 0.08;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec2 uv = (fragCoord * 2.0 - iResolution.xy) / iResolution.y;
+
+    vec3 finalCol = vec3(0.0);
+    float finalDepth = 1.0; // start at far
+    float closestD = 1e10;
+
+    // Render hearts along Mandelbrot spiral paths
+    for (float line = 0.0; line < LINE_COUNT; line++) {
+        for (float i = 0.0; i < HEART_COUNT; i++) {
+            float t = fract(i / HEART_COUNT - iTime * SPIRAL_SPEED + line * 0.33);
+
+            vec2 pos;
+            float scale, rotation;
+            mandelbrotPath(t, line, pos, scale, rotation);
+
+            // Heart size reacts to audio
+            scale *= HEART_SCALE;
+            rotation += HEART_SPIN + t * PI;
+
+            // Transform UV into heart space
+            vec2 heartUV = (uv - pos) * rot(rotation) / max(scale, 0.01);
+
+            float d = sdHeart(heartUV);
+
+            if (d < 0.0) {
+                // Distance from center determines chromadepth:
+                // center hearts = red (near), outer hearts = blue (far)
+                float distFromCenter = length(pos);
+                float depthVal = clamp(distFromCenter * 0.3, 0.0, 1.0);
+
+                // Interior fractal noise adds depth variation within the heart
+                float noise = fractalNoise(heartUV * 3.0, iTime + line * 2.0) * NOISE_INTENSITY;
+                depthVal = depthVal * 0.7 + noise * 0.3;
+
+                // Drop shift toward red
+                depthVal = max(depthVal - DROP_SHIFT, 0.0);
+                depthVal = clamp(depthVal + HUE_DRIFT, 0.0, 1.0);
+
+                vec3 col = chromadepth(depthVal);
+
+                // Edge glow: near the heart boundary
+                float edgeFade = smoothstep(0.0, -0.08, d);
+                col *= edgeFade;
+
+                // Flux-driven edge highlight
+                float edgeHighlight = smoothstep(-0.01, 0.0, d) * FLUX_GLOW * 0.3;
+                col += edgeHighlight * vec3(1.0, 0.9, 0.8);
+
+                // Beat flash
+                col *= BEAT_FLASH;
+
+                // Layer compositing: closer hearts overwrite farther ones
+                if (distFromCenter < closestD) {
+                    closestD = distFromCenter;
+                    finalCol = max(finalCol, col);
+                    finalDepth = depthVal;
+                } else {
+                    finalCol = max(finalCol, col * 0.6);
+                }
+            }
+        }
+    }
+
+    // Background: subtle chromadepth glow radiating outward
+    float bgDist = length(uv);
+    float bgDepth = clamp(bgDist * 0.35, 0.0, 1.0);
+    vec3 bgCol = chromadepth(mix(0.5, 0.75, bgDepth)) * 0.08;
+    bgCol *= 1.0 - bgDist * 0.3;
+    finalCol = max(finalCol, bgCol);
+
+    finalCol = clamp(finalCol, 0.0, 1.0);
+
+    // --- FRAME FEEDBACK with oklab blending ---
+    float fbAngle = iTime * 0.006;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotatedUV = vec2(centered.x * fbc - centered.y * fbs,
+                          centered.x * fbs + centered.y * fbc) + 0.5;
+
+    // Gentle radial expansion in feedback for bloom effect
+    vec2 expand = (rotatedUV - 0.5) * 0.997 + 0.5;
+    vec2 fbUV = clamp(expand, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    // Oklab blend
+    vec3 colOk = rgb2oklab(finalCol);
+    vec3 prevOk = rgb2oklab(prev);
+
+    prevOk.x *= 0.95;
+    prevOk.yz *= 0.97;
+
+    float newAmount = 0.68;
+    newAmount -= TREND_CONFIDENCE * 0.06;
+    newAmount = clamp(newAmount, 0.5, 0.85);
+
+    vec3 blended = mix(prevOk, colOk, newAmount);
+
+    // Prevent chroma death
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.6) {
+        blended.yz = mix(blended.yz, colOk.yz, 0.3);
+    }
+
+    finalCol = oklab2rgb(blended);
+    finalCol *= 1.0 + float(beat) * 0.08;
+
+    // Vignette
+    vec2 vc = screenUV - 0.5;
+    finalCol *= 1.0 - dot(vc, vc) * 0.6;
+
+    finalCol = clamp(finalCol, 0.0, 1.0);
+    fragColor = vec4(finalCol, 1.0);
+}

--- a/shaders/nella/heart/indigo-mist.frag
+++ b/shaders/nella/heart/indigo-mist.frag
@@ -1,0 +1,310 @@
+// @fullscreen: true
+// @mobile: true
+// @favorite: true
+// @tags: heart, chromadepth, 3d, fractal, kali, love, pulse, blue
+// ChromaDepth Kali Heart — Indigo Mist
+// Deep indigo background with soft fractal noise clouds that breathe
+// with the music. The mist creates a sense of atmospheric depth behind
+// the heart. Everything in oklab for perceptual uniformity.
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS
+// ============================================================================
+
+#define HEART_BREATH (1.0 + bassZScore * 0.08)
+#define KALI_X (0.78 + trebleZScore * 0.02)
+#define KALI_Y (0.82 + spectralCentroidSlope * 12.0 * spectralCentroidRSquared * 0.04)
+#define KALI_Z (0.68 + spectralEntropyNormalized * 0.2)
+#define INNER_ZOOM (2.5 + energyNormalized * 1.5)
+#define INNER_ROT (iTime * 0.06 + pitchClassNormalized * 0.4)
+#define EDGE_GLOW_STRENGTH (0.3 + max(spectralFluxZScore, 0.0) * 0.4)
+#define BRIGHT_MOD (0.8 + energyZScore * 0.15)
+#define BEAT_THROB (beat ? 1.06 : 1.0)
+#define BEAT_FLASH (beat ? 1.2 : 1.0)
+#define DROP_INTENSITY (max(-energyZScore, 0.0))
+#define HUE_SHIFT (spectralSpreadNormalized * 0.08)
+#define ROUGHNESS_SAT (0.88 + spectralRoughnessNormalized * 0.12)
+#define TREND_CONFIDENCE (energyRSquared * 0.5 + bassRSquared * 0.3 + spectralCentroidRSquared * 0.2)
+#define PAN_MOD (midsZScore * 0.02)
+
+// ============================================================================
+// BACKGROUND HEARTS
+// ============================================================================
+#define ENERGY_TREND_SIGNAL clamp(energySlope * 12.0 * energyRSquared, -1.0, 1.0)
+#define BASS_PRESENCE bassNormalized
+#define FLUX_TREND clamp(spectralFluxSlope * 10.0 * spectralFluxRSquared, 0.0, 1.0)
+#define TEXTURE_LEVEL (spectralRoughnessNormalized * 0.5 + spectralEntropyNormalized * 0.5)
+#define BASS_CHARACTER (bassZScore - energyZScore * 0.7)
+#define BG_BASE 0.12
+#define BG_INTENSITY (BG_BASE \
+    + clamp(ENERGY_TREND_SIGNAL, 0.0, 0.35) \
+    + BASS_PRESENCE * 0.15 \
+    + FLUX_TREND * 0.2 \
+    + TEXTURE_LEVEL * 0.1 \
+    + max(BASS_CHARACTER, 0.0) * 0.12)
+#define BG_HEART_GRID 5.0
+#define BG_HEART_SIZE (0.07 + BASS_PRESENCE * 0.04)
+#define BG_DRIFT (0.04 + FLUX_TREND * 0.06)
+#define HEART_WARMTH spectralRoughnessNormalized
+#define HEART_ROT_MOD spectralCentroidNormalized
+
+// Mist reactivity: mids breathe the fog density
+#define MIST_DENSITY (0.6 + midsNormalized * 0.3)
+// #define MIST_DENSITY 0.7
+
+// Mist drift: spectral spread moves the clouds
+#define MIST_DRIFT (spectralSpreadNormalized * 0.3)
+// #define MIST_DRIFT 0.15
+
+#define PI 3.14159265359
+#define KALI_ITER 10
+#define PHI 1.61803398875
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+float dot2(vec2 v) { return dot(v, v); }
+
+mat2 rot2(float a) {
+    float s = sin(a), c = cos(a);
+    return mat2(c, -s, s, c);
+}
+
+float hash21(vec2 p) {
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+}
+
+vec2 hash22(vec2 p) {
+    return vec2(hash21(p), hash21(p + 17.3));
+}
+
+// Smooth value noise
+float vnoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float a = hash21(i);
+    float b = hash21(i + vec2(1.0, 0.0));
+    float c = hash21(i + vec2(0.0, 1.0));
+    float d = hash21(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+// Fractal brownian motion for cloud mist
+float fbm(vec2 p) {
+    float v = 0.0;
+    float amp = 0.5;
+    for (int i = 0; i < 4; i++) {
+        v += vnoise(p) * amp;
+        p = p * 2.1 + vec2(1.7, 3.2);
+        amp *= 0.5;
+    }
+    return v;
+}
+
+float sdHeart(vec2 p) {
+    p.x = abs(p.x);
+    p.y += 0.6;
+    if (p.y + p.x > 1.0)
+        return sqrt(dot2(p - vec2(0.25, 0.75))) - sqrt(2.0) / 4.0;
+    return sqrt(min(dot2(p - vec2(0.0, 1.0)),
+                dot2(p - 0.5 * max(p.x + p.y, 0.0)))) * sign(p.x - p.y);
+}
+
+// ============================================================================
+// CHROMADEPTH (oklab)
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = 0.4 + t * 4.5;
+    float L = 0.72 - t * 0.15;
+    float C = 0.2 - t * 0.04;
+    return max(oklab2rgb(vec3(L, C * cos(hue), C * sin(hue))), vec3(0.0));
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    // Heart transform
+    vec2 heartUV = uv;
+    heartUV.y += 0.05;
+    float heartScale = 0.55 * HEART_BREATH * BEAT_THROB;
+    heartUV /= max(heartScale, 0.01);
+    float heartD = sdHeart(heartUV);
+
+    // Deep indigo background with mist clouds
+    float distFromCenter = length(uv);
+
+    // Base deep indigo in oklab
+    vec3 bgBase = vec3(0.12, 0.02, -0.07); // deep indigo
+
+    // Animated cloud mist — drifts slowly, breathes with mids
+    vec2 mistUV = uv * 2.5 + vec2(iTime * 0.03 + MIST_DRIFT, iTime * 0.02);
+    float mist = fbm(mistUV);
+    float mist2 = fbm(mistUV * 1.5 + vec2(3.7, 1.2));
+    float mistVal = mist * 0.6 + mist2 * 0.4;
+
+    // Mist brightens the indigo slightly — creates cloudy depth layers
+    vec3 bgOk = bgBase;
+    bgOk.x += mistVal * 0.06 * MIST_DENSITY;
+    // Mist shifts hue slightly between indigo and blue
+    bgOk.z -= mistVal * 0.02;
+
+    vec3 col = max(oklab2rgb(bgOk), vec3(0.0));
+
+    if (heartD < 0.0) {
+        // === INSIDE THE HEART: Kali fractal ===
+        vec2 fracUV = heartUV * 0.7;
+        float fAngle = INNER_ROT;
+        float fca = cos(fAngle), fsa = sin(fAngle);
+        fracUV = mat2(fca, -fsa, fsa, fca) * fracUV;
+        fracUV *= INNER_ZOOM;
+        fracUV += vec2(PAN_MOD, PAN_MOD * 0.7);
+
+        float wt = iTime * 0.025;
+        vec3 kaliParam = vec3(
+            KALI_X + 0.12 * sin(wt * 1.0) + 0.06 * cos(wt * PHI * 0.5),
+            KALI_Y + 0.1 * sin(wt * 0.7 * PHI),
+            KALI_Z + 0.08 * sin(wt * 0.9) + 0.05 * cos(wt * PHI * 0.7)
+        );
+
+        float dropJolt = DROP_INTENSITY * (1.0 - TREND_CONFIDENCE) * 0.1;
+        kaliParam.x += sin(iTime * 3.7) * dropJolt;
+        kaliParam.y += cos(iTime * 2.3) * dropJolt;
+        kaliParam = clamp(kaliParam, vec3(0.35), vec3(1.35));
+
+        vec3 p = vec3(fracUV, 0.5 + spectralEntropyNormalized * 0.2);
+        float trapOrigin = 1e10;
+        float trapAxis = 1e10;
+        float accumGlow = 0.0;
+        float accumDepth = 0.0;
+
+        for (int i = 0; i < KALI_ITER; i++) {
+            p = abs(p);
+            float d = max(dot(p, p), 0.001);
+            p = p / d - kaliParam;
+            float dist = length(p);
+            trapOrigin = min(trapOrigin, dist);
+            trapAxis = min(trapAxis, min(abs(p.x), min(abs(p.y), abs(p.z))));
+            float weight = 1.0 / (1.0 + float(i) * 0.5);
+            accumGlow += exp(-dist * 4.0) * weight;
+            accumDepth += dist * weight;
+        }
+
+        float tOrigin = clamp(trapOrigin * 0.8, 0.0, 1.0);
+        float tEdge = clamp(trapAxis * 2.0, 0.0, 1.0);
+        float tGlow = clamp(accumGlow * 0.4, 0.0, 1.0);
+        float tOrbit = clamp(accumDepth / float(KALI_ITER) * 0.3, 0.0, 1.0);
+
+        float depth = tOrigin * 0.2 + tEdge * 0.15 + (1.0 - tGlow) * 0.35 + tOrbit * 0.3;
+        depth = smoothstep(0.05, 0.95, depth);
+        depth = mix(depth, 0.0, DROP_INTENSITY * 0.35);
+        depth = fract(depth + HUE_SHIFT);
+
+        col = chromadepth(depth);
+        float foldGlow = clamp(accumGlow * 0.6, 0.0, 1.0);
+        float edgeBright = exp(-tEdge * 6.0) * 0.35;
+        float brightness = 0.4 + foldGlow * 0.35 + edgeBright;
+        brightness *= clamp(BRIGHT_MOD, 0.3, 1.2);
+        col *= brightness;
+
+        float fEdge = length(vec2(dFdx(depth), dFdy(depth)));
+        col += smoothstep(0.0, 0.07, fEdge) * 0.15 * vec3(1.0, 0.95, 0.88);
+
+        float edgeFade = smoothstep(0.0, -0.06, heartD);
+        col *= edgeFade;
+        col *= BEAT_FLASH;
+
+    } else {
+        // === OUTSIDE: indigo mist + edge glow + background hearts ===
+
+        // Edge glow
+        float glowDist = smoothstep(0.15, 0.0, heartD);
+        col += chromadepth(0.05) * glowDist * EDGE_GLOW_STRENGTH;
+        col *= 1.0 + float(beat) * 0.15;
+
+        float pulse = sin(iTime * 2.0 + heartD * 10.0) * 0.5 + 0.5;
+        col += chromadepth(0.1) * glowDist * pulse * 0.06;
+
+        // Background hearts
+        float intensity = clamp(BG_INTENSITY, 0.0, 1.0);
+        float heartBright = mix(0.06, 0.5, intensity);
+
+        float cellSize = 1.0 / max(BG_HEART_GRID, 1.0);
+        vec2 driftUV = uv + vec2(0.0, iTime * BG_DRIFT);
+        vec2 cellID = floor(driftUV / cellSize);
+        vec2 cellUV = fract(driftUV / cellSize) - 0.5;
+
+        vec3 heartCol = vec3(0.0);
+        for (float dx = -1.0; dx <= 1.0; dx++) {
+            for (float dy = -1.0; dy <= 1.0; dy++) {
+                vec2 neighbor = cellID + vec2(dx, dy);
+                float rnd = hash21(neighbor);
+                vec2 jitter = hash22(neighbor * 7.1) - 0.5;
+                float hSize = mix(0.35, 0.85, rnd) * BG_HEART_SIZE / max(cellSize, 0.001);
+                float hRot = (rnd - 0.5) * 1.0 + HEART_ROT_MOD * 0.4 + sin(iTime * 0.3 + rnd * 6.28) * 0.1;
+
+                vec2 hPos = cellUV - vec2(dx, dy) - jitter * 0.6;
+                hPos = rot2(hRot) * hPos;
+                hPos /= max(hSize, 0.01);
+                float hd = sdHeart(hPos);
+
+                if (hd < 0.0) {
+                    float hAngle = mix(1.1, 1.7, mix(rnd, 1.0 - HEART_WARMTH, 0.4));
+                    float perHeartBright = heartBright * mix(0.7, 1.0, rnd);
+                    float L = mix(0.15, 0.7, perHeartBright);
+                    float C = 0.15 + perHeartBright * 0.08;
+                    vec3 hCol = max(oklab2rgb(vec3(L, C * cos(hAngle), C * sin(hAngle))), vec3(0.0));
+                    float fill = smoothstep(0.0, -0.18, hd);
+                    hCol *= fill * (1.0 + float(beat) * 0.08);
+                    heartCol = max(heartCol, hCol);
+                } else if (hd < 0.05) {
+                    float glow = smoothstep(0.05, 0.0, hd) * 0.1 * heartBright;
+                    vec3 glowCol = max(oklab2rgb(vec3(0.5, 0.12 * cos(1.3), 0.12 * sin(1.3))), vec3(0.0));
+                    heartCol = max(heartCol, glowCol * glow);
+                }
+            }
+        }
+        col = max(col, heartCol);
+    }
+
+    col = clamp(col, 0.0, 1.0);
+
+    // Frame feedback with oklab
+    float fbAngle = iTime * 0.005;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotUV = vec2(centered.x * fbc - centered.y * fbs,
+                      centered.x * fbs + centered.y * fbc) + 0.5;
+    vec2 fbUV = clamp(rotUV, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    vec3 colOk = rgb2oklab(col);
+    vec3 prevOk = rgb2oklab(prev);
+    prevOk.x *= 0.95;
+    prevOk.yz *= 0.97;
+    float newAmount = 0.7 - TREND_CONFIDENCE * 0.07;
+    newAmount = clamp(newAmount, 0.55, 0.85);
+    vec3 blended = mix(prevOk, colOk, newAmount);
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.6)
+        blended.yz = mix(blended.yz, colOk.yz, 0.35);
+
+    col = oklab2rgb(blended);
+
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.55;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/nella/heart/julia-trap.frag
+++ b/shaders/nella/heart/julia-trap.frag
@@ -1,0 +1,268 @@
+// @fullscreen: true
+// @mobile: true
+// @favorite: true
+// @tags: heart, chromadepth, 3d, fractal, julia, love
+// ChromaDepth Julia Set with Heart-Shaped Orbit Trap
+// The fractal reveals hidden hearts everywhere in the boundary structure.
+// Red = near (hearts pop forward), Blue/Violet = far (background recedes)
+// Oklab blending for perceptually smooth frame feedback.
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS
+// ============================================================================
+
+// Julia c real: bass gently reshapes the fractal
+#define C_REAL (-0.76 + bassZScore * 0.04)
+// #define C_REAL -0.76
+
+// Julia c imaginary: treble shifts fractal form
+#define C_IMAG (0.22 + trebleZScore * 0.025)
+// #define C_IMAG 0.22
+
+// Zoom: energy drives zoom depth
+#define ZOOM (1.6 + spectralCentroidNormalized * 0.4)
+// #define ZOOM 1.6
+
+// Rotation: pitch class slowly spins the view
+#define ROTATION (iTime * 0.04 + pitchClassNormalized * 0.3)
+// #define ROTATION 0.0
+
+// Heart trap rotation: spectral entropy rotates the heart trap
+#define TRAP_ROT (iTime * 0.08 + spectralEntropyNormalized * 0.5)
+// #define TRAP_ROT 0.0
+
+// Heart trap scale: mids control how large the heart trap is
+#define TRAP_SCALE (0.8 + midsNormalized * 0.3)
+// #define TRAP_SCALE 1.0
+
+// Pan drift
+#define PAN_X (spectralRoughnessZScore * 0.04)
+// #define PAN_X 0.0
+
+#define PAN_Y (midsZScore * 0.03)
+// #define PAN_Y 0.0
+
+// Brightness modulation
+#define BRIGHT_MOD (0.85 + energyZScore * 0.15)
+// #define BRIGHT_MOD 0.85
+
+// Hue offset: spectral entropy shifts the chromadepth palette
+#define HUE_OFFSET (spectralEntropyNormalized * 0.1)
+// #define HUE_OFFSET 0.0
+
+// Beat pulse
+#define BEAT_PULSE (beat ? 1.2 : 1.0)
+// #define BEAT_PULSE 1.0
+
+// Drop detection: hue shift toward red on drops
+#define DROP_SHIFT (max(-energyZScore, 0.0) * 0.08)
+// #define DROP_SHIFT 0.0
+
+// Feedback confidence
+#define TREND_CONFIDENCE (energyRSquared * 0.5 + bassRSquared * 0.3 + spectralCentroidRSquared * 0.2)
+// #define TREND_CONFIDENCE 0.5
+
+// Max iterations (mobile safe)
+#define MAX_ITER 64
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+float dot2(vec2 v) { return dot(v, v); }
+
+// Signed distance to a heart shape
+float sdHeart(vec2 p) {
+    p.x = abs(p.x);
+    p.y += 0.6;
+    if (p.y + p.x > 1.0)
+        return sqrt(dot2(p - vec2(0.25, 0.75))) - sqrt(2.0) / 4.0;
+    return sqrt(min(dot2(p - vec2(0.0, 1.0)),
+                dot2(p - 0.5 * max(p.x + p.y, 0.0)))) * sign(p.x - p.y);
+}
+
+// ============================================================================
+// CHROMADEPTH COLORING (HSL-based depth, oklab blending)
+// ============================================================================
+// 0.0 = red (nearest), 0.33 = green (mid), 0.75 = violet (farthest)
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.75;
+    float sat = 0.93 - t * 0.08;
+    float lit = 0.52 - t * 0.1;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    // Rotation
+    float angle = ROTATION;
+    float ca = cos(angle), sa = sin(angle);
+    uv = mat2(ca, -sa, sa, ca) * uv;
+
+    // Zoom and pan
+    uv = uv * ZOOM + vec2(PAN_X, PAN_Y);
+
+    // Julia iteration with heart-shaped orbit trap
+    vec2 z = uv;
+    vec2 c = vec2(C_REAL, C_IMAG);
+
+    float iter = 0.0;
+    float smoothIter = 0.0;
+    bool escaped = false;
+
+    // Heart orbit trap: minimum distance the orbit comes to a heart shape
+    float heartTrapMin = 1e10;
+    float originTrapMin = 1e10;
+    float lineTrapMin = 1e10;
+    float orbitAngle = 0.0;
+
+    // Heart trap transform
+    float trapA = TRAP_ROT;
+    float trapCos = cos(trapA), trapSin = sin(trapA);
+
+    for (int i = 0; i < MAX_ITER; i++) {
+        // z = z^2 + c
+        z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+
+        float mag2 = dot(z, z);
+        float mag = sqrt(mag2);
+
+        // Heart orbit trap: rotate z into heart space
+        vec2 hz = mat2(trapCos, -trapSin, trapSin, trapCos) * z;
+        hz /= TRAP_SCALE;
+        float heartD = abs(sdHeart(hz));
+        heartTrapMin = min(heartTrapMin, heartD);
+
+        // Standard orbit traps
+        originTrapMin = min(originTrapMin, mag);
+        lineTrapMin = min(lineTrapMin, min(abs(z.x), abs(z.y)));
+        orbitAngle += atan(z.y, z.x);
+
+        if (mag2 > 256.0) {
+            smoothIter = float(i) - log2(log2(mag2)) + 4.0;
+            escaped = true;
+            break;
+        }
+        smoothIter = float(i);
+        iter += 1.0;
+    }
+
+    // --- DEPTH MAPPING ---
+    float depth;
+    float brightness = 1.0;
+
+    if (escaped) {
+        // Exterior: near boundary = green/cyan, far = violet
+        float iterFrac = smoothIter / float(MAX_ITER);
+        float logIter = log(1.0 + smoothIter) / log(1.0 + float(MAX_ITER));
+
+        // Heart trap bleeds into exterior near boundary
+        float heartInfluence = exp(-heartTrapMin * 3.0) * logIter;
+
+        // Base exterior depth
+        depth = mix(0.75, 0.4, pow(logIter, 0.45));
+
+        // If heart trap was close, pull toward red
+        depth = mix(depth, 0.05, heartInfluence * 0.6);
+
+        brightness = mix(0.15, 0.75, pow(logIter, 0.5));
+        brightness += heartInfluence * 0.3;
+    } else {
+        // Interior: heart trap drives depth
+        float tHeart = clamp(heartTrapMin * 1.5, 0.0, 1.0);
+        float tOrigin = clamp(originTrapMin * 0.8, 0.0, 1.0);
+        float tLine = clamp(lineTrapMin * 2.0, 0.0, 1.0);
+        float tAngle = fract(orbitAngle * 0.05);
+
+        // Heart trap close = red (nearest), far = yellow-green
+        float heartDepth = tHeart;
+        float geoDepth = tOrigin * 0.4 + tLine * 0.3 + tAngle * 0.3;
+
+        // Heart trap dominates for thematic effect
+        depth = heartDepth * 0.55 + geoDepth * 0.45;
+        depth = smoothstep(0.02, 0.92, depth);
+
+        // Map interior to red-green range
+        depth *= 0.35;
+
+        brightness = 0.5 + (1.0 - tHeart) * 0.3 + tAngle * 0.15;
+    }
+
+    // Drop shifts toward red
+    depth = max(depth - DROP_SHIFT, 0.0);
+
+    // --- CHROMADEPTH COLOR ---
+    float finalDepth = fract(depth + HUE_OFFSET);
+    vec3 col = chromadepth(finalDepth);
+
+    // Apply brightness
+    col *= clamp(brightness * BRIGHT_MOD, 0.1, 1.2);
+
+    // Beat pulse
+    col *= BEAT_PULSE;
+
+    // Edge glow on fractal boundaries
+    float edge = length(vec2(dFdx(depth), dFdy(depth)));
+    float edgeGlow = smoothstep(0.0, 0.06, edge) * 0.2;
+    col += edgeGlow * vec3(1.0, 0.92, 0.85);
+
+    col = clamp(col, 0.0, 1.0);
+
+    // --- FRAME FEEDBACK with oklab blending ---
+    float fbAngle = iTime * 0.007;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotatedUV = vec2(centered.x * fbc - centered.y * fbs,
+                          centered.x * fbs + centered.y * fbc) + 0.5;
+
+    float fbStrength = escaped
+        ? 0.03 * pow(smoothIter / float(MAX_ITER), 0.35)
+        : 0.04 * (1.0 - heartTrapMin * 0.3);
+    fbStrength += float(beat) * 0.012;
+
+    vec2 fbWarp = vec2(
+        sin(orbitAngle * 0.03) * 0.008,
+        cos(orbitAngle * 0.04) * 0.006
+    ) * fbStrength * 8.0;
+
+    vec2 fbUV = clamp(rotatedUV + fbWarp, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    // Oklab blend
+    vec3 colOk = rgb2oklab(col);
+    vec3 prevOk = rgb2oklab(prev);
+
+    prevOk.x *= 0.96;
+    prevOk.yz *= 0.98;
+
+    float newAmount = 0.72;
+    newAmount -= TREND_CONFIDENCE * 0.08;
+    newAmount = clamp(newAmount, 0.55, 0.85);
+
+    vec3 blended = mix(prevOk, colOk, newAmount);
+
+    // Prevent chroma death
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.6) {
+        blended.yz = mix(blended.yz, colOk.yz, 0.35);
+    }
+
+    col = oklab2rgb(blended);
+    col *= 1.0 + float(beat) * 0.1;
+
+    // Vignette
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.65;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/nella/heart/kali-pulse.frag
+++ b/shaders/nella/heart/kali-pulse.frag
@@ -1,0 +1,265 @@
+// @fullscreen: true
+// @mobile: true
+// @favorite: true
+// @tags: heart, chromadepth, 3d, fractal, kali, love, pulse
+// ChromaDepth Kali Heart Pulse - A single pulsing heart filled with Kali fractal
+// The heart shape contains an entire recursive fractal universe inside it.
+// Outside the heart: dark void with subtle glow. Inside: Kali fold filigree.
+// Chromadepth maps fractal depth: fold-core = red (near), sparse = violet (far).
+// Bass makes it breathe. Beats make it throb. Oklab feedback for persistence.
+
+// ============================================================================
+// AUDIO-REACTIVE PARAMETERS
+// ============================================================================
+
+// Heart pulse: bass makes the heart breathe
+#define HEART_BREATH (1.0 + bassZScore * 0.08)
+// #define HEART_BREATH 1.0
+
+// Kali param X: treble shifts fractal structure
+#define KALI_X (0.78 + trebleZScore * 0.02)
+// #define KALI_X 0.78
+
+// Kali param Y: spectral centroid slope with confidence gating
+#define KALI_Y (0.82 + spectralCentroidSlope * 12.0 * spectralCentroidRSquared * 0.04)
+// #define KALI_Y 0.82
+
+// Kali param Z: entropy controls the 3rd dimension fold
+#define KALI_Z (0.68 + spectralEntropyNormalized * 0.2)
+// #define KALI_Z 0.75
+
+// Internal zoom: energy drives how deep we see into the fractal
+#define INNER_ZOOM (2.5 + energyNormalized * 1.5)
+// #define INNER_ZOOM 3.0
+
+// Inner rotation: pitch class slowly turns the fractal view
+#define INNER_ROT (iTime * 0.06 + pitchClassNormalized * 0.4)
+// #define INNER_ROT 0.0
+
+// Edge glow: spectral flux brightens the heart edge
+#define EDGE_GLOW_STRENGTH (0.3 + max(spectralFluxZScore, 0.0) * 0.4)
+// #define EDGE_GLOW_STRENGTH 0.5
+
+// Brightness from energy
+#define BRIGHT_MOD (0.8 + energyZScore * 0.15)
+// #define BRIGHT_MOD 0.85
+
+// Beat throb: the heart visually expands on beat
+#define BEAT_THROB (beat ? 1.06 : 1.0)
+// #define BEAT_THROB 1.0
+
+// Beat brightness flash
+#define BEAT_FLASH (beat ? 1.2 : 1.0)
+// #define BEAT_FLASH 1.0
+
+// Drop detection
+#define DROP_INTENSITY (max(-energyZScore, 0.0))
+// #define DROP_INTENSITY 0.0
+
+// Hue shift from spectral spread
+#define HUE_SHIFT (spectralSpreadNormalized * 0.08)
+// #define HUE_SHIFT 0.0
+
+// Roughness for saturation
+#define ROUGHNESS_SAT (0.88 + spectralRoughnessNormalized * 0.12)
+// #define ROUGHNESS_SAT 0.92
+
+// Feedback confidence
+#define TREND_CONFIDENCE (energyRSquared * 0.5 + bassRSquared * 0.3 + spectralCentroidRSquared * 0.2)
+// #define TREND_CONFIDENCE 0.5
+
+// Mids for subtle pan
+#define PAN_MOD (midsZScore * 0.02)
+// #define PAN_MOD 0.0
+
+#define PI 3.14159265359
+#define KALI_ITER 10
+#define PHI 1.61803398875
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+float dot2(vec2 v) { return dot(v, v); }
+
+float sdHeart(vec2 p) {
+    p.x = abs(p.x);
+    p.y += 0.6;
+    if (p.y + p.x > 1.0)
+        return sqrt(dot2(p - vec2(0.25, 0.75))) - sqrt(2.0) / 4.0;
+    return sqrt(min(dot2(p - vec2(0.0, 1.0)),
+                dot2(p - 0.5 * max(p.x + p.y, 0.0)))) * sign(p.x - p.y);
+}
+
+// ============================================================================
+// CHROMADEPTH
+// ============================================================================
+
+vec3 chromadepth(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float hue = t * 0.78;
+    float sat = ROUGHNESS_SAT - t * 0.08;
+    float lit = 0.52 - t * 0.1;
+    return hsl2rgb(vec3(hue, sat, lit));
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 screenUV = fragCoord / iResolution.xy;
+    vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
+
+    // Heart transform: center, scale, breathe
+    vec2 heartUV = uv;
+    heartUV.y += 0.05; // shift heart slightly up
+    float heartScale = 0.55 * HEART_BREATH * BEAT_THROB;
+    heartUV /= max(heartScale, 0.01);
+
+    float heartD = sdHeart(heartUV);
+
+    vec3 col = vec3(0.0);
+
+    if (heartD < 0.0) {
+        // === INSIDE THE HEART: Kali fractal ===
+
+        // Map heart interior UVs into fractal space
+        vec2 fracUV = heartUV * 0.7;
+
+        // Rotation
+        float fAngle = INNER_ROT;
+        float fca = cos(fAngle), fsa = sin(fAngle);
+        fracUV = mat2(fca, -fsa, fsa, fca) * fracUV;
+
+        // Zoom
+        fracUV *= INNER_ZOOM;
+
+        // Pan
+        fracUV += vec2(PAN_MOD, PAN_MOD * 0.7);
+
+        // Wander through Kali param space
+        float wt = iTime * 0.025;
+        vec3 kaliParam = vec3(
+            KALI_X + 0.12 * sin(wt * 1.0) + 0.06 * cos(wt * PHI * 0.5),
+            KALI_Y + 0.1 * sin(wt * 0.7 * PHI),
+            KALI_Z + 0.08 * sin(wt * 0.9) + 0.05 * cos(wt * PHI * 0.7)
+        );
+
+        // Drop jolts param
+        float dropJolt = DROP_INTENSITY * (1.0 - TREND_CONFIDENCE) * 0.1;
+        kaliParam.x += sin(iTime * 3.7) * dropJolt;
+        kaliParam.y += cos(iTime * 2.3) * dropJolt;
+        kaliParam = clamp(kaliParam, vec3(0.35), vec3(1.35));
+
+        // --- KALI ITERATION ---
+        vec3 p = vec3(fracUV, 0.5 + spectralEntropyNormalized * 0.2);
+
+        float trapOrigin = 1e10;
+        float trapAxis = 1e10;
+        float accumGlow = 0.0;
+        float accumDepth = 0.0;
+        vec3 p1 = p, p2 = p;
+
+        for (int i = 0; i < KALI_ITER; i++) {
+            p = abs(p);
+            float d = max(dot(p, p), 0.001);
+            p = p / d - kaliParam;
+
+            float dist = length(p);
+            trapOrigin = min(trapOrigin, dist);
+            trapAxis = min(trapAxis, min(abs(p.x), min(abs(p.y), abs(p.z))));
+
+            float weight = 1.0 / (1.0 + float(i) * 0.5);
+            accumGlow += exp(-dist * 4.0) * weight;
+            accumDepth += dist * weight;
+
+            if (i == 1) p1 = p;
+            if (i == 3) p2 = p;
+        }
+
+        // --- DEPTH from orbit traps ---
+        float tOrigin = clamp(trapOrigin * 0.8, 0.0, 1.0);
+        float tEdge = clamp(trapAxis * 2.0, 0.0, 1.0);
+        float tGlow = clamp(accumGlow * 0.4, 0.0, 1.0);
+        float tOrbit = clamp(accumDepth / float(KALI_ITER) * 0.3, 0.0, 1.0);
+
+        float depth = tOrigin * 0.2 + tEdge * 0.15 + (1.0 - tGlow) * 0.35 + tOrbit * 0.3;
+        depth = smoothstep(0.05, 0.95, depth);
+
+        // Drop pushes toward red
+        depth = mix(depth, 0.0, DROP_INTENSITY * 0.35);
+        depth = fract(depth + HUE_SHIFT);
+
+        col = chromadepth(depth);
+
+        // Brightness from fold glow
+        float foldGlow = clamp(accumGlow * 0.6, 0.0, 1.0);
+        float edgeBright = exp(-tEdge * 6.0) * 0.35;
+        float brightness = 0.4 + foldGlow * 0.35 + edgeBright;
+        brightness *= clamp(BRIGHT_MOD, 0.3, 1.2);
+        col *= brightness;
+
+        // Fractal edge highlight
+        float fEdge = length(vec2(dFdx(depth), dFdy(depth)));
+        col += smoothstep(0.0, 0.07, fEdge) * 0.15 * vec3(1.0, 0.95, 0.88);
+
+        // Fade near heart boundary for smooth edge
+        float edgeFade = smoothstep(0.0, -0.06, heartD);
+        col *= edgeFade;
+
+        col *= BEAT_FLASH;
+
+    } else {
+        // === OUTSIDE THE HEART: dark with red edge glow ===
+        float glowDist = smoothstep(0.15, 0.0, heartD);
+        // Red/orange glow right at the edge (pops forward in chromadepth)
+        col = chromadepth(0.05) * glowDist * EDGE_GLOW_STRENGTH;
+
+        // Beat makes the glow flare
+        col *= 1.0 + float(beat) * 0.3;
+
+        // Subtle pulsing ember glow
+        float pulse = sin(iTime * 2.0 + heartD * 10.0) * 0.5 + 0.5;
+        col += chromadepth(0.1) * glowDist * pulse * 0.08;
+    }
+
+    col = clamp(col, 0.0, 1.0);
+
+    // --- FRAME FEEDBACK with oklab ---
+    float fbAngle = iTime * 0.005;
+    vec2 centered = screenUV - 0.5;
+    float fbc = cos(fbAngle), fbs = sin(fbAngle);
+    vec2 rotUV = vec2(centered.x * fbc - centered.y * fbs,
+                      centered.x * fbs + centered.y * fbc) + 0.5;
+
+    vec2 fbUV = clamp(rotUV, 0.0, 1.0);
+    vec3 prev = getLastFrameColor(fbUV).rgb;
+
+    vec3 colOk = rgb2oklab(col);
+    vec3 prevOk = rgb2oklab(prev);
+
+    prevOk.x *= 0.95;
+    prevOk.yz *= 0.97;
+
+    float newAmount = 0.7;
+    newAmount -= TREND_CONFIDENCE * 0.07;
+    newAmount = clamp(newAmount, 0.55, 0.85);
+
+    vec3 blended = mix(prevOk, colOk, newAmount);
+
+    float blendedChroma = length(blended.yz);
+    float freshChroma = length(colOk.yz);
+    if (blendedChroma < freshChroma * 0.6) {
+        blended.yz = mix(blended.yz, colOk.yz, 0.35);
+    }
+
+    col = oklab2rgb(blended);
+
+    // Vignette
+    vec2 vc = screenUV - 0.5;
+    col *= 1.0 - dot(vc, vc) * 0.5;
+
+    col = clamp(col, 0.0, 1.0);
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/nella/heart/kali-pulse.frag
+++ b/shaders/nella/heart/kali-pulse.frag
@@ -340,16 +340,17 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
                 float hd = sdHeart(hPos);
 
                 if (hd < 0.0) {
-                    // Color: gold/yellow, warmth from roughness
-                    float hue = mix(0.08, 0.18, mix(rnd, 1.0 - HEART_WARMTH, 0.4));
-                    float sat = 0.85 + rnd * 0.1;
+                    // Color in oklab: gold/yellow via oklch hue
+                    // Warm gold ~1.2 rad, cooler yellow ~1.7 rad
+                    float hAngle = mix(1.1, 1.7, mix(rnd, 1.0 - HEART_WARMTH, 0.4));
 
-                    // Per-heart brightness: stagger slightly so they're not uniform
-                    // Larger hearts glow brighter during peaks, smaller stay dimmer
+                    // Per-heart brightness: stagger so they're not uniform
                     float perHeartBright = heartBright * mix(0.7, 1.0, rnd);
-                    float lit = mix(0.08, 0.5, perHeartBright);
+                    float L = mix(0.15, 0.7, perHeartBright);
+                    float C = 0.15 + perHeartBright * 0.08;
 
-                    vec3 hCol = hsl2rgb(vec3(hue, sat, lit));
+                    vec3 hCol = oklab2rgb(vec3(L, C * cos(hAngle), C * sin(hAngle)));
+                    hCol = max(hCol, vec3(0.0));
 
                     // Soft interior fade
                     float fill = smoothstep(0.0, -0.18, hd);
@@ -360,9 +361,10 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
                     heartCol = max(heartCol, hCol);
                 } else if (hd < 0.05) {
-                    // Warm glow halo — also always present, just dimmer
+                    // Warm glow halo in oklab
                     float glow = smoothstep(0.05, 0.0, hd) * 0.1 * heartBright;
-                    vec3 glowCol = hsl2rgb(vec3(0.1, 0.8, 0.35));
+                    vec3 glowLab = vec3(0.5, 0.12 * cos(1.3), 0.12 * sin(1.3));
+                    vec3 glowCol = max(oklab2rgb(glowLab), vec3(0.0));
                     heartCol = max(heartCol, glowCol * glow);
                 }
             }


### PR DESCRIPTION
## Summary

Three heart-themed ChromaDepth fractal shaders with oklab blending, created for Nella:

| Shader | Description | Preview |
|--------|-------------|---------|
| julia-trap | Julia set with heart-shaped orbit trap — hearts hidden throughout the fractal boundary | [preview](https://nellla-heart.paper-cranes-visuals.pages.dev/?shader=nella/heart/julia-trap) |
| fractal-bloom | Hearts spiraling outward along Mandelbrot orbits with fractal noise interiors | [preview](https://nellla-heart.paper-cranes-visuals.pages.dev/?shader=nella/heart/fractal-bloom) |
| kali-pulse | Single pulsing heart filled with a Kali fold fractal universe inside | [preview](https://nellla-heart.paper-cranes-visuals.pages.dev/?shader=nella/heart/kali-pulse) |

All three use:
- ChromaDepth coloring (red=near, violet=far) for 3D glasses
- Oklab color space for perceptually uniform frame feedback
- Full audio reactivity with the #define swap pattern
- Mobile-safe iteration counts
- Fullscreen support

## Test plan

- [ ] Open each shader preview link and verify it renders without errors
- [ ] Test with audio input — hearts should respond to bass, beats, spectral features
- [ ] Test on mobile device for performance
- [ ] Optionally test with ChromaDepth 3D glasses for depth effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)