### PR TITLE
Stop list page from forcing fullscreen on tap

### DIFF
--- a/list.js
+++ b/list.js
@@ -154,9 +154,9 @@ const MusicVisual = ({ name, fileUrl, visualizerUrl, filterText }) => {
       }
     } else {
       // If no presets, copy and navigate
-      const fullscreenUrl = buildFullscreenUrl(getFullUrl(targetUrl))
-      navigator.clipboard.writeText(fullscreenUrl)
-      window.location.href = fullscreenUrl
+      const url = getFullUrl(targetUrl)
+      navigator.clipboard.writeText(url)
+      window.location.href = url
     }
   }
 
@@ -219,9 +219,9 @@ const MusicVisual = ({ name, fileUrl, visualizerUrl, filterText }) => {
                   const params = Object.fromEntries(presetUrl.searchParams.entries())
                   remoteController.sendParams(params)
                 } else {
-                  const fullscreenUrl = buildFullscreenUrl(getFullUrl(preset))
-                  navigator.clipboard.writeText(fullscreenUrl)
-                  window.location.href = fullscreenUrl
+                  const url = getFullUrl(preset)
+                  navigator.clipboard.writeText(url)
+                  window.location.href = url
                 }
               }}>
                 <span>${getPresetName(preset, index)}</span>

--- a/shaders/subtronics.frag
+++ b/shaders/subtronics.frag
@@ -1,5 +1,4 @@
-// @fullscreen: true
-// http://localhost:6969/edit.html?fullscreen=true&image=images%2Fsubtronics.jpg
+// http://localhost:6969/edit.html?image=images%2Fsubtronics.jpg
 #define ZOOM_LEVEL mapValue(energyZScore, -1., 1., 0.5, 2.5)
 #define WAVES_STRENGTH spectralCrestZScore
 #define RIPPLE_FREQUENCY mapValue(spectralRoughnessZScore, -1., 1., 0.1, 10.)


### PR DESCRIPTION
## Summary
- Tapping a shader or preset in the list page was always routing through `buildFullscreenUrl`, which unconditionally appends `fullscreen=true`. Now only the dedicated fullscreen button does that.
- Removed `@fullscreen: true` metadata from `subtronics.frag`.

## Test plan
- [ ] Tap a shader in the list page — should navigate without `fullscreen=true` in the URL
- [ ] Tap a preset — same, no forced fullscreen
- [ ] Fullscreen button still adds `fullscreen=true`
- [ ] Remote control mode still works for both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)