### PR TITLE
Fix broken WebGL context attributes, preserve drawing buffer

### DIFF
--- a/src/Visualizer.js
+++ b/src/Visualizer.js
@@ -96,14 +96,11 @@ export const makeVisualizer = async ({ canvas, initialImageUrl, fullscreen }) =>
 
     const gl = canvas.getContext('webgl2', {
         antialias: false,
+        alpha: false,
+        depth: false,
+        stencil: false,
+        preserveDrawingBuffer: true,
         powerPreference: 'high-performance',
-        attributes: {
-            alpha: false,
-            depth: false,
-            stencil: false,
-            preserveDrawingBuffer: false,
-            pixelRatio: 1
-        }
     })
 
     if (!gl) {


### PR DESCRIPTION
## Summary
- Context attributes (`alpha`, `depth`, `stencil`, `preserveDrawingBuffer`) were nested under an `attributes` key that WebGL ignores — all were silently defaulting
- Moved to top level; set `preserveDrawingBuffer: true` so the canvas retains its last frame during macOS desktop transitions (Plash)

## Proof
| Attribute | Before (broken) | After (fixed) |
|---|---|---|
| `alpha` | `true` (default) | `false` ✓ |
| `depth` | `true` (default) | `false` ✓ |
| `preserveDrawingBuffer` | `false` (default) | `true` ✓ |

Verified via `gl.getContextAttributes()` — attributes were provably ignored before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)