### PR TITLE
fix: prevent editor reload on shader save

### DIFF
--- a/index.js
+++ b/index.js
@@ -425,9 +425,11 @@ const main = async () => {
 
 main()
 
-// Reload the page when shader files change on disk (replaces full-reload from shader-plugin)
+// Reload the page when shader files change on disk (replaces full-reload from shader-plugin).
+// Skip on the editor page — it handles shader updates via the editor-sync HMR event.
 if (import.meta.hot) {
     import.meta.hot.on('shaders-changed', () => {
+        if (window.location.pathname.includes('edit')) return
         location.reload()
     })
 }

--- a/src/worker-communication.js
+++ b/src/worker-communication.js
@@ -1,14 +1,21 @@
-// Service worker registration - Vite migration
+// Service worker registration
+// In dev mode (Vite HMR available), skip the SW entirely — it detects file
+// changes and force-reloads all clients, which conflicts with HMR.
+const isDev = !!import.meta.hot
 window.addEventListener('load', async () => {
   const { serviceWorker } = navigator
-  if (!serviceWorker) {
+  if (!serviceWorker) return
+
+  if (isDev) {
+      // Unregister any leftover SW from production or previous sessions
+      const regs = await serviceWorker.getRegistrations()
+      for (const r of regs) await r.unregister()
       return
   }
+
   serviceWorker.addEventListener('message', processServiceWorkerMessage)
-  // Add cache version to URL to force update when version changes
   const registration = await serviceWorker.register(`/service-worker.js`)
   registration.addEventListener('message', processServiceWorkerMessage)
-
 })
 
 /**
@@ -20,6 +27,9 @@ const RELOAD_GRACE = 5000
 
 const processServiceWorkerMessage = (event) => {
   if (event.data === 'reload') {
+      // The editor page handles shader updates via HMR — don't full-reload
+      // when the service worker detects a .frag file changed on disk.
+      if (window.location.pathname.includes('edit')) return
       if (reloadTimeout) return
       const lastReload = parseInt(sessionStorage.getItem('sw-last-reload') || '0')
       if (Date.now() - lastReload < RELOAD_GRACE) return

--- a/vite-plugins/editor-sync-plugin.js
+++ b/vite-plugins/editor-sync-plugin.js
@@ -1,11 +1,18 @@
 import { readFile, writeFile } from 'fs/promises'
 import { join } from 'path'
+import chokidar from 'chokidar'
 
 const SHADER_DIR = 'shaders'
 
 export function editorSyncPlugin() {
+  let watcher = null
+
   return {
     name: 'vite-plugin-editor-sync',
+
+    handleHotUpdate({ file }) {
+      if (file.endsWith('.frag')) return []
+    },
 
     configureServer(server) {
       server.middlewares.use(async (req, res, next) => {
@@ -25,7 +32,7 @@ export function editorSyncPlugin() {
             const filePath = join(SHADER_DIR, `${normalized}.frag`)
 
             await writeFile(filePath, code, 'utf-8')
-            console.log(`[editor-sync] Saved ${filePath}`)
+            console.log(`[editor-sync] Saved ${filePath} (${code.length} bytes)`)
 
             res.writeHead(200, { 'Content-Type': 'application/json' })
             res.end(JSON.stringify({ ok: true, path: filePath }))
@@ -37,7 +44,11 @@ export function editorSyncPlugin() {
         })
       })
 
-      server.watcher.on('change', async (filePath) => {
+      // Use our own chokidar watcher instead of server.watcher, because
+      // .frag files are ignored by Vite's watcher to prevent full-page reloads.
+      watcher = chokidar.watch(SHADER_DIR, { ignoreInitial: true })
+
+      watcher.on('change', async (filePath) => {
         if (!filePath.endsWith('.frag')) return
 
         const projectRoot = server.config.root
@@ -65,6 +76,10 @@ export function editorSyncPlugin() {
       })
 
       console.log('[editor-sync] Bidirectional shader sync enabled')
+    },
+
+    closeBundle() {
+      watcher?.close()
     },
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,12 @@ export default defineConfig({
     port: parseInt(process.env.PORT) || branchToPort(gitBranch),
     host: '0.0.0.0',
     allowedHosts: true,
+    watch: {
+      // Ignore files that our plugins regenerate on .frag changes.
+      // Without this, Vite sees these writes and triggers a full page reload.
+      // The plugins handle updates via custom HMR events instead.
+      ignored: ['**/shaders.json', '**/manifests/**', '**/shaders/**'],
+    },
   },
   build: {
     target: 'esnext',


### PR DESCRIPTION
## Summary
- **Stop editor page from reloading when saving shaders** — three independent reload triggers were firing on every Ctrl+S:
  1. `index.js` had a `shaders-changed` HMR listener that called `location.reload()` on all pages, including the editor
  2. The service worker detected `.frag` file changes via cache diffing and force-reloaded all clients
  3. Vite's watcher saw `shaders.json`/manifest regeneration and triggered its own reload
- **Disable service worker in dev mode** — it conflicts with Vite HMR and caused spurious reloads
- **Give editor-sync plugin its own file watcher** — since Vite's watcher now ignores the `shaders/` directory to prevent reloads

## Test plan
- [ ] Open two `edit.html?shader=plasma` tabs
- [ ] Save in one tab — verify no page reload (editor state preserved)
- [ ] Save in one tab — verify the other tab does NOT reload
- [ ] Edit in one tab — verify multiplayer syncs text to the other tab's editor
- [ ] Verify the visualizer only updates on explicit save, not on multiplayer edits
- [ ] Open `list.html` — verify shader list still loads (shaders.json regenerates)
- [ ] Edit a shader externally (in an editor) — verify the editor picks up changes via HMR
- [ ] Verify production build still registers the service worker (`npm run build && npx serve dist`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)