### PR TITLE
feat: multiplayer editor with live cursors

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -3,8 +3,7 @@
 
 <head>
     <link rel="stylesheet" href="edit.css" />
-    <link rel="stylesheet" data-name="vs/editor/editor.main"
-        href="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs/editor/editor.main.min.css">
+    <link rel="stylesheet" href="./src/multiplayer/multiplayer.css" />
     <title>Paper Cranes - Editor</title>
     <script type="module" src="./src/worker-communication.js"></script>
 </head>
@@ -22,8 +21,12 @@
         <button id="reset">Reset</button>
     </div>
     <div id="monaco-editor"></div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs/loader.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs/editor/editor.main.js"></script>
+    <div id="multiplayer-peers"></div>
+    <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.53.0/min/vs/loader.js"></script>
+    <script>
+        require.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.53.0/min/vs' } })
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.53.0/min/vs/editor/editor.main.js"></script>
 
     <script type="module" src="./src/monaco.js"></script>
     <script type="module" src="./index.js"></script>

--- a/edit.js
+++ b/edit.js
@@ -3,6 +3,23 @@ import { useState, useEffect, useRef } from 'preact/hooks'
 import { html } from 'htm/preact'
 import { getRelativeOrAbsoluteShaderUrl } from './src/utils.js'
 import { createParamsManager } from './src/params/ParamsManager.js'
+import { initMultiplayerEditor } from './src/multiplayer/MultiplayerEditor.js'
+
+// Initialize multiplayer editing as soon as Monaco is ready
+const startMultiplayer = () => {
+    const editor = window.__monacoEditor
+    if (!editor) return
+    try {
+        initMultiplayerEditor(editor)
+    } catch (e) {
+        console.error('[MP] Failed to initialize multiplayer:', e)
+    }
+}
+if (window.__monacoEditor) {
+    startMultiplayer()
+} else {
+    window.addEventListener('monaco-editor-ready', startMultiplayer, { once: true })
+}
 
 // Check if we're in remote control mode
 const searchParams = new URLSearchParams(window.location.search)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       hypnosound:
         specifier: ^1.14.0
         version: 1.14.0
-      playwright:
-        specifier: ^1.55.1
-        version: 1.58.2
       preact:
         specifier: ^10.25.4
         version: 10.28.3
@@ -48,6 +45,9 @@ importers:
       glslang-validator-prebuilt:
         specifier: ^0.0.7
         version: 0.0.7
+      playwright:
+        specifier: ^1.55.1
+        version: 1.58.2
       prettier:
         specifier: ^3.4.2
         version: 3.8.1
@@ -304,66 +304,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}

--- a/src/monaco.js
+++ b/src/monaco.js
@@ -1,12 +1,19 @@
 async function init() {
-    //if we have a shader in the query param, return
-    // if (new URLSearchParams(window.location.search).get('shader')) return
+    console.log('[monaco.js] init() starting, monaco=', typeof monaco)
 
-    // add the worker as a blob url
+    // Load Monaco's worker via the AMD loader (same CDN base as editor.main)
+    // This cross-origin worker trick wraps it as a blob that importScripts() the real worker
+    const MONACO_CDN = 'https://cdn.jsdelivr.net/npm/monaco-editor@0.53.0/min/vs'
+    const workerBlob = new Blob(
+        [`self.MonacoEnvironment = { baseUrl: '${MONACO_CDN}/' };
+          importScripts('${MONACO_CDN}/base/worker/workerMain.js');`],
+        { type: 'text/javascript' }
+    )
+    const workerUrl = URL.createObjectURL(workerBlob)
+    self.MonacoEnvironment = {
+        getWorkerUrl: () => workerUrl
+    }
 
-    const res = await fetch('https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs/base/worker/workerMain.js')
-    const blob = await res.blob()
-    const workerUrl = URL.createObjectURL(blob)
     // Create the editor instance
     const editor = monaco.editor.create(document.getElementById('monaco-editor'), {
         value: '',
@@ -15,10 +22,10 @@ async function init() {
         minimap: { enabled: false },
         automaticLayout: true,
     });
-    // add the web workers
-    self.MonacoEnvironment = {
-        getWorkerUrl: () => workerUrl
-        }
+
+    // Expose for multiplayer / other modules
+    window.__monacoEditor = editor
+    window.dispatchEvent(new CustomEvent('monaco-editor-ready', { detail: { editor } }))
 
     // Watch for shader errors
     setInterval(() => {
@@ -738,4 +745,10 @@ async function init() {
 }
 
 // Wait for Monaco to be loaded from CDN
-window.addEventListener('load', () => init());
+console.log('[monaco.js] module loaded, readyState=', document.readyState)
+const runInit = () => init().catch(e => console.error('[monaco.js] init failed:', e))
+if (document.readyState === 'complete') {
+    runInit()
+} else {
+    window.addEventListener('load', runInit);
+}

--- a/src/multiplayer/MultiplayerEditor.js
+++ b/src/multiplayer/MultiplayerEditor.js
@@ -1,0 +1,242 @@
+import { WebSocketClient } from '../remote/WebSocketClient.js'
+import { getIdentity } from './identity.js'
+
+const STYLE_EL_ID = 'mp-peer-styles'
+
+const ensurePeerStyle = (userId, color, colorAlpha) => {
+    let styleEl = document.getElementById(STYLE_EL_ID)
+    if (!styleEl) {
+        styleEl = document.createElement('style')
+        styleEl.id = STYLE_EL_ID
+        document.head.appendChild(styleEl)
+    }
+    const className = `mp-peer-${userId.replace(/[^a-z0-9]/gi, '')}`
+    if (styleEl.textContent.includes(`.${className}-cursor`)) return className
+    styleEl.textContent += `
+        .${className}-cursor { background: ${color} !important; }
+        .${className}-cursor::before { background: ${color}; }
+        .${className}-selection { background: ${colorAlpha}; }
+    `
+    return className
+}
+
+export const initMultiplayerEditor = (editor) => {
+    const identity = getIdentity()
+    console.log('[MP] Starting multiplayer as', identity.name, identity.userId)
+
+    const peers = new Map()
+    let isApplyingRemoteEdit = false
+    let isReady = false
+    let peersEl = document.getElementById('multiplayer-peers')
+
+    const updatePeersUI = () => {
+        if (!peersEl) return
+        const chips = [
+            `<span class="mp-chip" style="background:${identity.color}">${identity.name} (you)</span>`,
+            ...Array.from(peers.values()).map(p =>
+                `<span class="mp-chip" style="background:${p.color}">${p.name}</span>`
+            ),
+        ]
+        peersEl.innerHTML = chips.join('')
+    }
+
+    const renderPeerCursor = (peer) => {
+        if (!peer.position) {
+            peer.decorationIds = editor.deltaDecorations(peer.decorationIds || [], [])
+            return
+        }
+        const className = ensurePeerStyle(peer.userId, peer.color, peer.colorAlpha)
+        const decorations = []
+        const { position, selection } = peer
+        decorations.push({
+            range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column),
+            options: {
+                className: `mp-peer-cursor ${className}-cursor`,
+                beforeContentClassName: `mp-peer-cursor ${className}-cursor`,
+                stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+                hoverMessage: { value: peer.name },
+            },
+        })
+        if (selection && (selection.startLineNumber !== selection.endLineNumber || selection.startColumn !== selection.endColumn)) {
+            decorations.push({
+                range: new monaco.Range(
+                    selection.startLineNumber, selection.startColumn,
+                    selection.endLineNumber, selection.endColumn
+                ),
+                options: {
+                    className: `mp-peer-selection ${className}-selection`,
+                },
+            })
+        }
+        peer.decorationIds = editor.deltaDecorations(peer.decorationIds || [], decorations)
+
+        // Inject data-mp-name on the cursor element for the ::before label
+        requestAnimationFrame(() => {
+            document.querySelectorAll(`.${className}-cursor`).forEach(el => {
+                el.setAttribute('data-mp-name', peer.name)
+            })
+        })
+    }
+
+    const getOrCreatePeer = (userId, name, color, colorAlpha) => {
+        let peer = peers.get(userId)
+        if (!peer) {
+            peer = { userId, name, color, colorAlpha, decorationIds: [] }
+            peers.set(userId, peer)
+            updatePeersUI()
+        } else {
+            peer.name = name
+            peer.color = color
+            peer.colorAlpha = colorAlpha
+        }
+        return peer
+    }
+
+    const removePeer = (userId) => {
+        const peer = peers.get(userId)
+        if (!peer) return
+        if (peer.decorationIds?.length) {
+            editor.deltaDecorations(peer.decorationIds, [])
+        }
+        peers.delete(userId)
+        updatePeersUI()
+    }
+
+    const handleMessage = (message) => {
+        const { type, data } = message
+        if (!type?.startsWith('mp-')) return
+
+        if (data?.userId === identity.userId) return
+
+        switch (type) {
+            case 'mp-hello': {
+                // A new peer is asking who's here — respond with our presence + current buffer
+                client.send('mp-presence', identity)
+                client.send('mp-sync-full', {
+                    userId: identity.userId,
+                    targetUserId: data.userId,
+                    content: editor.getValue(),
+                })
+                break
+            }
+            case 'mp-presence': {
+                getOrCreatePeer(data.userId, data.name, data.color, data.colorAlpha)
+                break
+            }
+            case 'mp-leave': {
+                removePeer(data.userId)
+                break
+            }
+            case 'mp-cursor': {
+                const peer = getOrCreatePeer(data.userId, data.name, data.color, data.colorAlpha)
+                peer.position = data.position
+                peer.selection = data.selection
+                renderPeerCursor(peer)
+                break
+            }
+            case 'mp-edit': {
+                isApplyingRemoteEdit = true
+                try {
+                    const edits = data.changes.map(c => ({
+                        range: new monaco.Range(
+                            c.range.startLineNumber, c.range.startColumn,
+                            c.range.endLineNumber, c.range.endColumn
+                        ),
+                        text: c.text,
+                        forceMoveMarkers: true,
+                    }))
+                    editor.getModel().applyEdits(edits)
+                } finally {
+                    isApplyingRemoteEdit = false
+                }
+                break
+            }
+            case 'mp-sync-full': {
+                if (data.targetUserId && data.targetUserId !== identity.userId) break
+                if (hasReceivedFullSync) break
+                hasReceivedFullSync = true
+                isApplyingRemoteEdit = true
+                try {
+                    editor.setValue(data.content)
+                } finally {
+                    isApplyingRemoteEdit = false
+                }
+                break
+            }
+        }
+    }
+
+    let hasReceivedFullSync = false
+
+    const handleStatusChange = (status) => {
+        console.log('[MP] Status:', status)
+        if (status === 'connected') {
+            // Announce ourselves and request state from any existing peers
+            client.send('mp-presence', identity)
+            client.send('mp-hello', { userId: identity.userId })
+            // Go live after a brief settle period so the initial setValue
+            // from monaco.js doesn't get broadcast as an edit
+            setTimeout(() => {
+                isReady = true
+                console.log('[MP] Ready — broadcasting edits')
+            }, 800)
+        }
+    }
+
+    const client = new WebSocketClient(handleMessage, handleStatusChange)
+    client.connect()
+
+    // Broadcast local cursor/selection changes
+    let cursorSendTimer = null
+    const sendCursor = () => {
+        if (!client.isConnected) return
+        const position = editor.getPosition()
+        const selection = editor.getSelection()
+        client.send('mp-cursor', {
+            ...identity,
+            position: position ? { lineNumber: position.lineNumber, column: position.column } : null,
+            selection: selection ? {
+                startLineNumber: selection.startLineNumber,
+                startColumn: selection.startColumn,
+                endLineNumber: selection.endLineNumber,
+                endColumn: selection.endColumn,
+            } : null,
+        })
+    }
+    const scheduleCursorSend = () => {
+        if (cursorSendTimer) return
+        cursorSendTimer = setTimeout(() => {
+            cursorSendTimer = null
+            sendCursor()
+        }, 30)
+    }
+
+    editor.onDidChangeCursorPosition(scheduleCursorSend)
+    editor.onDidChangeCursorSelection(scheduleCursorSend)
+
+    editor.onDidChangeModelContent((e) => {
+        if (isApplyingRemoteEdit) return
+        if (!client.isConnected) return
+        if (!isReady) return
+        client.send('mp-edit', {
+            userId: identity.userId,
+            changes: e.changes.map(c => ({
+                range: {
+                    startLineNumber: c.range.startLineNumber,
+                    startColumn: c.range.startColumn,
+                    endLineNumber: c.range.endLineNumber,
+                    endColumn: c.range.endColumn,
+                },
+                text: c.text,
+            })),
+        })
+    })
+
+    window.addEventListener('beforeunload', () => {
+        if (client.isConnected) client.send('mp-leave', { userId: identity.userId })
+    })
+
+    updatePeersUI()
+
+    return { identity, peers, client }
+}

--- a/src/multiplayer/identity.js
+++ b/src/multiplayer/identity.js
@@ -1,0 +1,31 @@
+const ADJECTIVES = ['Swift', 'Bright', 'Cosmic', 'Lunar', 'Neon', 'Pulsing', 'Radiant', 'Fractal', 'Prismatic', 'Solar']
+const NOUNS = ['Falcon', 'Comet', 'Dolphin', 'Phoenix', 'Tiger', 'Nebula', 'Panther', 'Vortex', 'Wolf', 'Orca']
+
+const pick = (arr) => arr[Math.floor(Math.random() * arr.length)]
+
+const hashHue = (str) => {
+    let h = 0
+    for (const c of str) h = ((h << 5) - h + c.charCodeAt(0)) | 0
+    return Math.abs(h) % 360
+}
+
+export const getIdentity = () => {
+    // sessionStorage: each tab gets its own identity, so two tabs in the
+    // same browser are treated as two different users. Name persists across
+    // reloads within the same tab, but a new tab is a new user.
+    const stored = sessionStorage.getItem('mp-identity')
+    if (stored) {
+        try { return JSON.parse(stored) } catch {}
+    }
+    const userId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+    const name = `${pick(ADJECTIVES)} ${pick(NOUNS)}`
+    const hue = hashHue(userId)
+    const identity = {
+        userId,
+        name,
+        color: `hsl(${hue}, 70%, 55%)`,
+        colorAlpha: `hsla(${hue}, 70%, 55%, 0.25)`,
+    }
+    sessionStorage.setItem('mp-identity', JSON.stringify(identity))
+    return identity
+}

--- a/src/multiplayer/multiplayer.css
+++ b/src/multiplayer/multiplayer.css
@@ -1,0 +1,48 @@
+.mp-peer-cursor {
+    position: absolute;
+    width: 2px !important;
+    margin-left: -1px;
+    pointer-events: none;
+}
+
+.mp-peer-cursor::before {
+    content: attr(data-mp-name);
+    position: absolute;
+    top: -1.2em;
+    left: 0;
+    padding: 1px 4px;
+    font-size: 10px;
+    font-family: system-ui, sans-serif;
+    color: white;
+    background: var(--mp-color, #888);
+    border-radius: 2px 2px 2px 0;
+    white-space: nowrap;
+    z-index: 10;
+}
+
+.mp-peer-selection {
+    background: var(--mp-color-alpha, rgba(136, 136, 136, 0.25));
+}
+
+#multiplayer-peers {
+    position: fixed;
+    bottom: 10px;
+    left: 10px;
+    padding: 6px 10px;
+    background: rgba(0, 0, 0, 0.7);
+    color: white;
+    font-family: system-ui, sans-serif;
+    font-size: 11px;
+    border-radius: 4px;
+    z-index: 10000;
+    pointer-events: none;
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
+#multiplayer-peers .mp-chip {
+    padding: 2px 6px;
+    border-radius: 3px;
+    color: white;
+}


### PR DESCRIPTION
## Summary

Updates Monaco to 0.53.0 and makes the edit page multiplayer — Live-Share-style. Multiple users connecting to the same dev server see each other's cursors, selections, and edits in real time.

- **Monaco 0.53.0** via jsdelivr, loaded through the AMD loader (worker now wraps `importScripts` of the CDN worker since 0.53 changed the worker path)
- **New `src/multiplayer/` module** — identity generation (random adjective+noun name, HSL color from userId hash, stored in `sessionStorage` so each tab is a distinct user), and a `MultiplayerEditor` that rides on top of the existing `/ws` infrastructure in `vite-plugins/remote-ws-plugin.js`
- **Message protocol** (`mp-presence`, `mp-hello`, `mp-cursor`, `mp-edit`, `mp-sync-full`, `mp-leave`) piggybacks the server's broadcast-to-other-clients behavior
- **Peer cursors** render as colored bars with floating name labels via Monaco `deltaDecorations`; selections render as translucent highlights
- **Late joiners** request a full-buffer sync from any existing peer on connect; `isReady` grace period prevents the initial `setValue` from being echoed as an edit
- Peer chips moved to bottom-left so they don't cover code

## Test plan

- [x] Monaco 0.53.0 loads and editor initializes
- [x] Two tabs show each other's presence chips
- [x] Typing in tab A reaches tab B (real keyboard + programmatic `executeEdits`)
- [x] Typing in tab B reaches tab A (bidirectional)
- [x] Peer cursor renders with name label at the correct line/column
- [ ] Test from two physically separate devices on the same dev server
- [ ] Test with 3+ concurrent users to verify full-sync targeting
- [ ] Verify `mp-leave` cleanup when a tab closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)