### PR TITLE
feat: bidirectional editor-filesystem sync in dev mode

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -692,6 +692,14 @@ const FeatureAdder = () => {
         try {
             const shaderCode = await getRelativeOrAbsoluteShaderUrl(searchParams.get('shader'))
             localStorage.setItem('cranes-manual-code', shaderCode)
+
+            if (import.meta.hot) {
+                // Dev mode: keep ?shader= in URL so editor-sync knows which file to save to.
+                // Monaco init will load from the filesystem via ?shader= param.
+                return false
+            }
+
+            // Production: strip ?shader= and reload (original behavior)
             const newUrl = new URL(window.location)
             newUrl.searchParams.delete('shader')
             window.history.replaceState({}, '', newUrl)

--- a/index.js
+++ b/index.js
@@ -423,3 +423,10 @@ const main = async () => {
 }
 
 main()
+
+// Reload the page when shader files change on disk (replaces full-reload from shader-plugin)
+if (import.meta.hot) {
+    import.meta.hot.on('shaders-changed', () => {
+        location.reload()
+    })
+}

--- a/list.js
+++ b/list.js
@@ -638,3 +638,10 @@ const List = () => {
 }
 
 render(html`<${List} />`, document.getElementsByTagName('main')[0])
+
+// Reload the page when shader files change on disk
+if (import.meta.hot) {
+    import.meta.hot.on('shaders-changed', () => {
+        location.reload()
+    })
+}

--- a/src/monaco.js
+++ b/src/monaco.js
@@ -567,8 +567,22 @@ async function init() {
     // Initialize editor content
     const searchParams = new URLSearchParams(window.location.search);
     (async () => {
-        // Normal initialization - only runs if no shader param or fetch failed
-        let shader = localStorage.getItem('cranes-manual-code')
+        let shader = null
+
+        // If ?shader= is set, load from the filesystem
+        const shaderParam = searchParams.get('shader')
+        if (shaderParam) {
+            try {
+                const path = shaderParam.endsWith('.frag') ? shaderParam : `${shaderParam}.frag`
+                const res = await fetch(`/shaders/${path}`)
+                if (res.ok) shader = await res.text()
+            } catch (e) {
+                console.warn('[monaco] Failed to load shader from filesystem:', e)
+            }
+        }
+
+        // Fall back to localStorage, then default
+        if (!shader) shader = localStorage.getItem('cranes-manual-code')
         if (!shader) {
             const res = await fetch('/shaders/default.frag')
             shader = await res.text()
@@ -578,6 +592,28 @@ async function init() {
         editor.pushUndoStop()
         editor.layout()
     })()
+
+    const getShaderParam = () => new URLSearchParams(window.location.search).get('shader')
+
+    const saveToFilesystem = import.meta.hot
+        ? async (code) => {
+            const shader = getShaderParam()
+            if (!shader) return
+            try {
+                const res = await fetch('/__save-shader', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ shader, code }),
+                })
+                if (!res.ok) {
+                    const err = await res.json().catch(() => ({}))
+                    console.error('[editor-sync] Save failed:', err.error || res.statusText)
+                }
+            } catch (e) {
+                // Dev server not running — silently skip
+            }
+        }
+        : () => {} // No-op in production
 
     const save = () => {
         editor.pushUndoStop()
@@ -592,7 +628,34 @@ async function init() {
             window.cranes.shader = code
             localStorage.setItem('cranes-manual-code', code)
         }
+
+        // Save to filesystem when editing a named shader in dev mode
+        saveToFilesystem(code)
+
         editor.pushUndoStop()
+    }
+
+    // Listen for filesystem changes via Vite HMR
+    if (import.meta.hot) {
+        import.meta.hot.on('shader-update', ({ shader, code }) => {
+            const currentShader = getShaderParam()
+            if (!currentShader || shader !== currentShader) return
+
+            // Skip if content is identical (e.g. our own save echoing back)
+            if (editor.getValue() === code) return
+
+            console.log(`[editor-sync] File changed on disk: ${shader}`)
+            editor.pushUndoStop()
+            editor.setValue(code)
+            editor.pushUndoStop()
+
+            // Push to visualizer
+            if (window.paramsManager) {
+                window.paramsManager.setShader(code)
+            } else if (window.cranes) {
+                window.cranes.shader = code
+            }
+        })
     }
 
     document.querySelector('#save').addEventListener('click', save)

--- a/src/monaco.js
+++ b/src/monaco.js
@@ -645,9 +645,19 @@ async function init() {
             if (editor.getValue() === code) return
 
             console.log(`[editor-sync] File changed on disk: ${shader}`)
-            editor.pushUndoStop()
-            editor.setValue(code)
-            editor.pushUndoStop()
+
+            // Suppress multiplayer broadcast — HMR already pushes to all
+            // connected peers, so relaying via multiplayer would be redundant
+            // and would send a full buffer replace that stomps concurrent edits.
+            const mpFlag = editor.__isApplyingRemoteEdit
+            if (mpFlag) mpFlag(true)
+            try {
+                editor.pushUndoStop()
+                editor.setValue(code)
+                editor.pushUndoStop()
+            } finally {
+                if (mpFlag) mpFlag(false)
+            }
 
             // Push to visualizer
             if (window.paramsManager) {

--- a/src/multiplayer/MultiplayerEditor.js
+++ b/src/multiplayer/MultiplayerEditor.js
@@ -26,6 +26,12 @@ export const initMultiplayerEditor = (editor) => {
 
     const peers = new Map()
     let isApplyingRemoteEdit = false
+    // Expose flag for HMR handler in monaco.js — disk changes reach all
+    // peers via HMR directly, so they shouldn't also broadcast via multiplayer.
+    editor.__isApplyingRemoteEdit = (val) => {
+        if (val !== undefined) isApplyingRemoteEdit = val
+        return isApplyingRemoteEdit
+    }
     let isReady = false
     let peersEl = document.getElementById('multiplayer-peers')
 

--- a/vite-plugins/editor-sync-plugin.js
+++ b/vite-plugins/editor-sync-plugin.js
@@ -1,0 +1,70 @@
+import { readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+
+const SHADER_DIR = 'shaders'
+
+export function editorSyncPlugin() {
+  return {
+    name: 'vite-plugin-editor-sync',
+
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        if (req.method !== 'POST' || req.url !== '/__save-shader') return next()
+
+        let body = ''
+        req.on('data', (chunk) => { body += chunk })
+        req.on('end', async () => {
+          try {
+            const { shader, code } = JSON.parse(body)
+            if (!shader || !code) {
+              res.writeHead(400, { 'Content-Type': 'application/json' })
+              return res.end(JSON.stringify({ error: 'Missing shader or code' }))
+            }
+
+            const normalized = shader.replace(/\.\./g, '').replace(/^\//, '')
+            const filePath = join(SHADER_DIR, `${normalized}.frag`)
+
+            await writeFile(filePath, code, 'utf-8')
+            console.log(`[editor-sync] Saved ${filePath}`)
+
+            res.writeHead(200, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ ok: true, path: filePath }))
+          } catch (e) {
+            console.error('[editor-sync] Save failed:', e.message)
+            res.writeHead(500, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: e.message }))
+          }
+        })
+      })
+
+      server.watcher.on('change', async (filePath) => {
+        if (!filePath.endsWith('.frag')) return
+
+        const projectRoot = server.config.root
+        const relative = filePath.startsWith(projectRoot)
+          ? filePath.slice(projectRoot.length + 1)
+          : filePath
+
+        if (!relative.startsWith(SHADER_DIR + '/')) return
+
+        const shaderName = relative
+          .slice(SHADER_DIR.length + 1)
+          .replace(/\.frag$/, '')
+
+        try {
+          const code = await readFile(filePath, 'utf-8')
+          server.ws.send({
+            type: 'custom',
+            event: 'shader-update',
+            data: { shader: shaderName, code },
+          })
+          console.log(`[editor-sync] Pushed ${shaderName} to editor`)
+        } catch (e) {
+          console.error(`[editor-sync] Failed to read ${filePath}:`, e.message)
+        }
+      })
+
+      console.log('[editor-sync] Bidirectional shader sync enabled')
+    },
+  }
+}

--- a/vite-plugins/shader-plugin.js
+++ b/vite-plugins/shader-plugin.js
@@ -159,7 +159,14 @@ export function shaderPlugin() {
         await generateManifests()
         console.log(`[shaders] ${eventType}: ${path} (${count} total)`)
 
-        server.ws.send({ type: 'full-reload' })
+        // Send a custom event instead of full-reload so the editor page
+        // can handle shader changes without losing editor state.
+        // Pages that need a full reload can listen for this event and reload themselves.
+        server.ws.send({
+          type: 'custom',
+          event: 'shaders-changed',
+          data: { path, eventType, count },
+        })
       }
 
       watcher.on('add', (path) => regenerate('added', path))

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import { resolve } from 'path'
 import { execSync } from 'child_process'
 import { shaderPlugin } from './vite-plugins/shader-plugin.js'
 import { remoteWsPlugin } from './vite-plugins/remote-ws-plugin.js'
+import { editorSyncPlugin } from './vite-plugins/editor-sync-plugin.js'
 
 
 const branchToPort = (branch) => {
@@ -45,5 +46,5 @@ export default defineConfig({
       external: (id) => id.startsWith('https://'),
     },
   },
-  plugins: [shaderPlugin(), remoteWsPlugin()],
+  plugins: [shaderPlugin(), remoteWsPlugin(), editorSyncPlugin()],
 })


### PR DESCRIPTION
## Summary
- Editor saves (Ctrl+S) now write shader code to disk when `?shader=` is in the URL, via a new `editorSyncPlugin` Vite plugin with a `POST /__save-shader` endpoint
- External file changes (e.g. editing in VS Code) push updates back to the Monaco editor via Vite HMR custom events
- Production behavior is unchanged — filesystem sync is gated behind `import.meta.hot` and tree-shaken out of builds

## Test plan
- [x] Dev server starts cleanly with `[editor-sync] Bidirectional shader sync enabled`
- [x] Open `edit.html?shader=plasma`, edit in browser, Ctrl+S → file written to disk
- [x] Edit `.frag` file on disk → editor updates without page reload
- [x] Production build succeeds with no errors
- [x] No console errors in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)