### PR TITLE
feat: opt-in MIDI controller support on index page

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,11 @@ const setupCranesState = () => {
         messageParams: {},          // Message parameters (highest precedence)
         frameCount: 0,
         // Centralized feature flattening function with proper order of precedence
-        flattenFeatures: getCranesState
+        flattenFeatures: getCranesState,
+        // Used by src/midi.js to set knob values
+        updateFeature: (name, value) => {
+            window.cranes.manualFeatures[name] = value
+        },
     }
 
     window.c = window.cranes
@@ -325,6 +329,9 @@ const main = async () => {
     // Initialize global state
     setupCranesState()
     startTime = performance.now()
+
+    // Lazy-load MIDI support when opted in via ?midi=true
+    if (params.get('midi') === 'true') import('./src/midi.js')
 
     // Initialize remote display mode if ?remote=display
     if (params.get('remote') === 'display') {


### PR DESCRIPTION
## Summary
- Adds `?midi=true` query param to lazy-load MIDI controller support on the index page
- Uses dynamic `import()` so the MIDI module is never downloaded unless explicitly opted in — zero bandwidth impact by default
- Adds `updateFeature` bridge to `window.cranes` so MIDI knob values flow into shaders via `manualFeatures`

## Test plan
- [ ] Load index page without `?midi=true` — verify no MIDI permission prompt, no extra network requests for midi.js
- [ ] Load with `?midi=true` — verify MIDI permission is requested and controller knobs affect shader uniforms
- [ ] Verify edit page MIDI still works as before (uses its own script tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)