### PR TITLE
Invert smoothing query param semantics

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,9 +130,9 @@ const setupAudio = async () => {
         const sourceNode = audioContext.createMediaStreamSource(stream);
         const historySize = parseInt(params.get('history_size') ?? '500');
         const fftSize = parseInt(params.get('fft_size') ?? '4096');
-        const smoothing = parseFloat(params.get('smoothing') ?? '0.15');
+        const smoothing = parseFloat(params.get('smoothing') ?? '0.85');
         const audioProcessor = new AudioProcessor(audioContext, sourceNode, historySize, fftSize);
-        audioProcessor.smoothingFactor = smoothing;
+        audioProcessor.smoothingFactor = 1 - smoothing;
         audioProcessor.start();
 
         return audioProcessor;

--- a/src/audio/AudioProcessor.js
+++ b/src/audio/AudioProcessor.js
@@ -30,7 +30,7 @@ export class AudioProcessor {
         this.currentFeatures = getFlatAudioFeatures()
         this.currentFeatures.beat = false
         this.smoothedFeatures = {}
-        this.smoothingFactor = 0.10 // Lower = smoother, higher = more responsive
+        this.smoothingFactor = 0.10 // Internal alpha: lower = smoother, higher = more responsive
     }
 
     createAnalyzer = () => {
@@ -59,7 +59,8 @@ export class AudioProcessor {
         const newFeatures = getFlatAudioFeatures(AudioFeatures, this.rawFeatures)
 
         // Check for manual override of smoothing factor
-        const currentSmoothing = window.cranes?.manualFeatures?.smoothing ?? this.smoothingFactor
+        const manualSmoothing = window.cranes?.manualFeatures?.smoothing
+        const currentSmoothing = manualSmoothing != null ? 1 - manualSmoothing : this.smoothingFactor
 
         // Apply exponential smoothing to reduce jitter
         for (const key in newFeatures) {


### PR DESCRIPTION
## Summary
- Inverts the `?smoothing=` query parameter so that **high values = smoother** (previously low values meant smoother, which was counterintuitive)
- Default changed from `0.15` to `0.85` (maps to same internal alpha of `0.15`)
- Runtime override via `window.cranes.manualFeatures.smoothing` is also inverted
- Internal exponential smoothing math is unchanged -- only the user-facing boundary is inverted

## Test plan
- [ ] Load with default (`?smoothing=` omitted) -- behavior should be identical to before
- [ ] `?smoothing=0.95` should be very smooth (low jitter)
- [ ] `?smoothing=0.05` should be very responsive (high jitter)
- [ ] `window.cranes.manualFeatures.smoothing = 0.9` at runtime should produce smooth output

🤖 Generated with [Claude Code](https://claude.com/claude-code)