### PR TITLE
docs: add errata for image deployment path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,7 @@ npm run dev  # Serves on localhost:6969
 - Auto-deploys to visuals.beadfamous.com via Cloudflare Pages
 - PRs to `shaders/<github-username>/` auto-merge
 - No backend required (static hosting)
+- **Images and static assets must go in `public/`** — see [docs/errata.md](docs/errata.md)
 
 ### Branch Preview URLs
 Every branch gets a Cloudflare Pages preview deployment at:

--- a/docs/errata.md
+++ b/docs/errata.md
@@ -1,0 +1,24 @@
+# Errata — Known Gotchas
+
+## Images must go in `public/images/`, not `images/`
+
+Cloudflare Pages only serves static assets from the `public/` directory. If you put an image in the repo-root `images/` folder, it will exist in the repo but **will not be deployed** — the URL will return an HTML fallback page instead of the image, and `getInitialFrameColor()` will silently fail.
+
+**Correct:**
+```
+public/images/my-image.png
+```
+
+**Wrong:**
+```
+images/my-image.png
+```
+
+The shader `?image=` parameter uses paths relative to the site root, so `?image=images/my-image.png` resolves to `public/images/my-image.png` at build time.
+
+You can verify an image is deployed correctly by checking the `content-type` header:
+```bash
+curl -sI "https://visuals.beadfamous.com/images/my-image.png" | grep content-type
+# Good: content-type: image/png
+# Bad:  content-type: text/html; charset=utf-8  ← not actually serving the image
+```


### PR DESCRIPTION
## Summary
- Add `docs/errata.md` documenting that images must go in `public/images/`, not repo-root `images/`
- Includes a curl command to verify correct deployment
- Link from CLAUDE.md deployment section

🤖 Generated with [Claude Code](https://claude.com/claude-code)