### PR TITLE
Fix cascading reloads on tab focus regain

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -23,12 +23,16 @@ self.addEventListener("message", (event) => {
     if(event.data.type === "network-changed") retryDeadRequests()
 })
 
+let lastReloadTime = 0
+const RELOAD_COOLDOWN = 3000
+
 const reloadAllClients = async () => {
-    //console.debug("Reloading all clients")
+    const now = Date.now()
+    if (now - lastReloadTime < RELOAD_COOLDOWN) return
+    lastReloadTime = now
     contentChanged = false
     const clients = await self.clients.matchAll()
     clients.forEach((client) => client.postMessage("reload"))
-    //console.debug("Reloaded", clients.length, "clients")
 }
 
 
@@ -173,12 +177,12 @@ const didThingsChange = async (request, response) => {
  */
 async function fetchWithCache(request) {
     const networkPromise = fetchWithRetry(request).then(async (response) => {
-        if (await didThingsChange(request, response)) {
+        const changed = await didThingsChange(request, response)
+        await addToCache(request, response)
+        if (changed) {
             contentChanged = true
-            // Trigger reload right away when changes are detected
             reloadAllClients()
         }
-        await addToCache(request, response)
         return response
     })
 

--- a/src/Visualizer.js
+++ b/src/Visualizer.js
@@ -116,6 +116,10 @@ export const makeVisualizer = async ({ canvas, initialImageUrl, fullscreen }) =>
         e.preventDefault()
     })
     canvas.addEventListener('webglcontextrestored', () => {
+        // Respect the same reload cooldown as the service worker
+        const lastReload = parseInt(sessionStorage.getItem('sw-last-reload') || '0')
+        if (Date.now() - lastReload < 5000) return
+        sessionStorage.setItem('sw-last-reload', String(Date.now()))
         window.location.reload()
     })
 

--- a/src/worker-communication.js
+++ b/src/worker-communication.js
@@ -16,10 +16,15 @@ window.addEventListener('load', async () => {
  * @param {MessageEvent} event
  */
 let reloadTimeout = null
+const RELOAD_GRACE = 5000
+
 const processServiceWorkerMessage = (event) => {
   if (event.data === 'reload') {
       if (reloadTimeout) return
+      const lastReload = parseInt(sessionStorage.getItem('sw-last-reload') || '0')
+      if (Date.now() - lastReload < RELOAD_GRACE) return
       reloadTimeout = setTimeout(() => {
+          sessionStorage.setItem('sw-last-reload', String(Date.now()))
           window.stop()
           window.location.reload()
       }, 100)


### PR DESCRIPTION
## Summary
- WebGL context loss on tab switch → `contextrestored` calls `reload()` → SW detects stale cache → sends another reload → cascade of black-screen flashes
- Root fix: update SW cache **before** triggering reload, add 3s cooldown on `reloadAllClients`, add 5s grace period (via `sessionStorage`) shared between SW messages and context-restore handler

## Test plan
- [x] Simulated WebGL context loss/restore — confirmed black screen + reload on original code
- [x] Simulated cascading SW "reload" messages — original code: 3+ reloads, fixed code: 1 reload then blocked
- [x] Verified grace period blocks both SW messages AND context-restore reloads within 5s window

🤖 Generated with [Claude Code](https://claude.com/claude-code)