### PR TITLE
fix: remove fake @image metadata from shaders

### DIFF
--- a/shaders/eddie-banana/banana-man.frag
+++ b/shaders/eddie-banana/banana-man.frag
@@ -2,7 +2,6 @@
 // @mobile: true
 // @favorite: true
 // @tags: banana, chromadepth, 3d, eddie, love, image
-// @image: images/banana-boy-1.png
 // Image-based dancing banana man with scattered Mandelbrot-path bananas
 // ChromaDepth: red=nearest, yellow=near, green=mid, blue=far, violet=farthest
 // http://localhost:6969/?shader=eddie-banana/banana-man&image=images/banana-boy-1.png

--- a/shaders/wooli/1.frag
+++ b/shaders/wooli/1.frag
@@ -1,7 +1,6 @@
 // @fullscreen: true
 // @favorite: true
 // @tags: wooli, mammoth, fractal, dubstep, ice
-// @image: images/wooli.png
 //
 // PRESETS:
 // Default — icy fractal mammoth

--- a/shaders/wooli/2.frag
+++ b/shaders/wooli/2.frag
@@ -1,7 +1,6 @@
 // @fullscreen: true
 // @favorite: true
 // @tags: wooli, mammoth, fractal, tapestry, oscilloscope
-// @image: images/wooli.png
 //
 // PRESETS:
 // Default — mammoth with scrolling tapestry line

--- a/shaders/wooli/chromadepth-1.frag
+++ b/shaders/wooli/chromadepth-1.frag
@@ -1,7 +1,6 @@
 // @fullscreen: true
 // @favorite: true
 // @tags: wooli, mammoth, fractal, dubstep, chromadepth, 3d
-// @image: images/wooli.png
 //
 // ChromaDepth version of wooli/1 — icy fractal mammoth with depth-mapped rainbow
 // Red = foreground (closest), Green = middle, Blue/Violet = farthest

--- a/shaders/wooli/chromadepth-2.frag
+++ b/shaders/wooli/chromadepth-2.frag
@@ -1,7 +1,6 @@
 // @fullscreen: true
 // @favorite: true
 // @tags: wooli, mammoth, fractal, tapestry, oscilloscope, chromadepth, 3d
-// @image: images/wooli.png
 //
 // ChromaDepth version of wooli/2 — mammoth with scrolling tapestry line
 // Red = foreground (closest), Green = middle, Blue/Violet = farthest


### PR DESCRIPTION
## Summary
- Remove `@image` metadata tag from banana-man and all wooli shaders — it's not a real tag, images load via `?image=` URL param only

🤖 Generated with [Claude Code](https://claude.com/claude-code)