### PR TITLE
revert: Monaco ESM migration, restore AMD loader

### DIFF
--- a/edit.css
+++ b/edit.css
@@ -36,44 +36,8 @@ body {
   top: 0;
   width: 50vw;
   height: 100vh;
-  padding-top: 24px;
-  background: #1e1e1e;
-  box-sizing: border-box;
 }
 
-/* Monaco 0.53 EditContext elements — the ESM CDN bundle ships without
-   styles for these, leaving them visible as white rectangles. Clip them. */
-#monaco-editor .native-edit-context,
-#monaco-editor .ime-text-area {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  top: 0 !important;
-  left: 0 !important;
-  opacity: 0 !important;
-  pointer-events: none;
-}
-
-/* vs-dark theme colors — the esm.sh bundle omits Monaco's runtime-injected
-   theme stylesheet, so the editor background and gutter come through
-   transparent. Apply the canonical vs-dark palette directly. */
-#monaco-editor .monaco-editor,
-#monaco-editor .monaco-editor-background,
-#monaco-editor .monaco-editor .inputarea.ime-input {
-  background-color: #1e1e1e;
-}
-#monaco-editor .monaco-editor .margin {
-  background-color: #1e1e1e;
-}
-#monaco-editor .monaco-editor .view-lines {
-  color: #d4d4d4;
-}
-#monaco-editor .monaco-editor .line-numbers {
-  color: #858585;
-}
-#monaco-editor .monaco-editor .current-line ~ .line-numbers {
-  color: #c6c6c6;
-}
 #monaco-editor .monaco-editor .cursors-layer .cursor {
   width: 2px !important;
   background-color: #ff79c6 !important;
@@ -83,12 +47,6 @@ body {
 #monaco-editor .monaco-editor .view-overlays .current-line {
   border: none !important;
   background: rgba(255, 121, 198, 0.06);
-}
-#monaco-editor .monaco-editor .minimap {
-  background-color: #1e1e1e;
-}
-#monaco-editor .monaco-scrollable-element > .scrollbar > .slider {
-  background: rgba(121, 121, 121, 0.4);
 }
 
 /* Feature editor drawer */

--- a/edit.html
+++ b/edit.html
@@ -22,6 +22,12 @@
     </div>
     <div id="monaco-editor"></div>
     <div id="multiplayer-peers"></div>
+    <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/loader.js"></script>
+    <script>
+        require.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs' } })
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/editor/editor.main.js"></script>
+
     <script type="module" src="./src/monaco.js"></script>
     <script type="module" src="./index.js"></script>
     <script type="module" src="./edit.js"></script>

--- a/edit.js
+++ b/edit.js
@@ -4,12 +4,21 @@ import { html } from 'htm/preact'
 import { getRelativeOrAbsoluteShaderUrl } from './src/utils.js'
 import { createParamsManager } from './src/params/ParamsManager.js'
 import { initMultiplayerEditor } from './src/multiplayer/MultiplayerEditor.js'
-import { editor } from './src/monaco.js'
 
-try {
-    initMultiplayerEditor(editor)
-} catch (e) {
-    console.error('[MP] Failed to initialize multiplayer:', e)
+// Initialize multiplayer editing as soon as Monaco is ready
+const startMultiplayer = () => {
+    const editor = window.__monacoEditor
+    if (!editor) return
+    try {
+        initMultiplayerEditor(editor)
+    } catch (e) {
+        console.error('[MP] Failed to initialize multiplayer:', e)
+    }
+}
+if (window.__monacoEditor) {
+    startMultiplayer()
+} else {
+    window.addEventListener('monaco-editor-ready', startMultiplayer, { once: true })
 }
 
 // Check if we're in remote control mode
@@ -472,7 +481,8 @@ const FeatureAdder = () => {
         if (isDrawerOpen && newFeatureInputRef.current) {
             // Store current cursor position before focusing drawer
             try {
-                {
+                const editor = window.__monacoEditor
+                if (editor) {
                     editorCursorPositionRef.current = editor.getPosition()
                 }
             } catch (e) {
@@ -487,7 +497,8 @@ const FeatureAdder = () => {
             // Focus monaco editor when drawer closes
             setTimeout(() => {
                 try {
-                    {
+                    const editor = window.__monacoEditor
+                    if (editor) {
                         editor.focus()
                         // Restore cursor position if we have one saved
                         if (editorCursorPositionRef.current) {

--- a/src/monaco.js
+++ b/src/monaco.js
@@ -1,16 +1,24 @@
-// Monaco version — bump this single line to upgrade
-import * as monaco from 'https://esm.sh/monaco-editor@0.53.0?bundle'
+async function init() {
+    const res = await fetch('https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs/base/worker/workerMain.js')
+    const blob = await res.blob()
+    const workerUrl = URL.createObjectURL(blob)
 
-export { monaco }
-
-// Create the editor instance
-export const editor = monaco.editor.create(document.getElementById('monaco-editor'), {
+    // Create the editor instance
+    const editor = monaco.editor.create(document.getElementById('monaco-editor'), {
         value: '',
         language: 'glsl',
         theme: 'vs-dark',
         minimap: { enabled: false },
         automaticLayout: true,
     });
+
+    self.MonacoEnvironment = {
+        getWorkerUrl: () => workerUrl
+    }
+
+    // Expose for multiplayer / other modules
+    window.__monacoEditor = editor
+    window.dispatchEvent(new CustomEvent('monaco-editor-ready', { detail: { editor } }))
 
     // Watch for shader errors
     setInterval(() => {
@@ -727,3 +735,13 @@ export const editor = monaco.editor.create(document.getElementById('monaco-edito
             }
         }
     })
+}
+
+// Wait for Monaco to be loaded from CDN
+console.log('[monaco.js] module loaded, readyState=', document.readyState)
+const runInit = () => init().catch(e => console.error('[monaco.js] init failed:', e))
+if (document.readyState === 'complete') {
+    runInit()
+} else {
+    window.addEventListener('load', runInit);
+}

--- a/src/multiplayer/MultiplayerEditor.js
+++ b/src/multiplayer/MultiplayerEditor.js
@@ -1,6 +1,5 @@
 import { WebSocketClient } from '../remote/WebSocketClient.js'
 import { getIdentity } from './identity.js'
-import { monaco } from '../monaco.js'
 
 const STYLE_EL_ID = 'mp-peer-styles'
 


### PR DESCRIPTION
## Summary

The ESM migration (2842aa7) moved Monaco from the AMD loader to `import * as monaco from 'esm.sh/monaco-editor?bundle'`, which intentionally dropped Web Workers and ran language services on the main thread. In practice the editor became visibly laggy, and the esm.sh bundle also omitted scrollbar, vs-dark theme, and EditContext styles — previously papered over with ~60 lines of hardcoded CSS overrides in `edit.css`.

This PR restores the AMD loader approach, which keeps language services in real Web Workers (fast), and drops all the CSS workarounds since Monaco's own stylesheet now loads properly.

- **edit.html**: re-add the three jsdelivr loader / require.config / editor.main script tags. Pinned to **0.52.2** — 0.53's worker script fails under the blob/importScripts trick when the host is a module script (`Module scripts don't support importScripts()`).
- **src/monaco.js**: restore the fetch-and-blob worker loader from the pre-multiplayer era (0.52.2 `workerMain.js` → blob URL → `MonacoEnvironment.getWorkerUrl`). Re-expose `window.__monacoEditor` and dispatch `monaco-editor-ready` so other modules can hook in.
- **edit.js**: drop `import { editor } from './src/monaco.js'`; use `window.__monacoEditor` in multiplayer init and the drawer-cursor-restore block.
- **MultiplayerEditor.js**: drop `import { monaco }` — with the AMD loader, `monaco` is a true global again.
- **edit.css**: strip the ESM workaround blocks (EditContext clipping, vs-dark palette hardcoding, `#monaco-editor` padding/background). Keep d16b8b0's cursor-size fix and button/palette restyling — genuine UX improvements independent of the loader.

## Test plan

- [x] `/edit.html` loads with zero console errors
- [x] 555-line shader (tie-dye.frag) renders and scrolls smoothly
- [x] Scrollbar, syntax highlighting, and vs-dark theme come from Monaco's real stylesheet
- [x] `window.__monacoEditor` global populated; multiplayer init runs
- [x] Drawer open/close still saves/restores Monaco cursor position
- [ ] Two browsers on the same dev server see each other's cursors
- [ ] Firefox microphone reconnect flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)