### PR TITLE
style: compact list page CSS for desktop

### DIFF
--- a/list.html
+++ b/list.html
@@ -12,6 +12,14 @@
       --padding: clamp(4px, 1vw, 8px);
     }
 
+    @media (min-width: 1200px) {
+      :root {
+        --title-size: 18px;
+        --text-size: 14px;
+        --padding: 4px;
+      }
+    }
+
     /* Reset & Layout */
     * {
       box-sizing: border-box;
@@ -165,36 +173,83 @@
     }
 
     @media (min-width: 1200px) {
+      body {
+        line-height: 1.3;
+      }
+
+      main {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 8px 16px;
+      }
+
       .shader-list>li {
-        padding: calc(var(--padding) * 2) 0;
+        padding: 4px 8px;
+      }
+
+      .main-link {
+        padding: 2px 4px;
       }
 
       .main-link-actions {
-        gap: calc(var(--padding) * 2);
+        gap: 8px;
       }
 
       .main-link-actions>* {
-        padding: 0 50px;
+        padding: 0 12px;
+      }
+
+      .copy-link svg {
+        width: 16px;
+        height: 16px;
+      }
+
+      .main-link+ul .copy-link svg {
+        width: 14px;
+        height: 14px;
+      }
+
+      .main-link+ul {
+        margin-left: 24px;
+      }
+
+      .preset-link {
+        padding: 1px 4px;
       }
 
       .chip-list {
         display: flex;
         flex-wrap: wrap;
         margin-left: 4px;
-        gap: var(--padding);
+        gap: 2px;
       }
 
       .chip {
-        font-size: calc(var(--text-size) * 0.5);
-        padding: calc(var(--padding) * 0.5);
-        margin: calc(var(--padding) * 0.5);
+        font-size: 11px;
+        padding: 1px 6px;
+        margin: 1px;
       }
 
       .edit-link {
         display: block;
         font-size: var(--text-size);
-        font-weight: bold;
+        font-weight: 600;
         text-transform: uppercase;
+      }
+
+      .search-input {
+        padding: 4px 8px;
+      }
+
+      .filter-toggle {
+        padding: 4px 8px;
+        font-size: 12px;
+        border-radius: 4px;
+      }
+
+      .filter-toggle input {
+        width: 14px;
+        height: 14px;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- Overrides CSS variables (`--title-size`, `--text-size`, `--padding`) at the `>=1200px` breakpoint to smaller fixed values (18px/14px/4px)
- Tightens row padding, line-height, icon sizes, chip sizing, and filter controls for a denser desktop layout
- Centers content at max-width 1200px on wide screens
- Mobile layout is completely unaffected — all changes are inside `@media (min-width: 1200px)`
- Colors are unchanged

## Test plan
- [x] Desktop (1440×900): verified compact layout with smaller text, tighter rows, same rainbow colors
- [x] Mobile (390×844): verified no visual changes from before
- [ ] Check intermediate widths around the 1200px breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)