### PR TITLE
fix: request wake lock on user gesture

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { AudioProcessor } from './src/audio/AudioProcessor.js'
 import { createAudioFileSource, initAudioFromFile } from './src/audio/audioFileSource.js'
-import { makeVisualizer } from './src/Visualizer.js'
+import { makeVisualizer, askForWakeLock } from './src/Visualizer.js'
 import { getInitialShader } from './src/shaderLoader.js'
 
 
@@ -313,6 +313,7 @@ const addListenersForFullscreen = (visualizer) => {
             } catch (e) {
                 console.error(`requesting fullscreen from event ${event} failed`, e);
             }
+            askForWakeLock().catch(e => console.warn('Wake lock failed after user gesture:', e))
         }, { once: true });
     }
 }

--- a/src/Visualizer.js
+++ b/src/Visualizer.js
@@ -84,7 +84,7 @@ const calculateResolutionRatio = (frameTime, renderTimes, lastResolutionRatio) =
     return lastResolutionRatio
 }
 
-const askForWakeLock = async () => {
+export const askForWakeLock = async () => {
     if(!navigator.wakeLock) return
     return navigator.wakeLock.request('screen')
 }


### PR DESCRIPTION
## Summary
- Some browsers require a user gesture before granting a screen wake lock
- The existing wake lock request at visualizer init can silently fail on these browsers, causing screens to turn off during visualizations
- Now also requests a wake lock on the first user interaction (touch/click/key), so it works reliably across browsers

## Test plan
- [ ] Open a visualization on a phone, verify screen stays on
- [ ] Test on browsers that require user gestures for wake lock (Safari iOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)