### PR TITLE
feat: /jam, /fork, /record skills for streamlined sessions

### DIFF
--- a/.claude/skills/fork/SKILL.md
+++ b/.claude/skills/fork/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: fork
+description: "Save the current shader + knob state as a new numbered iteration. Usage: `/fork` (auto-detects shader) or `/fork <shader-path>`"
+allowed-tools: Bash Read Write Edit Grep Glob Agent mcp__claude-in-chrome__tabs_context_mcp mcp__claude-in-chrome__javascript_tool
+---
+
+# Fork — Save Current State as New Shader Iteration
+
+Capture the current shader code + knob values from the browser and create a new numbered `.frag` file with the knob values baked into comments and a companion `.md` doc.
+
+## Context
+
+Arguments (optional shader path):
+!`echo "$ARGUMENTS"`
+
+Browser tabs:
+!`echo "Use tabs_context_mcp + javascript_tool to read current state"`
+
+## Steps
+
+### 1. Find the current shader
+
+If `$ARGUMENTS` specifies a path, use it. Otherwise:
+1. Check the browser — read `window.location.search` for `?shader=`
+2. Fall back to most recently modified `.frag` in the worktree
+
+### 2. Read the current state from the browser
+
+On the jam/editor tab, run:
+```javascript
+JSON.stringify({
+  shader: new URLSearchParams(window.location.search).get('shader'),
+  controller: new URLSearchParams(window.location.search).get('controller'),
+  knobs: Object.fromEntries(
+    Object.entries(window.cranes.manualFeatures || {})
+      .filter(([k]) => /^knob_\d+$/.test(k))
+      .filter(([_, v]) => v !== undefined && v !== null)
+      .sort(([a],[b]) => parseInt(a.split('_')[1]) - parseInt(b.split('_')[1]))
+  )
+})
+```
+
+### 3. Determine the new filename
+
+Look at existing numbered files in the shader directory:
+```
+shaders/<path>/dubstep-daddy-2.frag
+shaders/<path>/dubstep-daddy-3.frag
+→ next: dubstep-daddy-4.frag
+```
+
+If no numbered files exist, use `2.frag` as the first fork.
+
+### 4. Copy the shader
+
+Copy the current `.frag` to the new filename. Update any internal comments that reference the old name.
+
+### 5. Write the companion doc
+
+Create `<new-name>.md` with:
+- Origin: which shader it was forked from, when, what music was playing
+- Baked knob values table (knob, value, what it controls)
+- Preset URL with all knob params
+- Controller info if one was active
+- Any notes about why this fork was created
+
+### 6. Hot-swap to the new shader
+
+Update the browser to use the new shader without reloading:
+```javascript
+// Fetch new shader and swap
+const r = await fetch('/shaders/<path>/<new>.frag?t=' + Date.now())
+window.cranes.shader = await r.text()
+// Update URL
+const url = new URL(window.location)
+url.searchParams.set('shader', '<new-shader-path>')
+history.replaceState({}, '', url)
+```
+
+### 7. Report
+
+Tell the user:
+> Forked `old-name` → `new-name` with knob values baked in. [list key knob settings]
+
+### Safety
+
+- Never overwrite an existing file — always create new numbered iterations
+- Confirm the shader directory exists before writing
+- The fork preserves all code — it's a copy, not a diff

--- a/.claude/skills/jam/SKILL.md
+++ b/.claude/skills/jam/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: jam
+description: "Launch a jam session — open the jam page with shader + controller + Spotify/SoundCloud, share tab audio, and get ready to tweak. Usage: `/jam [shader-path] [music-url]`"
+allowed-tools: Bash Read Write Edit Grep Glob Agent mcp__claude-in-chrome__tabs_context_mcp mcp__claude-in-chrome__tabs_create_mcp mcp__claude-in-chrome__navigate mcp__claude-in-chrome__javascript_tool mcp__claude-in-chrome__read_page mcp__claude-in-chrome__read_console_messages mcp__claude-in-chrome__computer
+---
+
+# Jam — Launch a Jam Page Session
+
+Open the jam page (`/jam.html`) with a shader, optional controller, and music source. The jam page is lighter than the editor — fullscreen shader + knob drawer + spacebar snapshots. No Monaco editor.
+
+## Context
+
+Arguments (optional shader path, controller, or music URL):
+!`echo "$ARGUMENTS"`
+
+Dev server status:
+!`curl -s -o /dev/null -w "%{http_code}" http://localhost:6969/ 2>/dev/null || echo "not running"`
+
+Modified shaders in worktree:
+!`git diff --name-only HEAD | grep '\.frag$' | head -3 2>/dev/null; git status --short | grep '\.frag' | head -3 2>/dev/null`
+
+Available controllers:
+!`ls controllers/*.js 2>/dev/null | sed 's|controllers/||;s|\.js||'`
+
+## Steps
+
+### 1. Ensure the dev server is running
+
+Check if `localhost:6969` responds. If not:
+```fish
+npm run dev &
+```
+Wait for it (poll with curl, max 10 seconds).
+
+### 2. Determine the shader
+
+Parse `$ARGUMENTS` for a shader path. Fall back to:
+1. Most recently modified `.frag` in the worktree
+2. `redaphid/wip/dubstep-daddy-fur-coat/dubstep-daddy-3` (the latest jam shader)
+
+### 3. Determine the controller
+
+Check if the shader has a matching controller in `controllers/`. Convention: shader `dubstep-daddy-3.frag` → controller `dubstep-daddy.js`.
+
+If a controller exists, add `&controller=<name>` to the URL.
+
+### 4. Determine the music source
+
+Parse `$ARGUMENTS` for a URL (Spotify, SoundCloud, YouTube). If none provided, default to `https://open.spotify.com`.
+
+### 5. Open Chrome and connect
+
+1. Ensure Chrome is running (`pgrep -x "Google Chrome"` or `open -a "Google Chrome"`)
+2. Call `tabs_context_mcp` with `createIfEmpty: true`
+3. Create a tab for the music source and navigate there
+4. Create a tab for the jam page:
+   ```
+   http://localhost:6969/jam.html?shader=<path>&audio=tab&controller=<name>
+   ```
+
+### 6. Verify the connection
+
+Run on the jam page tab:
+```javascript
+JSON.stringify({ cranes: !!window.cranes, shader: !!window.cranes?.shader })
+```
+
+### 7. Tell the user we're ready
+
+Short and excited:
+> Jam page up with [shader]. [Music source] is ready. Play a track, share tab audio, and hit spacebar to snapshot. Let's go!
+
+Remind them:
+- Share tab audio when prompted (the `?audio=tab` param triggers the picker)
+- **Spacebar** = snapshot preset to queue
+- **Backspace** = undo last snapshot
+- **Cmd+Shift+D** = toggle knob drawer
+- Shader and controller edits hot-swap without reload
+
+### 8. Enter jam mode
+
+Claude should:
+- **Edit the shader directly** — `.frag` file edits hot-swap via HMR
+- **Edit the controller** — `.js` edits in `controllers/` also hot-swap
+- **Read audio state** via `window.cranes.flattenFeatures()` on the jam tab
+- **Read knob state** via `window.cranes.manualFeatures`
+- **Be responsive** — "more zoom", "eyes too bright", "love the coat" → act immediately
+- **Use `/preset process`** to batch-process snapshot queue when asked
+- **Use `/fork`** to save the current state as a new shader iteration
+
+### Differences from `/live-session`
+
+| | `/live-session` | `/jam` |
+|---|---|---|
+| Page | `edit.html` (Monaco editor) | `jam.html` (knob drawer only) |
+| Code editing | In-browser Monaco | Claude edits .frag on disk, HMR hot-swaps |
+| Snapshots | No | Spacebar → snapshot queue |
+| Controller | Not loaded by default | Auto-detected from shader name |
+| Purpose | Collaborative coding | Tweaking knobs + capturing presets |

--- a/.claude/skills/record/SKILL.md
+++ b/.claude/skills/record/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: record
+description: "Record a music video from the current shader. Captures canvas video via MediaRecorder, restarts the Spotify/music track, and auto-stops when done. Usage: `/record [duration-seconds]`"
+allowed-tools: Bash Read Write Edit Grep Glob Agent mcp__claude-in-chrome__tabs_context_mcp mcp__claude-in-chrome__tabs_create_mcp mcp__claude-in-chrome__navigate mcp__claude-in-chrome__javascript_tool mcp__claude-in-chrome__read_page mcp__claude-in-chrome__computer
+---
+
+# Record — Capture a Music Video from the Shader
+
+Record the WebGL canvas as a WebM video file using the browser's MediaRecorder API. Optionally restarts the music track so the video starts from the beginning.
+
+## Context
+
+Arguments (optional duration in seconds, default 30):
+!`echo "$ARGUMENTS"`
+
+## Steps
+
+### 1. Find the active tabs
+
+Call `tabs_context_mcp` to find:
+- The shader tab (jam page or editor — look for `jam.html` or `edit.html` in the URL)
+- The music tab (Spotify, SoundCloud, YouTube — look for these domains)
+
+If no shader tab is found, tell the user to open one first (suggest `/jam`).
+
+### 2. Parse duration
+
+If `$ARGUMENTS` contains a number, use it as duration in seconds. Default: 30.
+If `$ARGUMENTS` contains "full", read the track duration from the music tab if possible.
+
+### 3. Determine the output filename
+
+Read the shader name and music tab title to generate a filename:
+```
+dubstep-daddy-3--rain-apashe.webm
+```
+
+### 4. Restart the music track
+
+On the music tab, click the Previous button twice to restart from the beginning:
+- Find the "Previous" button via `read_page` (interactive filter)
+- Click it twice with `computer` tool
+
+Wait 0.5s for the track to restart.
+
+### 5. Start recording
+
+On the shader tab, inject the recording script:
+```javascript
+(() => {
+  const canvas = document.getElementById('visualizer')
+  const stream = canvas.captureStream(30) // 30fps from canvas
+  
+  const recorder = new MediaRecorder(stream, {
+    mimeType: 'video/webm;codecs=vp9',
+    videoBitsPerSecond: 8000000
+  })
+  
+  const chunks = []
+  recorder.ondataavailable = (e) => { if (e.data.size > 0) chunks.push(e.data) }
+  recorder.onstop = () => {
+    const blob = new Blob(chunks, { type: 'video/webm' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = '<FILENAME>'
+    a.click()
+    URL.revokeObjectURL(url)
+    window.flashToast?.('Video saved!')
+    window._recordingDone = true
+  }
+  
+  window._recorder = recorder
+  window._recordingDone = false
+  recorder.start(100)
+  
+  setTimeout(() => {
+    if (recorder.state === 'recording') recorder.stop()
+  }, <DURATION_MS>)
+  
+  window.flashToast?.('Recording... (' + <DURATION_S> + 's)')
+  return 'recording'
+})()
+```
+
+Replace `<FILENAME>`, `<DURATION_MS>`, and `<DURATION_S>` with actual values.
+
+### 6. Wait for completion
+
+The recording auto-stops after the duration. Check periodically:
+```javascript
+window._recordingDone
+```
+
+### 7. Report
+
+Tell the user:
+> Recorded [duration]s of [shader name] with [music]. Check your downloads for `<filename>`.
+
+### Limitations
+
+- **Video only** — the canvas `captureStream()` API captures video but not the tab audio. The audio would need to be muxed separately. Mention this to the user.
+- **WebM format** — browsers record as WebM. If the user needs MP4, suggest: `ffmpeg -i input.webm -c:v libx264 output.mp4`
+- **30fps** — canvas capture is locked to 30fps. The shader may render at 60fps but the recording won't capture every frame.
+
+### Future: Audio Muxing
+
+If the user wants audio in the video, the approach would be:
+1. Record the canvas video as above
+2. Record the tab audio separately via `audioContext.createMediaStreamDestination()`
+3. Combine both streams into one MediaRecorder
+4. Or use ffmpeg to mux the video with a separate audio file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,8 +751,12 @@ vec3 rd = normalize(uv.x * right + uv.y * up + fov * forward);
 
 | Skill | Purpose |
 |-------|---------|
-| `/solo` | Toggle a shader between knob mode and audio mode. Auto-detects current mode and switches. Use `/solo knobs` or `/solo audio` to force a mode. Defaults to the modified `.frag` in the worktree. |
+| `/jam` | Launch a jam session — open the jam page with shader + controller + music source. Lighter than `/live-session`: no editor, just knobs + snapshots. |
 | `/live-session` | Launch a live creative session — open Chrome with shader editor + audio source, connect Claude-in-Chrome, and jam. Optionally pass a shader path or SoundCloud/Spotify URL. See [docs/live-session-insights.md](docs/live-session-insights.md). |
+| `/fork` | Save the current shader + knob state as a new numbered iteration. Reads knobs from the browser, copies the `.frag`, writes a companion doc. |
+| `/record` | Record a music video from the current shader canvas. Uses MediaRecorder API, restarts the music track, auto-stops after duration. |
+| `/preset` | Save knob state as a named preset (live) or batch-process the snapshot queue (`/preset process`). |
+| `/solo` | Toggle a shader between knob mode and audio mode. Auto-detects current mode and switches. Use `/solo knobs` or `/solo audio` to force a mode. Defaults to the modified `.frag` in the worktree. |
 | `/changelog` | Update docs/CHANGELOG.md and README with recent features. |
 | `/pr` | Create a PR, request review, and open in browser. |
 


### PR DESCRIPTION
## Summary

Three new Claude Code skills to streamline the live jam workflow, addressing pain points from the dubstep-daddy session:

- **`/jam [shader] [music-url]`** — Launch the jam page with the right shader, auto-detect its controller, open the music source. Lighter than `/live-session` (no Monaco editor, just knobs + snapshots).
- **`/fork`** — Save the current shader + knob state as a new numbered `.frag` iteration with companion docs. Reads knob values from the browser, copies the shader, hot-swaps to the new file. No more manual copy/rename/update cycles.
- **`/record [duration]`** — Record a music video from the shader canvas using MediaRecorder API. Restarts the Spotify track, captures at 30fps, auto-downloads as WebM.

### Pain points these solve

| Before | After |
|--------|-------|
| Manually construct jam page URL with shader + controller + audio params | `/jam dubstep-daddy-3` |
| Copy shader, update references, capture knobs, write docs | `/fork` |
| No way to capture video | `/record 30` |
| `/live-session` opens the heavy editor page | `/jam` opens the lean jam page |

Also updated CLAUDE.md skills table with all current skills.

## Test plan
- [ ] Run `/jam` — verify it opens jam page with correct shader + controller
- [ ] Run `/fork` during a jam session — verify new numbered shader + docs created
- [ ] Run `/record 10` — verify 10s WebM downloaded from canvas
- [ ] Verify CLAUDE.md skills table matches actual available skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)