### PR TITLE
feat: warm-up ramp to prevent visual spikes on start

### DIFF
--- a/src/audio/AudioProcessor.js
+++ b/src/audio/AudioProcessor.js
@@ -4,6 +4,30 @@ import { WorkerRPC } from './WorkerRPC.js'
 // Workers compute these but hypnosound's StatTypes doesn't include them
 const AllStatTypes = [...StatTypes, 'slope', 'intercept', 'rSquared']
 
+// Neutral values for each stat type during warm-up (what the shader sees when audio hasn't "arrived" yet)
+const neutralValues = {
+    ZScore: 0,
+    Normalized: 0.5,
+    Mean: 0,
+    Median: 0,
+    Min: 0,
+    Max: 0,
+    StandardDeviation: 0,
+    Slope: 0,
+    Intercept: 0,
+    RSquared: 0,
+}
+
+// Returns the neutral value for a given feature key based on its stat suffix
+const getNeutralValue = (key) => {
+    for (const [suffix, value] of Object.entries(neutralValues)) {
+        if (key.endsWith(suffix)) return value
+    }
+    return 0 // raw values (e.g. "bass", "energy") ramp from 0
+}
+
+const WARMUP_FRAMES = 120 // ~2 seconds at 60fps
+
 export const getFlatAudioFeatures = (audioFeatures = AudioFeatures, rawFeatures = {}) => {
     const features = {}
     for (const feature of audioFeatures) {
@@ -31,6 +55,7 @@ export class AudioProcessor {
         this.currentFeatures.beat = false
         this.smoothedFeatures = {}
         this.smoothingFactor = 0.10 // Lower = smoother, higher = more responsive
+        this.warmupFrame = 0
     }
 
     createAnalyzer = () => {
@@ -90,8 +115,22 @@ export class AudioProcessor {
             }
         }
 
+        // Warm-up ramp: ease features from neutral to real over WARMUP_FRAMES
+        if (this.warmupFrame < WARMUP_FRAMES) {
+            const t = this.warmupFrame / WARMUP_FRAMES
+            const ramp = t * t * (3 - 2 * t) // smoothstep: smooth S-curve from 0 to 1
+
+            for (const key in this.currentFeatures) {
+                if (typeof this.currentFeatures[key] !== 'number') continue
+                const neutral = getNeutralValue(key)
+                this.currentFeatures[key] = neutral + (this.currentFeatures[key] - neutral) * ramp
+            }
+
+            this.warmupFrame++
+        }
+
         this.historySize = window.cranes?.manualFeatures?.history_size ?? this.historySize
-        this.currentFeatures.beat = this.isBeat()
+        this.currentFeatures.beat = this.warmupFrame >= WARMUP_FRAMES && this.isBeat()
     }
 
     isBeat = () => {


### PR DESCRIPTION
## Summary
- Adds a 120-frame (~2 second) warm-up ramp to `AudioProcessor` that eases audio features from neutral values to their real values using a smoothstep curve
- Prevents the jarring visual spike that happens when audio starts because z-scores and normalized values are wildly unstable with a near-empty history buffer
- Suppresses beat detection during warm-up since the statistics are unreliable

## How it works
- Z-scores ramp from 0, normalized values from 0.5, raw values from 0
- Uses a smoothstep curve (`t²(3-2t)`) so the transition starts slow, accelerates, then eases in
- After 120 frames, the ramp is done — just a single `if` check per frame, no ongoing cost
- By the time the ramp finishes, the 500-sample history buffer is well-populated

## Test plan
- [ ] Load any shader with mic audio — confirm no initial spike/flash
- [ ] Load with `?audio_file=` — confirm smooth fade-in
- [ ] After ~2 seconds, visuals should be fully reactive (no lingering dampening)
- [ ] Beat detection should not fire during the first 2 seconds
- [ ] Compare before/after on a shader like `plasma` or `melted-satin/2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)