### PR TITLE
feat: add audio=none query param

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,8 +106,9 @@ const setupCanvasEvents = (canvas) => {
 const noAudio = { getFeatures: () => ({}) }
 
 const setupAudio = async () => {
-    // if we have a query param that says 'noaudio=true', just return a dummy audio processor
-    if (params.get('noaudio') === 'true' || params.get('embed') === 'true') {
+    // audio=none disables audio input (consistent with audio=tab pattern)
+    // noaudio=true and embed=true are kept for backwards compatibility
+    if (params.get('audio') === 'none' || params.get('noaudio') === 'true' || params.get('embed') === 'true') {
         return noAudio
     }
 

--- a/playlist.js
+++ b/playlist.js
@@ -60,7 +60,7 @@ const setupCanvasEvents = (canvas) => {
 const noAudio = { getFeatures: () => ({}) }
 
 const setupAudio = async () => {
-    if (params.get('noaudio') === 'true') return noAudio
+    if (params.get('audio') === 'none' || params.get('noaudio') === 'true') return noAudio
 
     try {
         const devices = await navigator.mediaDevices.enumerateDevices()

--- a/src/shader-transformers/shader-wrapper.js
+++ b/src/shader-transformers/shader-wrapper.js
@@ -13,7 +13,7 @@ const getKnownUniforms = () => {
 const getQueryParamUniforms = (shader, otherUniforms = '') => {
     if (typeof window === 'undefined') return ''
     const params = new URLSearchParams(window.location.search)
-    const knownParams = new Set(['shader', 'noaudio', 'embed', 'fullscreen', 'remote', 'fft_size', 'smoothing', 'history_size', 'controller', 'performance'])
+    const knownParams = new Set(['shader', 'audio', 'noaudio', 'embed', 'fullscreen', 'remote', 'fft_size', 'smoothing', 'history_size', 'controller', 'performance'])
     const knownUniforms = getKnownUniforms()
 
     // Combine shader and other uniform declarations, strip whitespace for matching


### PR DESCRIPTION
## Summary
- Adds `?audio=none` as a way to disable audio input, consistent with the existing `?audio=tab` pattern
- Keeps `?noaudio=true` and `?embed=true` working for backwards compatibility
- Adds `audio` to the known params exclusion set so it doesn't get injected as a shader uniform

## Test plan
- [ ] Verify `?audio=none` disables audio (no mic prompt, features return empty)
- [ ] Verify `?noaudio=true` still works
- [ ] Verify `?audio=tab` still works
- [ ] Verify `?audio=none` doesn't create a shader uniform

🤖 Generated with [Claude Code](https://claude.com/claude-code)