### PR TITLE
vj skill + live VJ session infrastructure

### DIFF
--- a/.claude/skills/remap/SKILL.md
+++ b/.claude/skills/remap/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: remap
+description: "Reset the MIDI controller mapping for the Paper Cranes jam/edit page. Clears `localStorage['cranes-midi-profiles']` and reloads the tab so the next CC twist auto-assigns afresh. Usage: `/remap` (clears all profiles) or `/remap <device-name>` (clears one)."
+allowed-tools: Bash mcp__claude-in-chrome__tabs_context_mcp mcp__claude-in-chrome__javascript_tool
+---
+
+# /remap — Reset MIDI Mapping
+
+Clears the MIDI CC → knob mappings stored in `localStorage['cranes-midi-profiles']` on the jam/edit page, then reloads so the auto-assign logic starts from scratch. See [docs/midi-mapping.md](../../docs/midi-mapping.md) for what's being reset.
+
+## Context
+
+Arguments:
+!`echo "$ARGUMENTS"`
+
+## Steps
+
+### 1. Find a jam or edit tab
+
+Call `tabs_context_mcp` and pick the tab whose URL contains `jam.html` or `edit.html`. If none, tell the user to open one.
+
+### 2. Inspect current profiles first (so the user knows what's being cleared)
+
+```javascript
+(() => {
+  const raw = localStorage.getItem('cranes-midi-profiles');
+  if (!raw) return { hadData: false };
+  const data = JSON.parse(raw);
+  const profiles = data.profiles || {};
+  return {
+    hadData: true,
+    devices: Object.keys(profiles),
+    mappingCounts: Object.fromEntries(
+      Object.entries(profiles).map(([name, p]) => [name, Object.keys(p.mappings || {}).length])
+    )
+  };
+})()
+```
+
+### 3. Clear
+
+**No args → clear all:**
+```javascript
+localStorage.removeItem('cranes-midi-profiles')
+```
+
+**`<device-name>` arg → clear just that device:**
+```javascript
+(() => {
+  const raw = localStorage.getItem('cranes-midi-profiles');
+  if (!raw) return 'no profiles';
+  const data = JSON.parse(raw);
+  const name = '<device-name>';
+  if (!data.profiles?.[name]) return 'no such device: ' + name;
+  delete data.profiles[name];
+  localStorage.setItem('cranes-midi-profiles', JSON.stringify(data));
+  return 'cleared ' + name;
+})()
+```
+
+### 4. Reload the tab so `createMidiMapper()` re-reads localStorage
+
+```javascript
+location.reload()
+```
+
+### 5. Confirm to the user
+
+`**MIDI mapping reset** — cleared N profiles (<device names>). Reload done. Next CC twist will auto-assign from knob_1.`
+
+## Notes
+
+- The profile store is per-origin localStorage. If the user has both `localhost:$PORT` and a deployed domain open, only the tab you ran this on is affected.
+- This does NOT touch the MIDI device itself or any physical LED state — it only clears the browser's memory of which CC maps to which knob.
+- If the user wants the mapping preserved across reloads but temporarily disabled, that's a different feature (not what this skill does).

--- a/.claude/skills/vj/SKILL.md
+++ b/.claude/skills/vj/SKILL.md
@@ -238,6 +238,26 @@ Bump `iteration` in `.claude/vj-state.json`.
 
 Keep it tight. No screenshot — the user is watching the shader live.
 
+### H. Journal cool moments (only when warranted)
+
+After the edit lands, notice the current visual+audio combination. If it's working especially well, append an entry to the **per-shader journal**:
+
+```
+journals/<shader-filename-without-dir-or-ext>-cool-moments.md
+```
+
+For example, `shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag` → `journals/the-coat-6-cool-moments.md`. Create it if missing.
+
+**Purpose: these journals feed the next shader.** When the user eventually says "make a new shader", the combined entries across shaders become a design brief — which audio/visual correspondences are worth keeping, which gating thresholds reliably produce "modes" rather than noise, which track types the current shader vocabulary can and can't serve. So write each entry with future-you (designing v7 from scratch) as the reader, not session-present-you.
+
+Each entry should capture:
+- **Audio fingerprint** — the *specific* feature combination that made the moment. Not vague ("bass hit") — precise ranges (`bass 0.65-0.75 + centroid < 0.15 + entropy < 0.1`) so a future shader can be designed to *reward* that fingerprint.
+- **What the shader did right** — which existing blocks fired, and *how their gating conditions overlapped*. The goal of a v7 is often to take an alignment that happened by accident here and make it deliberate.
+- **What the shader missed** — moments where the music was doing X and the shader *should* have responded but didn't (wrong gate threshold, no matching effect, clashing overlay). These are v7 requirements.
+- **Design hypothesis** — one line: "next shader should have a dedicated effect for audio-pattern X."
+
+Skip ordinary ticks. The git log already records *what* changed — the journal captures *why a specific audio-pattern called for a specific visual response*. 3-5 honest entries per shader beats 30 mediocre ones.
+
 ## Stop conditions
 
 - `iteration >= target` → `CronDelete(jobId)`, delete state file

--- a/.claude/skills/vj/SKILL.md
+++ b/.claude/skills/vj/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vj
-description: "VJ a shader live at a party — auto-mutates the shader every minute to match the track. Reads audio features + Spotify track name from the jam page, edits the .frag via /__save-shader (HMR hot-swaps). Usage: `/vj [duration-minutes]` (default 180). Use `/vj stop` to end early."
+description: "VJ a shader live at a party — auto-mutates the shader every minute to match the track. Reads audio features + Spotify track name from the jam page, edits the .frag via /__save-shader (HMR hot-swaps). Usage: `/vj [N-iterations] [shader-path-or-name]` (default 180, most-recent .frag). `/vj stop` ends early. `/vj tick` runs one iteration (what the cron fires)."
 allowed-tools: Bash Read Write Edit Grep Glob CronCreate CronList CronDelete mcp__claude-in-chrome__tabs_context_mcp mcp__claude-in-chrome__tabs_create_mcp mcp__claude-in-chrome__navigate mcp__claude-in-chrome__javascript_tool
 ---
 

--- a/.claude/skills/vj/SKILL.md
+++ b/.claude/skills/vj/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: vj
+description: "VJ a shader live at a party — auto-mutates the shader every minute to match the track. Reads audio features + Spotify track name from the jam page, edits the .frag via /__save-shader (HMR hot-swaps). Usage: `/vj [duration-minutes]` (default 180). Use `/vj stop` to end early."
+allowed-tools: Bash Read Write Edit Grep Glob CronCreate CronList CronDelete mcp__claude-in-chrome__tabs_context_mcp mcp__claude-in-chrome__tabs_create_mcp mcp__claude-in-chrome__navigate mcp__claude-in-chrome__javascript_tool
+---
+
+# VJ — Live Auto-VJ Loop for the Jam Page
+
+Run Claude as the VJ: every minute, read the current audio features + track name, make ONE meaningful edit to the shader, move on. Non-destructive by default (edits `.frag` via `/__save-shader`, HMR hot-swaps).
+
+## Philosophy
+
+- **Match the music**: read audio state before each edit, let track name / pitch / energy guide the move.
+- **One focused move per tick**: add/change a single feature (palette, effect, geometry tweak). Don't rewrite.
+- **Respect the user**: the user might be twiddling knobs or watching the editor — don't smash their knobs, don't rewrite their code wholesale.
+- **Fail loud, not silent**: validate each edit with `scripts/validate-shader.js`; if it breaks, fix or revert.
+
+## Context
+
+Arguments:
+!`echo "$ARGUMENTS"`
+
+Dev server port (from `scripts/dev-port` — branch-derived, `PORT` env overrides):
+!`./scripts/dev-port`
+
+Dev server status:
+!`PORT=$(./scripts/dev-port); curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/ 2>/dev/null || echo "not running"`
+
+Existing state file (if a run is in progress):
+!`cat .claude/vj-state.json 2>/dev/null || echo "(none)"`
+
+## Arguments
+
+- **No args** → 180 iterations (3 hours), 1 per minute
+- **Single integer N** → N iterations
+- **`stop`** → read `.claude/vj-state.json`, `CronDelete` the stored job ID, remove the state file
+- **`tick`** → single iteration (what the cron fires)
+
+## Setup (once, at start)
+
+### 1. Read the port
+
+```fish
+set PORT (./scripts/dev-port)
+```
+
+### 2. Ensure dev server is running
+
+If `localhost:$PORT` isn't responding:
+```fish
+npm run dev &
+```
+Poll with curl (max 10 seconds).
+
+### 3. Ensure jam page + Spotify tabs exist
+
+- `tabs_context_mcp` with `createIfEmpty: true`
+- Find or create a jam tab: `http://localhost:$PORT/jam.html?shader=<path>&controller=<name>`
+  - Default shader: most recently modified `.frag` in the worktree, else `redaphid/wip/the-coat-fur-coat/the-coat-3`
+  - Default controller: match shader name (e.g. `the-coat-3` → `the-coat`) if a matching `controllers/*.js` exists
+- Find or create a Spotify tab: `https://open.spotify.com`
+
+Record the **jam tab ID** and **spotify tab ID** — you'll reuse them every iteration.
+
+### 4. Schedule the minute cron
+
+```
+CronCreate({
+  cron: "* * * * *",
+  prompt: "/vj tick",
+  recurring: true
+})
+```
+
+Record the returned **job ID**.
+
+### 5. Persist state to `.claude/vj-state.json`
+
+```json
+{
+  "jobId": "<from CronCreate>",
+  "iteration": 0,
+  "target": 180,
+  "shaderPath": "redaphid/wip/the-coat-fur-coat/the-coat-3",
+  "jamTabId": 653089308,
+  "spotifyTabId": 653089312,
+  "port": 4788,
+  "startedAt": "<ISO timestamp>"
+}
+```
+
+### 6. Run iteration 1 immediately (don't wait for first cron fire)
+
+Then each subsequent minute the cron re-enters the skill with `/vj tick`.
+
+## Per iteration (`/vj tick`)
+
+### A. Load state
+
+Read `.claude/vj-state.json`. If missing, print "no VJ run in progress" and exit.
+
+If `iteration >= target`, call `CronDelete(jobId)`, delete the state file, print "VJ run complete", exit.
+
+### B. Read state from browser
+
+Run on the jam tab:
+```javascript
+(() => {
+  const f = window.cranes.flattenFeatures();
+  return JSON.stringify({
+    bass: f.bassNormalized?.toFixed(2), bassZ: f.bassZScore?.toFixed(2),
+    treb: f.trebleNormalized?.toFixed(2), trebZ: f.trebleZScore?.toFixed(2),
+    mids: f.midsNormalized?.toFixed(2),
+    energy: f.energyNormalized?.toFixed(2), energyZ: f.energyZScore?.toFixed(2),
+    flux: f.spectralFluxZScore?.toFixed(2),
+    entropy: f.spectralEntropyNormalized?.toFixed(2),
+    centroid: f.spectralCentroidNormalized?.toFixed(2),
+    pitch: f.pitchClassNormalized?.toFixed(2),
+    beat: f.beat,
+  });
+})()
+```
+
+Read the track name on the Spotify tab:
+```javascript
+document.querySelector('[data-testid="now-playing-widget"]')?.textContent?.trim().slice(0, 100)
+```
+
+### C. Pick ONE move
+
+Let the features + track name guide it. Some reliable archetypes:
+
+| Signal | Move |
+|---|---|
+| Track-name theme (e.g. "Starlight", "Volcano", "Lights Out") | Palette/motif shift toward the theme |
+| High bass + low centroid | Heart pulse, kick flash, ember floor pulse, subwoofer rings |
+| High treble + high centroid | Scan line, chromatic aberration, electric hiss, twinkle-speed boost |
+| High entropy + roughness | Crystalline shards, RGB split, glitch |
+| Beat=true, flux spike | Beat ring, rim zap, snap |
+| Low energy / calm | Breathing hue cycle, mist, subtle glow |
+| Drop / energyZ rising | Ghost echo coat, bass bloom, zoom punch |
+
+**Avoid stacking more than ~6 simultaneous overlay effects** — the composition blows out. If adding something heavy, reduce or remove something else.
+
+### D. Apply the edit via the jam tab
+
+Read + edit + save through the browser so HMR is the edit path:
+```javascript
+(async () => {
+  const src = await (await fetch('/shaders/<shader-path>.frag?t=' + Date.now())).text();
+  let edited = src;
+  // ... string replacements ...
+  const res = await fetch('/__save-shader', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ shader: '<shader-path>', code: edited })
+  });
+  return await res.text();
+})()
+```
+
+Note: the `/__save-shader` `shader` field takes the path WITHOUT `.frag`.
+
+### E. Validate
+
+```fish
+node scripts/validate-shader.js <shader-path>.frag 2>&1 | grep -E "^ERROR" | head -5
+```
+
+The validator exits non-zero on warnings too (e.g. divide-by-zero hints), so check for `^ERROR` lines, not exit status.
+
+If errors appear:
+- Fix inline (common issues: GLSL reserved words like `active`, `input`, `output`, `sample` → rename)
+- If unfixable in one pass, revert to the previous version via `git checkout -- <file>` and skip this iteration's edit
+
+Track consecutive failures in `vj-state.json` (`failCount`). After 3 in a row, stop the cron and tell the user.
+
+### F. Increment + persist
+
+Bump `iteration` in `.claude/vj-state.json`.
+
+### G. One-line summary to the user
+
+`**Iteration N/total** — <track> — <what changed>.`
+
+Keep it tight. No screenshot — the user is watching the shader live.
+
+## Stop conditions
+
+- `iteration >= target` → `CronDelete(jobId)`, delete state file
+- User invokes `/vj stop` → same
+- 3 consecutive validation failures → same, tell user
+- MCP disconnects → skip the tick gracefully; cron will re-fire next minute
+
+## Shader swap (optional, when requested)
+
+If the user says "switch shaders":
+1. Pick a different base shader from `shaders/<user>/` or `shaders/wip/`.
+2. Update the jam tab URL via `navigate` → `http://localhost:$PORT/jam.html?shader=<new-path>&controller=<match>`
+3. Update `shaderPath` in `.claude/vj-state.json`.
+4. Read the new shader's structure first (don't blind-edit), then continue iterations.
+
+## Common pitfalls (learned the hard way)
+
+- **GLSL reserved words**: `active`, `sample`, `input`, `output`, `common`, `filter`, `using` — pick a different var name or the compile fails.
+- **Feedback accumulation blowouts**: effects that add to `col` feed back each frame. If a frame looks white, clamp `bg` or reduce the feedback multiplier (e.g. `prev * 0.78` → `* 0.66`).
+- **Strobe direction matters**: default BRIGHT with dark punches, not the other way around.
+- **Bass pulse stacking**: ember floor × sunburst × bass bloom × kick pulse all firing on the same bass spike → saturation. Pick one primary bass visualizer per session.
+- **Kaleidoscope tiling persists via feedback**: even after disabling kaleido, the backdrop keeps the tile pattern until feedback decays. Lower `prev *` for a few iterations to shake it off.
+- **Port is branch-derived**: main = 6969, other branches hash to 1024–65534. Always use `./scripts/dev-port` — never hardcode 6969.
+
+## Example `/vj tick` output
+
+> **Iteration 52/180** — *Love Spell* — Prism rainbow rim on the coat (rim hue now angular around head + time). Pink shoulder / green chest / cyan hem.

--- a/.claude/skills/vj/SKILL.md
+++ b/.claude/skills/vj/SKILL.md
@@ -142,14 +142,51 @@ Let the features + track name guide it. Some reliable archetypes:
 
 **Avoid stacking more than ~6 simultaneous overlay effects** — the composition blows out. If adding something heavy, reduce or remove something else.
 
+### C.1 Move style: dramatic vs. subtle
+
+`vj-state.json` holds a `moveStyle` field — `"subtle"` (default: parameter nudges, coefficient tweaks) or `"dramatic"` (new visual motifs per tick: black-hole silhouette, lightning strikes, aurora, tearfall, rotor gear, crystalline facets, time-echo, water pool). Dramatic mode adds a whole feature each tick instead of adjusting one. Switch modes when user says "more variation" or "less busy". Save the choice.
+
+### C.2 Auto-wire knobs the user is twisting
+
+`vj-state.json` holds `knobSnapshot` (previous values) and `unwiredKnobs` (knob indices with no shader reference). Each tick, diff current knob values vs snapshot. If an **unwired** knob moved by >0.02, wire it to something interesting (fog density, palette tint, an existing-effect intensity knob). Update `knobSnapshot` every tick, and remove the knob from `unwiredKnobs` once mapped.
+
+To find which knobs are already in the shader, grep the `.frag` for `knob_N`. Exclude comment-only references.
+
 ### D. Apply the edit via the jam tab
 
-Read + edit + save through the browser so HMR is the edit path:
+**Validate BEFORE saving** — never write a broken shader to disk. The static linter doesn't catch forward-reference or type errors; only the real GLSL compiler does. Use `window.__vjValidate` installed on the jam tab.
+
+**One-time install per jam-tab reload:**
+```javascript
+(async () => {
+  if (typeof window.__vjValidate === 'function') return 'already installed';
+  const mod = await import('/src/shader-transformers/shader-wrapper.js');
+  const wrap = mod.shaderWrapper;
+  const canvas = document.createElement('canvas');
+  canvas.width = 4; canvas.height = 4;
+  const gl = canvas.getContext('webgl2');
+  window.__vjValidate = (src) => {
+    const wrapped = wrap(src);
+    const sh = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(sh, wrapped);
+    gl.compileShader(sh);
+    const ok = gl.getShaderParameter(sh, gl.COMPILE_STATUS);
+    const info = ok ? null : gl.getShaderInfoLog(sh);
+    gl.deleteShader(sh);
+    return { ok, info };
+  };
+  return 'installed';
+})()
+```
+
+Then each tick:
 ```javascript
 (async () => {
   const src = await (await fetch('/shaders/<shader-path>.frag?t=' + Date.now())).text();
   let edited = src;
   // ... string replacements ...
+  const v = window.__vjValidate(edited);
+  if (!v.ok) return 'COMPILE FAIL (not saved): ' + v.info;
   const res = await fetch('/__save-shader', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
@@ -161,19 +198,15 @@ Read + edit + save through the browser so HMR is the edit path:
 
 Note: the `/__save-shader` `shader` field takes the path WITHOUT `.frag`.
 
-### E. Validate
+### E. Post-save sanity check (optional)
 
 ```fish
 node scripts/validate-shader.js <shader-path>.frag 2>&1 | grep -E "^ERROR" | head -5
 ```
 
-The validator exits non-zero on warnings too (e.g. divide-by-zero hints), so check for `^ERROR` lines, not exit status.
+The static linter is a secondary check — pre-save GL compile (step D) is the primary gate.
 
-If errors appear:
-- Fix inline (common issues: GLSL reserved words like `active`, `input`, `output`, `sample` → rename)
-- If unfixable in one pass, revert to the previous version via `git checkout -- <file>` and skip this iteration's edit
-
-Track consecutive failures in `vj-state.json` (`failCount`). After 3 in a row, stop the cron and tell the user.
+If a broken edit somehow slipped through (e.g. validator install failed silently), revert with `git checkout -- <file>`, bump `failCount` in state. After 3 consecutive failures, stop the cron and tell the user.
 
 ### F. Increment + persist
 

--- a/.claude/skills/vj/SKILL.md
+++ b/.claude/skills/vj/SKILL.md
@@ -238,25 +238,67 @@ Bump `iteration` in `.claude/vj-state.json`.
 
 Keep it tight. No screenshot — the user is watching the shader live.
 
-### H. Journal cool moments (only when warranted)
+### H. Read + update the per-shader journal (every session, every cool moment, every user flag)
 
-After the edit lands, notice the current visual+audio combination. If it's working especially well, append an entry to the **per-shader journal**:
+The **per-shader journal** is the session-memory of the VJ run. It lives at:
 
 ```
 journals/<shader-filename-without-dir-or-ext>-cool-moments.md
 ```
 
-For example, `shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag` → `journals/the-coat-6-cool-moments.md`. Create it if missing.
+e.g. `shaders/redaphid/wip/the-coat-fur-coat/the-coat-8.frag` → `journals/the-coat-8-cool-moments.md`.
 
-**Purpose: these journals feed the next shader.** When the user eventually says "make a new shader", the combined entries across shaders become a design brief — which audio/visual correspondences are worth keeping, which gating thresholds reliably produce "modes" rather than noise, which track types the current shader vocabulary can and can't serve. So write each entry with future-you (designing v7 from scratch) as the reader, not session-present-you.
+**Two purposes:**
+1. **Resume the VJ session** later — a new `/vj` run should pick up with full awareness of what's already been explored with this shader: which audio-features-to-visual mappings worked, which the user flagged for removal/fix, which track types were in rotation.
+2. **Refine this shader** — between sessions we can return with a "todo" list: issues to fix, tweaks to try, effects that were close-but-off.
 
-Each entry should capture:
-- **Audio fingerprint** — the *specific* feature combination that made the moment. Not vague ("bass hit") — precise ranges (`bass 0.65-0.75 + centroid < 0.15 + entropy < 0.1`) so a future shader can be designed to *reward* that fingerprint.
-- **What the shader did right** — which existing blocks fired, and *how their gating conditions overlapped*. The goal of a v7 is often to take an alignment that happened by accident here and make it deliberate.
-- **What the shader missed** — moments where the music was doing X and the shader *should* have responded but didn't (wrong gate threshold, no matching effect, clashing overlay). These are v7 requirements.
-- **Design hypothesis** — one line: "next shader should have a dedicated effect for audio-pattern X."
+**When to read:**
+- **At `/vj` setup** (step 3/4/5 in the session start) — if `journals/<shader-name>-cool-moments.md` exists, read it first. Its contents should shape the session: don't re-introduce effects the user already rejected, prioritize the Todo section's unfixed items when planning early ticks.
+- **Before each tick that proposes a dramatic move** — so we don't re-add a motif that was already vetoed.
 
-Skip ordinary ticks. The git log already records *what* changed — the journal captures *why a specific audio-pattern called for a specific visual response*. 3-5 honest entries per shader beats 30 mediocre ones.
+**When to write:**
+- **Cool moment** — visual + audio combo landed well. Add a dated entry under `## Cool moments`.
+- **User flag** — user called something out (remove, fix, nudge). Add an entry under `## Todo` with enough context to act on it later.
+- **Removal / major change** — record what was pulled and why under `## History of changes` so future-you knows not to re-add it.
+- **Fork** — note the fork under `## Forks` on both the source and the destination journal.
+
+**Journal structure** (create sections on first write, append after that):
+
+```markdown
+# <shader-name> — Session Journal
+
+## Status
+One-line current state. Updated each tick or as often as meaningful.
+e.g. "Iter 47 on /vj run. User approves everything except mercury-flow diamonds."
+
+## Cool moments
+Entries for (audio-fingerprint → visual-response) wins. Each entry:
+- **Audio fingerprint** — precise ranges, not vague. e.g. `bass 0.65-0.75 + centroid < 0.15 + entropy < 0.1`.
+- **What worked** — which blocks fired, how their gates overlapped.
+- **What was missed** — signal that should have provoked a response but didn't.
+- **Design hypothesis** — one line for the next shader.
+
+## Todo
+Unresolved user requests. Ordered by how much they matter.
+- `[ ] fix mercury-flow diamond lattice (user: "flannel-like, moves quickly, artifacting")`
+- `[ ] warm breath intensity feels low at mids > 0.7 — try 0.45 → 0.7 scale`
+Tick off with `[x]` when fixed, don't remove — history is useful.
+
+## History of changes
+Brief bullets of removals + reasons. Don't re-add these.
+- "Removed CONFETTI (iter 45 after fork to -8) — user request."
+- "Removed RGB-SPLIT (iter pre-fork -5) — user: 'rgb checkerboard on coat'."
+
+## Forks
+- `the-coat-8 ← the-coat-7` (iter 45): confetti removed.
+
+## Design hypotheses for v(next)
+Accumulated one-liners from cool moments. Read this when designing the next shader.
+- "Dedicated mid-dominant warmth effect for mids > 0.7 AND centroid < 0.3 AND entropy < 0.2."
+- "Effects should declare their feature-space region so alignments are deliberate, not emergent."
+```
+
+Skip the journal only on totally ordinary parameter nudges with nothing learned. Otherwise write.
 
 ## Stop conditions
 

--- a/.claude/skills/vj/SKILL.md
+++ b/.claude/skills/vj/SKILL.md
@@ -31,10 +31,30 @@ Existing state file (if a run is in progress):
 
 ## Arguments
 
-- **No args** → 180 iterations (3 hours), 1 per minute
-- **Single integer N** → N iterations
+The skill parses `$ARGUMENTS` by looking for these tokens in any order:
+
+- **No args** → 180 iterations (3 hours), 1 per minute, shader = most recently modified `.frag`
+- **Integer N** → N iterations instead of 180
 - **`stop`** → read `.claude/vj-state.json`, `CronDelete` the stored job ID, remove the state file
 - **`tick`** → single iteration (what the cron fires)
+- **A shader path** → use this shader for the run. Accepted forms:
+  - `shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag` (full path from repo root)
+  - `redaphid/wip/the-coat-fur-coat/the-coat-6.frag` (relative to `shaders/`)
+  - `redaphid/wip/the-coat-fur-coat/the-coat-6` (no extension, same format `/__save-shader` accepts)
+  - Absolute path anywhere under the repo
+  - A bare shader name if unique: `/vj the-coat-6` resolves by find-matching under `shaders/`
+  - A URL containing `?shader=...`: extract the param
+  Normalize to the no-extension form before saving to `vj-state.json` as `shaderPath`.
+
+Examples:
+- `/vj` — 180 iters on the most-recent .frag
+- `/vj 30` — 30 iters
+- `/vj redaphid/wip/the-coat-fur-coat/the-coat-6` — 180 iters on this shader
+- `/vj 60 the-coat-6` — 60 iters, resolving `the-coat-6` by name
+- `/vj stop` — end the run
+- `/vj tick` — what cron fires; reads state, runs one iteration
+
+If a shader arg is passed mid-run (skill re-invoked while state exists), treat it as a shader-swap: update `shaderPath` in state and navigate the jam tab to the new shader URL without reloading the whole page (use `window.cranes.shader = <code>` + `history.replaceState` pattern).
 
 ## Setup (once, at start)
 

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ test-screenshots/
 screenshots/
 public/test-audio/
 public/images/*.webp
+.claude/vj-state.json

--- a/journals/2026-04-22-vj-skill-ergonomics.md
+++ b/journals/2026-04-22-vj-skill-ergonomics.md
@@ -1,0 +1,91 @@
+# 2026-04-22 — VJ Skill Ergonomics Session
+
+## Setup
+- Branch: `vj`
+- Shader: `redaphid/wip/the-coat-fur-coat/the-coat-3`
+- Audio: tab capture, Spotify
+- Music rotation: Layton Giordani, John Summit, SIDEPIECE, Westend, Of The Trees, ZISO
+- Cadence: `/vj` at 1-minute cron (target 180 iterations)
+- Goal: debug and improve the `/vj` skill while actively running it
+
+## What happened
+
+Started by asking Claude to clear stale vj-ish cron jobs (there were none, but the reflex reveals something). Then ran `/vj` — which immediately crashed on a context-loading bash error (`ls .claude/scheduled_tasks.json` returning non-zero). That became the entry point to a debug-while-jamming session.
+
+Fixed the skill in layers. Meanwhile, every 60 seconds a cron tick fired, made one shader move, validated, bumped iteration. The user twisted knobs constantly, swapped tracks frequently, and occasionally dropped requests mid-flow ("map the knob I'm twisting to zoom", "let me zoom 3× as far out", "optimize the shader without losing too much").
+
+Thirteen iterations landed. Every iteration touched a different audio feature channel (bass, treble, flux, entropy, centroid, pitch). The shader now has sub-ring, ember haze, starfield, RGB split, heart pulse, scan line, ghost-echo-on-bass, mids-breathing hue, pitch-driven heart color, centroid-driven palette lightness, flux-driven fur shimmer. And a pow→mul optimization pass.
+
+## Direct requests the user made
+
+1. **"Clear any cron job for claude that's trying to vj or alter shaders"** — defensive reflex when starting a fresh session. Implies: don't trust that a prior /vj run ended cleanly. → `/vj` on invoke should detect stale state (vj-state.json exists but no live cron matches) and offer a clean-slate path.
+
+2. **"Debug the vj skill. First, understand what it's doing and open the browser tabs"** — wants Claude to *bootstrap*, not explain. → skill should be aggressively self-starting (open tabs, start dev server, schedule cron, run iter 1) without ceremonial check-ins.
+
+3. **"Start the dev server in the background"** — minimal narration. → if `/vj` needs dev server, just start it silently.
+
+4. **"That awk thing is going to match on all node processes. Instead, export a function…"** — cares about code quality even in helper scripts. → skill helpers should be code, not shell grepping. Any time the skill context shells out, consider whether a small library fn would be more robust. Resulted in `scripts/dev-port.js` (library + CLI detection).
+
+5. **"./scripts/dev-port works"** — prefers terse, no-extension CLI names. → wrapper scripts should feel like installed binaries.
+
+6. **"Just write a wrapper shell script"** — pragmatic tradeoffs over purity. When a clean solution doesn't work (esbuild choking on shebang when vite inlines the library), accept a workaround. → don't over-engineer; one subprocess spawn at dev-server startup is fine.
+
+7. **"I don't think we use esbuild anymore. Update the docs if that's true"** — conscientious about docs. → skill should flag when it's reinforcing an obsolete convention (in this case, esbuild is still a transitive dep of vite, so no update needed, but the instinct was right).
+
+8. **"Add a skill, /remap, that resets the midi mapping"** — emerged from real frustration during the jam. Shader edits churn through knob mappings; needed a quick reset. → live-session rituals (reset, save, fork, preset) want keyboard-speed invocations. The more VJ runs, the more accessory skills.
+
+9. **"I just saw a full-page reload. We need to minimize this in jam mode"** — **reloads kill audio capture**, forcing re-share of tab audio. Breaks flow. Root cause was `src/worker-communication.js` not excluding `jam.html` from the service-worker reload path. → **the #1 flow killer is losing tab audio.** Skill should be paranoid about anything that reloads the page. Could watchdog the jam tab — if audio drops mid-session, flash a warning.
+
+10. **"Map the knob I'm twisting to zoom"** — user expected Claude to *infer from behavior* which knob. Instead of naming a knob, they described the action. → the skill should observe knob deltas across ticks ("user is actively touching knob_X") and surface those as natural mapping candidates. Track `lastActiveKnob` in state.
+
+11. **"Let me zoom 3× as far out"** — wants **range-relative** adjustments, not absolute values. User doesn't care the zoom is `mix(0.3, 2.5, knob_1)`; they want a lever that lets them go farther. → when the user asks for "more X", the skill should widen the range of existing levers rather than invent new ones.
+
+12. **"Optimize the shader without losing too much"** — wants optimization as a *non-destructive sweep*. The "without losing too much" phrasing is important: accept subtle visual changes but not feature removal. → an `/optimize` command or `/vj optimize` subcommand doing micro-wins (pow→mul, duplicate samples, expensive-op flagging) could be its own thing.
+
+13. **"Take detailed notes about the developer ergonomic requests I'm making during the session"** — explicitly reflective. They're treating this session as product research on the skill itself. → the user runs skills with meta-awareness. Build a feedback-capture step into long-running skills.
+
+## Observed patterns (not stated but inferred)
+
+- **User twists knobs constantly.** Every tick the values shifted. This is a *continuous* performance, not set-and-forget. Skill shouldn't assume knob state is static.
+- **Track changes are frequent** (Spotify flipping every 1-2 minutes). Skill should react to track changes as *first-class events*, not passively consume.
+- **The user doesn't want screenshots returned.** Removed in the skill-fix pass. They're watching live — Claude's job is to *write*, not *report*.
+- **The one-line summary per tick works.** User isn't asking for more verbose output.
+- **Free knobs get rediscovered for repurposing** (knob_2 was zoom, became free after I remapped knob_1→zoom). There's creative energy in giving unused knobs a new job.
+
+## Friction ranked by how much it broke flow
+
+1. **Page reloads killing audio** — highest. Kills the entire jam loop.
+2. **Port guessing (6969 hardcoded)** — initial bootstrap broke.
+3. **Validator false-positives reverting good edits** — would silently eat iterations.
+4. **Iteration counter stateless across cron ticks** — skill wouldn't know when to stop.
+5. **No way to find the cron job to stop it** — `/vj stop` had no handle.
+6. **Context-probe shelling out to nonexistent files** — `/vj` itself erroring before running.
+
+## Ideas worth prototyping
+
+- **`/vj status`** — dump current iteration, cron job ID, tabs, last 5 edits.
+- **Knob-activity detection** — track which knobs moved in last N ticks; expose as "active knobs" so "map what I'm twisting" can resolve automatically.
+- **Track-change trigger** — when the Spotify widget text changes, mark the tick for a bigger move (palette shift, not just a parameter tweak). Track boundaries = musical phrases.
+- **Non-destructive audit** — `/vj audit` scans the current shader for perf issues, unused VJ blocks, blowout risks. Reports without touching the file.
+- **Undo/revert** — `/vj undo` keeps last N edits in a ring buffer in `vj-state.json` so you can roll back a bad move without `git checkout`.
+- **Inline preset capture during /vj** — a shortcut for "save this moment" that snapshots shader + knobs + track name + iteration number.
+- **Theme-driven sessions** — if the user sets a theme ("goth", "sunset") in state, the skill biases moves toward that palette rather than per-track.
+- **Fail-soft on MCP disconnects** — auto-retry the read step once before bailing.
+- **"Widen this lever"** pattern — recognized via phrases like "more", "farther", "harder"; skill finds the relevant `mix(a, b, knob)` and expands the range.
+
+## What's working well
+
+- The **1-minute cron + one-focused-move** cadence feels right. Long enough to notice changes, short enough to stay engaged.
+- **Shader edits via `/__save-shader` + HMR** (once the service-worker reload was fixed) = zero interruption to the audio or visuals.
+- The **state file (.claude/vj-state.json)** turned out to be the right place to hang iteration count, job ID, tab IDs. Would extend it for the ideas above.
+- The **single source of truth for port** (`scripts/dev-port`) removed a whole category of "which host should I hit" bugs.
+
+## Tooling built or changed this session
+
+- `scripts/dev-port.js` — library with `branchToPort()`, `getPort()`, CLI detection via `import.meta.url` check.
+- `scripts/dev-port` — shell wrapper (needed because esbuild chokes on shebangs when vite inlines the file).
+- `vite.config.js` — uses the wrapper.
+- `.claude/skills/vj/SKILL.md` — rewritten: no hardcoded port, stateful across ticks, `/vj stop` via stored job ID, validator checks `^ERROR` not exit code, no screenshots per tick.
+- `.claude/skills/remap/SKILL.md` — new skill for clearing the MIDI mapping during a session.
+- `.claude/vj-state.json` (gitignored) — iteration state.
+- `src/worker-communication.js` — skip service-worker hard reload on `jam.html` (matches existing `edit.html` exclusion).

--- a/journals/the-coat-6-cool-moments.md
+++ b/journals/the-coat-6-cool-moments.md
@@ -1,0 +1,39 @@
+# the-coat-6 — Cool Moments
+
+One journal per shader. **Purpose: feed the next shader's design.** When somebody sits down to make v7, these entries are the brief — they say which audio/visual correspondences were worth rewarding and which ones were missed.
+
+Not a changelog. Not a highlight reel. A list of *(audio-pattern → visual-response)* mappings with enough specificity that a future shader can be built to handle them deliberately.
+
+---
+
+## Template
+
+```markdown
+### iter N — *Track* — Artist
+
+**Audio fingerprint:** precise ranges for the features that made the moment. e.g. `bass 0.65-0.75 + centroid < 0.15 + entropy < 0.1 + mids 0.80-0.90`.
+
+**Shader did right:** which VJ blocks fired, how their gates happened to overlap. Be specific about *which three-way alignment* made the scene hang together.
+
+**Shader missed:** what the music was doing that *should* have produced a visual response but didn't. Wrong threshold? No matching effect? An active effect that clashed?
+
+**Design hypothesis:** one line. "v7 should have a dedicated X effect gated on audio-pattern Y."
+```
+
+---
+
+## Entries
+
+### iter 39 — *Odds & Ends* — Late Night Radio
+
+**Audio fingerprint:** `bass 0.69 (bassZ +0.58) + mids 0.85 + treble 0.19 (trebZ -0.72) + centroid 0.10 + entropy 0.07 + roughness 0.04`. Warm instrumental, almost no high-frequency content, slow pulsing bass. Very rare corner of feature-space.
+
+**Shader did right:** Mercury flow (gated `bass > 0.25 AND centroid < 0.6`) + ground quake (gated `bass > 0.3 AND centroid < 0.5`) + aurora veils (gated `centroid < 0.35`, max intensity at `< 0.10`) + nebula fog pulse (on `bassZScore > 0`) + black hole (on `bassZ > 0.3`) **all fired simultaneously**. The scene read as a coherent *place* — liquid-chrome figure pouring while the ground rippled and green-teal curtains lit the sky — because five effects with different gating schemes happened to overlap at the same audio corner.
+
+**Shader missed:** Nothing was keyed off `mids=0.85` specifically. A warm-instrumental track like this has almost no bass-kick *transients* — just a steady low pump + dominant mids. The current shader treats "dominant mids" as mild hue drift. It missed that this was the track's *identity* — a visual response specifically for *mid-dominant warmth* (not treble, not bass-transient) would have been distinctive.
+
+**Design hypothesis:** v7 should have **at least one dedicated effect keyed to `mids > 0.7 AND centroid < 0.3 AND entropy < 0.2`** — the "warm dark instrumental" corner. Something that makes mid-energy *feel warm* rather than just nudging a hue offset. Candidate: a slow-breathing amber inner glow radiating *from* the silhouette outward, like the character is the warm heat source. Separate from the bass ring system (which fires on transients, not sustained levels).
+
+**Secondary hypothesis:** The three-way alignment (mercury + quake + aurora) was an accident — they happen to share a centroid-band. v7 could *deliberately* build a gating DSL where effects declare the *region* of feature-space they belong to, making alignments intentional rather than emergent.
+
+---

--- a/journals/the-coat-8-cool-moments.md
+++ b/journals/the-coat-8-cool-moments.md
@@ -1,7 +1,7 @@
 # the-coat-8 — Session Journal
 
 ## Status
-Iter 46/180. Mercury diamond-lattice fixed (fbm-based flow, no tiling). Active track: *STARBURST – ProbCause, AHEE*. No open user flags.
+Iter 47/180. Mercury lattice + warm-breath intensity both addressed. No open user flags. Active track: *Take It Off - Dubstep – AIR SIK*.
 
 ## Cool moments
 
@@ -19,7 +19,7 @@ Iter 46/180. Mercury diamond-lattice fixed (fbm-based flow, no tiling). Active t
 
 - [x] **Fix mercury-flow diamond lattice** (iter 46) — replaced `sin(uv.x*18 + sin(uv.y*4 + t)*2.5 - t*2)` cross-product with fbm-based domain warp: `fbm(uv * (2.5, 3.5) + vec2(sin(t*0.7)*0.4, t*1.1))`. fbm has no periodic lattice so no diamonds can form. Preserves "flowing liquid" character without the microscope-artifact look. Also slowed flow_t base from 0.5 → 0.3 per bass-scale unit to read less frantic.
 
-- [ ] **Warm breath intensity (iter 45)** — subtle. Users calling for "feels good" might want a stronger effect. Current: `0.45 * pulse * warm_on`. Try `0.7` if it under-reads.
+- [x] **Warm breath intensity (iter 47)** — bumped `* 0.45` → `* 0.70`. Gates on `centroid < 0.8` so won't over-read on bright tracks. Will show more presence when a warm low-centroid passage kicks in.
 
 ## History of changes
 

--- a/journals/the-coat-8-cool-moments.md
+++ b/journals/the-coat-8-cool-moments.md
@@ -1,0 +1,46 @@
+# the-coat-8 — Session Journal
+
+## Status
+Forked from the-coat-7 at iter 45, mid-`/vj` run (target 180). Confetti removed. User-approved state apart from one open issue (mercury-flow diamond lattice). Active track: *Watch Me – Scorsi*.
+
+## Cool moments
+
+### iter 39 (carried from the-coat-6) — *Odds & Ends* — Late Night Radio
+
+**Audio fingerprint:** `bass 0.69 (bassZ +0.58) + mids 0.85 + treble 0.19 + centroid 0.10 + entropy 0.07 + roughness 0.04`. Warm dark instrumental, no transients.
+
+**What worked:** Mercury flow (bass > 0.25 AND centroid < 0.6) + ground quake (bass > 0.3 AND centroid < 0.5) + aurora veils (centroid < 0.10) + nebula fog bass-pulse + black hole all fired simultaneously. Character poured like chrome while the ground rippled and green-teal curtains lit the sky — five effects with different gates happened to overlap at the same audio corner. Read as a *place*, not a stack.
+
+**What was missed:** Nothing keyed specifically to *dominant sustained mids* as a signal in its own right. Warm instrumental character has that as its identity; the shader only saw it as "mild hue drift."
+
+**Design hypothesis:** v(next) should have a dedicated effect for `mids > 0.7 AND centroid < 0.3 AND entropy < 0.2` — "warm dark instrumental" — a slow-breathing amber inner glow radiating *from* the silhouette, distinct from the bass-ring system. (Partially addressed: warm-breath chest glow added in iter 45, coat-7.)
+
+## Todo
+
+- [ ] **Fix mercury-flow diamond lattice** — user: "flannel-like, large diamonds with thick lines, almost like zooming into a microscope, moves quickly." Caused by `sin(uv.x * 18 + sin(uv.y * 4 + flow_t) * 2.5 - flow_t * 2)` — the cross-sine product creates a diamond grid. Coat-only because gated `silhouette > 0.05`. Fix candidates: (a) drop the cross-modulation → plain vertical stripes via `sin(uv.x * 9 - flow_t * 2)`, (b) shift to `fbm`-based mercury with no lattice period, (c) remove mercury flow entirely and replace with something else for the bass-heavy-low-centroid corner.
+
+- [ ] **Warm breath intensity (iter 45)** — subtle. Users calling for "feels good" might want a stronger effect. Current: `0.45 * pulse * warm_on`. Try `0.7` if it under-reads.
+
+## History of changes
+
+(Most recent last. Don't re-add these.)
+
+- **the-coat-3** base session: accumulated nebula fog, starfield, sub-ring, heart pulse, RGB split, scan line, lightning, crystalline facets, rotor gear, cosmic shockwave, time-echo, water pool, volumetric beams, camera drift, fog pulse, fur shimmer, aurora, tearfall, black hole, dissolution particles, hyperspace tunnel, mercury flow, ground quake, searchlight, flux hue drift, mouth glow, warm breath, bouncing body.
+- **Removed in -5 fork:** RGB-SPLIT (chromatic aberration block) — user: "rgb checkerboard on coat."
+- **Removed iter 35:** TEARFALL — user: "vertical white streaks."
+- **Removed iter 37:** LIGHTNING + SCAN LINE + CRYSTALLINE FACETS — user: "horizontal lightning / CRT scan / rainbow checkerboard."
+- **Removed iter pre-fork -7:** INFINITY MIRROR (spinning tiled kaleido) — user: "spinning squares, distracting."
+- **Removed in -8 fork (iter 45):** CONFETTI — user request.
+
+## Forks
+
+- `the-coat-7 ← the-coat-6` (iter 45): snapshot of "pretty gorgeous" state before mercury-flow fix attempt.
+- `the-coat-8 ← the-coat-7` (iter 45): confetti removed.
+
+## Design hypotheses for v(next)
+
+- Dedicated **mid-dominant warmth** effect for `mids > 0.7 AND centroid < 0.3 AND entropy < 0.2` (slow amber inner glow emanating from silhouette).
+- **Effects declare their feature-space region** via a lightweight DSL so multi-effect alignments are deliberate rather than accidental. The iter-39 five-way alignment happened because three separate blocks coincidentally wanted the same corner; v(next) should express that intent in one place.
+- **Avoid visible sine-cross products** on elements that will be textured onto silhouettes — they read as artifacting (mercury-flow lattice lesson).
+- **Pitch-driven color** (iter 41 confetti, iter 19 chrome, iter 43 mouth glow) consistently felt *intentional*. Keep this pattern: the music's note → some visual channel's hue. v(next) should have a single place where pitchClass is the palette's anchor, rather than each effect computing its own.
+- **Feedback is the #1 flow killer** when effects feed back into next frame and create tiling. Keep effect blocks *after* the `col = mix(prev, col, feedback_amt)` step if they shouldn't persist across frames.

--- a/journals/the-coat-8-cool-moments.md
+++ b/journals/the-coat-8-cool-moments.md
@@ -1,7 +1,7 @@
 # the-coat-8 — Session Journal
 
 ## Status
-Forked from the-coat-7 at iter 45, mid-`/vj` run (target 180). Confetti removed. User-approved state apart from one open issue (mercury-flow diamond lattice). Active track: *Watch Me – Scorsi*.
+Iter 46/180. Mercury diamond-lattice fixed (fbm-based flow, no tiling). Active track: *STARBURST – ProbCause, AHEE*. No open user flags.
 
 ## Cool moments
 
@@ -17,7 +17,7 @@ Forked from the-coat-7 at iter 45, mid-`/vj` run (target 180). Confetti removed.
 
 ## Todo
 
-- [ ] **Fix mercury-flow diamond lattice** — user: "flannel-like, large diamonds with thick lines, almost like zooming into a microscope, moves quickly." Caused by `sin(uv.x * 18 + sin(uv.y * 4 + flow_t) * 2.5 - flow_t * 2)` — the cross-sine product creates a diamond grid. Coat-only because gated `silhouette > 0.05`. Fix candidates: (a) drop the cross-modulation → plain vertical stripes via `sin(uv.x * 9 - flow_t * 2)`, (b) shift to `fbm`-based mercury with no lattice period, (c) remove mercury flow entirely and replace with something else for the bass-heavy-low-centroid corner.
+- [x] **Fix mercury-flow diamond lattice** (iter 46) — replaced `sin(uv.x*18 + sin(uv.y*4 + t)*2.5 - t*2)` cross-product with fbm-based domain warp: `fbm(uv * (2.5, 3.5) + vec2(sin(t*0.7)*0.4, t*1.1))`. fbm has no periodic lattice so no diamonds can form. Preserves "flowing liquid" character without the microscope-artifact look. Also slowed flow_t base from 0.5 → 0.3 per bass-scale unit to read less frantic.
 
 - [ ] **Warm breath intensity (iter 45)** — subtle. Users calling for "feels good" might want a stronger effect. Current: `0.45 * pulse * warm_on`. Try `0.7` if it under-reads.
 

--- a/scripts/dev-port
+++ b/scripts/dev-port
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec node "$(dirname "$0")/dev-port.js" "$@"

--- a/scripts/dev-port.js
+++ b/scripts/dev-port.js
@@ -1,0 +1,20 @@
+import { execSync } from 'child_process'
+
+export const branchToPort = (branch) => {
+  if (branch === 'main') return 6969
+  let hash = 0
+  for (const ch of branch) hash = ((hash << 5) - hash + ch.charCodeAt(0)) | 0
+  return 1024 + (Math.abs(hash) % 64511)
+}
+
+export const getPort = () => {
+  if (process.env.PORT) return parseInt(process.env.PORT)
+  const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim()
+  return branchToPort(branch)
+}
+
+const main = () => {
+  process.stdout.write(String(getPort()))
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main()

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-3.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-3.frag
@@ -10,7 +10,7 @@ uniform float drop_glow; // from the-coat controller — sustained drop with dec
 
 // ============================================================================
 // KNOB CONTROLS — knobs override baked defaults from the jam session
-// knob_2: zoom (0=wide, 1=tight)
+// knob_1: zoom (0=wide, 1=tight) — live-remapped
 // knob_3: god ray intensity override
 // knob_4: eye wash override
 // knob_5: drop zoom override
@@ -21,8 +21,8 @@ uniform float drop_glow; // from the-coat controller — sustained drop with dec
 
 // --- ZOOM ---
 // Baked from knob_2=-0.346 session value
-// knob_2: 0=wide, 1=tight
-#define BASE_ZOOM (mix(0.3, 2.5, knob_2) + energyNormalized * 0.4)
+// knob_1: 0=wide, 1=tight — live-remapped from knob_2
+#define BASE_ZOOM (mix(0.1, 2.5, knob_1) + energyNormalized * 0.4)
 
 // --- COAT SHAPE ---
 #define SHOULDER_Y      (-0.02 + max(bassZScore, 0.0) * 0.015)
@@ -66,9 +66,10 @@ uniform float drop_glow; // from the-coat controller — sustained drop with dec
 
 // --- COLOR ---
 // Base hue shifts with pitch class — different notes = different colors
-#define HUE_BASE (0.78 + pitchClassNormalized * 0.15)
+// VJ breathing rainbow — full cycle every ~60s, mids nudge the hue
+#define HUE_BASE (fract(0.78 + time * 0.0167 + pitchClassNormalized * 0.15 + midsNormalized * 0.20))
 // Drop shifts toward hot orange/yellow
-#define HUE_DROP (0.08 + spectralCentroidNormalized * 0.1)
+#define HUE_DROP (fract(0.99 + spectralCentroidNormalized * 0.05))
 
 // --- COAT SURFACE (the star of the show) ---
 // Fluff bristles up on energy spikes AND spectral roughness
@@ -318,9 +319,9 @@ float sdCurls(vec2 p, Pose P, float beat_phase, float pump) {
     hp = vec2(hp.x * ct - hp.y * st, hp.x * st + hp.y * ct);
 
     float d = 1e6;
-    for (int i = 0; i < 14; i++) {
+    for (int i = 0; i < 8; i++) {
         float fi = float(i);
-        float t = fi / 13.0;
+        float t = fi / 7.0;
         float ang = mix(PI * 1.05, PI * -0.05, t);
         float radius = 0.155;
         float jx = hash(vec2(fi, 1.0)) - 0.5;
@@ -367,6 +368,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     zoom_intensity = zoom_intensity * zoom_intensity * zoom_intensity;
     float zoomAmount = BASE_ZOOM + zoom_intensity * INTENSITY_ZOOM + drop_hit * DROP_ZOOM;
     vec2 zoomCenter = P.head_c;
+    // VJ CAMERA DRIFT — slow lateral sway + flux nudge so the frame never sits locked
+    vec2 cam_drift = vec2(
+        sin(time * 0.12) * 0.015 + spectralFluxZScore * 0.012,
+        sin(time * 0.09 + 1.3) * 0.010
+    );
+    zoomCenter += cam_drift;
     uv = (uv - zoomCenter) / zoomAmount + zoomCenter;
 
     // Camera tilt — knob_6 controls how much swagger
@@ -380,9 +387,82 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     // ---- BACKDROP ----
     float bg_grad = smoothstep(-0.8, 0.8, uv.y);
-    vec3 bg = mix(vec3(0.08, 0.02, 0.12), vec3(0.02, 0.0, 0.05), bg_grad);
-    float spot = exp(-pow(uv.x, 2.0) * 4.0) * smoothstep(-0.3, -0.6, uv.y);
-    bg += spot * vec3(0.5, 0.2, 0.6) * (0.5 + 0.5 * sin(BEAT_PHASE * 2.0));
+    vec3 bg = mix(vec3(0.04, 0.02, 0.10), vec3(0.01, 0.00, 0.04), bg_grad);
+    float spot = exp(-uv.x*uv.x * 4.0) * smoothstep(-0.3, -0.6, uv.y);
+    bg += spot * vec3(0.5, 0.2, 0.6) * (0.5 + 0.5 * sin(BEAT_PHASE * 2.0)) * (0.8 + clamp(energyZScore, -0.5, 2.0) * 0.6);
+    // VJ STARFIELD — sparkle crosses in the upper sky, twinkle faster on treble
+    {
+        vec2 sp = uv * 14.0;
+        vec2 scell = floor(sp);
+        vec2 scf = fract(sp) - 0.5;
+        float sr = hash(scell);
+        float sr2 = hash(scell + vec2(3.7, 1.3));
+        float star_active = step(0.80, sr);
+        vec2 spos = (vec2(sr2, hash(scell + vec2(2.1, 5.9))) - 0.5) * 0.4;
+        vec2 delta = scf - spos;
+        float sd = length(delta);
+        float cross_h = exp(-delta.y*delta.y * 2500.0) * exp(-abs(delta.x) * 15.0);
+        float cross_v = exp(-delta.x*delta.x * 2500.0) * exp(-abs(delta.y) * 15.0);
+        float core = exp(-sd * sd * 800.0);
+        float tw_s = 0.5 + 0.5 * sin(time * (2.0 + sr * 4.0 + trebleNormalized * 6.0 + max(trebleZScore, 0.0) * 5.0) + sr * 30.0);
+        float twinkle = 0.35 + 0.65 * tw_s * tw_s;
+        float star = (core + (cross_h + cross_v) * 0.6) * star_active * twinkle;
+        float sky_mask = smoothstep(-0.2, 0.3, uv.y);
+        bg += vec3(1.0, 0.95, 0.85) * star * sky_mask * (1.3 + clamp(trebleZScore, 0.0, 2.5) * 0.8);
+    }
+
+    // VJ NEBULA FOG — slow drifting cosmic haze, no per-frame hashing
+    {
+        float t = time * 0.05 + trebleNormalized * 0.08;
+        vec2 np = uv * 1.3;
+        float n1 = sin(np.x * 1.7 + t * 1.3) * sin(np.y * 2.1 - t * 0.9);
+        float n2 = sin(np.x * 3.1 - t * 0.7) * sin(np.y * 2.7 + t * 1.1);
+        float n3 = sin((np.x + np.y) * 0.9 + t * 0.6);
+        float fog = (n1 + n2 * 0.6 + n3 * 0.4) * 0.25 + 0.5;
+        fog = smoothstep(0.25, 0.95, fog);
+        vec3 nebula_a = vec3(0.35, 0.15, 0.55);
+        vec3 nebula_b = vec3(0.10, 0.35, 0.70);
+        vec3 nebula = mix(nebula_a, nebula_b, sin(np.x * 0.7 + t) * 0.5 + 0.5);
+        // knob_2: nebula fog density (0 = clear, 1 = thick cosmic cloud) — auto-wired when twisted
+        float fog_pulse = 1.0 + clamp(bassZScore, 0.0, 2.0) * 0.35;
+        bg += nebula * fog * mix(0.04, 0.45, knob_2) * (0.7 + midsNormalized * 0.4) * fog_pulse;
+    }
+        // VJ AURORA VEILS — glowing green-teal curtains in dark/wonky phases (low centroid)
+    {
+        float aurora_on = smoothstep(0.35, 0.10, spectralCentroidNormalized);
+        if (aurora_on > 0.02) {
+            float t = time * 0.35;
+            float v1 = sin(uv.x * 2.3 + t) * 0.5 + sin(uv.x * 1.1 - t * 0.7) * 0.25;
+            float v2 = sin(uv.x * 3.7 - t * 0.6) * 0.35;
+            float curtain1 = exp(-pow(uv.y - 0.35 - v1 * 0.25, 2.0) * 14.0);
+            float curtain2 = exp(-pow(uv.y - 0.20 - v2 * 0.3, 2.0) * 10.0);
+            float intensity = aurora_on * (0.5 + bassNormalized * 0.6);
+            bg += vec3(0.25, 0.85, 0.55) * curtain1 * intensity * 0.7;
+            bg += vec3(0.15, 0.55, 0.95) * curtain2 * intensity * 0.5;
+        }
+    }
+    // VJ ROTOR GEAR — stepped 8-spoke halo behind head, ticks on treble-heavy phases
+    {
+        float gear_on = clamp((spectralCentroidNormalized - 0.45) * 2.0, 0.0, 1.0);
+        gear_on *= clamp(trebleNormalized - 0.3, 0.0, 1.0) * 1.8;
+        if (gear_on > 0.02) {
+            vec2 gear_p = uv - P.head_c;
+            float gear_r = length(gear_p);
+            float gear_a = atan(gear_p.y, gear_p.x);
+            // Stepped rotation — 2Hz clock, 8 positions
+            float step_rot = floor(time * 2.0) * (PI / 4.0);
+            float rot_a = gear_a + step_rot;
+            // 8 spokes
+            float spoke = 0.5 + 0.5 * cos(rot_a * 8.0);
+            spoke = smoothstep(0.72, 0.95, spoke);
+            // Only within a ring band behind head
+            float band = smoothstep(0.18, 0.21, gear_r) * smoothstep(0.33, 0.28, gear_r);
+            float gear = spoke * band;
+            // Masked outside the silhouette — radial falloff instead of silhouette ref (not defined yet here)
+            gear *= smoothstep(0.17, 0.20, gear_r);
+            bg += vec3(0.95, 0.75, 0.25) * gear * gear_on * 1.2;
+        }
+    }
     float rays = pow(max(0.0, 1.0 - abs(uv.x) * 1.2), 4.0) * smoothstep(0.0, 1.0, uv.y);
     bg += rays * vec3(1.0, 0.7, 0.3) * IS_DROP * 0.6;
 
@@ -416,7 +496,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float coat_edge_gate = coat * (1.0 - coat) * 4.0;
     coat_rim *= coat_edge_gate;
 
-    float chest_glow = exp(-pow(length(uv - vec2(P.hip * 0.7, -0.02)) * 3.0, 2.0));
+    float chest_glow_d = length(uv - vec2(P.hip * 0.7, -0.02)) * 3.0;
+    float chest_glow = exp(-chest_glow_d*chest_glow_d);
     chest_glow *= smoothstep(0.005, -0.005, d_body) * (0.3 + pump * 0.7);
 
     // Eyes
@@ -450,8 +531,10 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     // ---- COLOR ----
     float hue = mix(HUE_BASE, HUE_DROP, IS_DROP);
-    vec3 leather = hsl2rgb(vec3(hue, 0.8, 0.10));
-    vec3 chrome  = hsl2rgb(vec3(fract(hue + 0.05), 1.0, 0.65));
+    vec3 leather = hsl2rgb(vec3(hue, 0.8, mix(0.06, 0.14, spectralCentroidNormalized)));
+    // VJ prism rim — chrome cycles its own rainbow based on uv angle + time
+    float chrome_hue = fract(atan(uv.y - P.head_c.y, uv.x) / 6.2831 + time * (0.10 + pitchClassNormalized * 0.25) + hue * 0.3);
+    vec3 chrome  = hsl2rgb(vec3(chrome_hue, 1.0, 0.65));
     vec3 hair    = hsl2rgb(vec3(0.06, 0.7, 0.12));
     vec3 hot     = hsl2rgb(vec3(0.08, 1.0, 0.6));
 
@@ -472,7 +555,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec3 fur_lo = hsl2rgb(vec3(fur_hue_lo, 0.9, clamp(fur_l_lo, 0.0, 0.85)));
     vec3 fur_col = mix(fur_hi, fur_lo, coat_grad);
     // Shoulder gleam pulses with spectral flux — light catching the coat
-    float shoulder_gleam = exp(-pow((uv.y - 0.08) * 10.0, 2.0));
+    float shoulder_gleam_d = (uv.y - 0.08) * 10.0;
+    float shoulder_gleam = exp(-shoulder_gleam_d*shoulder_gleam_d);
     float gleam_intensity = GLEAM_INTENSITY;
     fur_col += shoulder_gleam * vec3(gleam_intensity * 0.5, gleam_intensity * 0.8, gleam_intensity * 1.5);
     // ---- FRACTAL FUR FIBERS ----
@@ -500,7 +584,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
             fbm(fp2 + vec2(2.1, warp_t * 0.5))
         ) * 1.5);
         // Shape the fibers: sharp ridges that look like individual strands
-        float strand = pow(abs(sin(fibers * PI * 4.0)), 3.0);
+        float strand = pow(abs(sin(fibers * PI * (4.0 + spectralFluxZScore * 1.5))), 3.0);
         // Color the strands: lighter than the base coat, tinted toward
         // cyan/white so they read as light catching individual fur fibers
         vec3 strand_col = mix(fur_col * 1.5, vec3(0.7, 0.9, 1.0), 0.3 + strand * 0.4);
@@ -524,43 +608,62 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     col = mix(col, fur_col, coat * (1.0 - curls));
     col = mix(col, hair, curls);
     col += rim * chrome * 1.3 * (1.0 - coat);
+    // VJ SUB RING — expanding cone ring on bass spikes (gated by bassZScore)
+    {
+        float bass_hit = clamp(bassZScore, 0.0, 2.5);
+        if (bass_hit > 0.3) {
+            vec2 sub_c = vec2(0.0, -0.15);
+            float sd = length(uv - sub_c);
+            float ring_speed = 1.2 + clamp(energyZScore, -0.5, 1.5) * 0.6;
+            float ring_radius = 0.2 + fract(time * ring_speed) * 0.5;
+            float ring_d = sd - ring_radius;
+            float ring = exp(-ring_d*ring_d * 400.0);
+            float ring_fade = 1.0 - fract(time * ring_speed);
+            col += vec3(1.0, 0.3, 0.1) * ring * bass_hit * ring_fade * 0.7;
+        }
+    }
+    // VJ HEART PULSE — red glow from chest center, pulses on bass
+    {
+        vec2 heart_c = vec2(P.hip * 0.7, -0.08);
+        float heart_d = length((uv - heart_c) * vec2(1.2, 1.0));
+        // Heart-shape-ish falloff
+        float heart = exp(-heart_d * 6.0);
+        float heart_pulse = 0.3 + clamp(bassZScore, 0., 2.) * 1.2 + bassNormalized * 0.5 + midsNormalized * 0.4;
+        vec3 heart_col = hsl2rgb(vec3(fract(0.92 + pitchClassNormalized * 0.10 + sin(time * 0.4) * 0.03), 1.0, 0.55));
+        col += heart * heart_col * heart_pulse * coat * 0.6;
+    }
     col += chest_glow * chrome * 0.8 * (1.0 - coat);
     // Coat rim — chrome edge hugs the shaggy outline (boosted for visibility)
     // Coat rim pulses with spectral flux — brighter on timbral changes
     float rim_boost = RIM_BOOST;
     col += coat_rim * chrome * rim_boost * (1.0 - curls);
+    // VJ CRYSTALLINE FACETS — on high entropy, coat turns to iridescent obsidian shards
+    {
+        float facet_on = clamp(spectralEntropyNormalized - 0.55, 0.0, 0.5) * 2.0;
+        if (facet_on > 0.02 && coat > 0.05) {
+            vec2 fp_c = uv * 9.0 + vec2(time * 0.15, -time * 0.07);
+            vec2 fcell = floor(fp_c);
+            vec2 ffrac = fract(fp_c) - 0.5;
+            float fh = hash(fcell);
+            float face_d = abs(ffrac.x) + abs(ffrac.y);
+            float facet = smoothstep(0.55, 0.15, face_d);
+            float iri_hue = fract(fh + time * 0.2 + spectralCentroidNormalized * 0.5);
+            vec3 iri = hsl2rgb(vec3(iri_hue, 0.9, 0.55));
+            vec3 obsidian = vec3(0.02, 0.02, 0.04);
+            vec3 shard = mix(obsidian, iri, facet * 0.8);
+            col = mix(col, shard, facet_on * coat * (1.0 - curls) * 0.8);
+        }
+    }
+
     // Button seam glow — chrome line down the center
     col += seam_glow * coat * chrome * 0.25 * (1.0 - curls);
     col += eyes * hot * 2.2;
     col = mix(col, col + hot * 0.6, eye_wash);
     col += eye_wash * hot * 0.4;
-    col += god_rays * hot * GODRAY_INTENSITY;
+    vec3 ray_col = mix(hot, vec3(0.4, 0.85, 1.0), smoothstep(0.45, 0.85, spectralCentroidNormalized));
+    col += god_rays * ray_col * GODRAY_INTENSITY;
 
-    // ---- INFINITY MIRROR ----
-    {
-        float minRes = min(res.x, res.y);
-        vec2 head_uv01 = vec2(0.5) + P.head_c * vec2(minRes / res.x, minRes / res.y);
-        float mirrorZoom = mix(1.3, 2.4, drop_hit);
-        float rot = time * 0.5 + drop_hit * sin(BEAT_PHASE) * 0.6;
-        float ca2 = cos(rot), sa2 = sin(rot);
-        vec2 mirror_uv = raw_uv01 - head_uv01;
-        mirror_uv = vec2(mirror_uv.x * ca2 - mirror_uv.y * sa2,
-                         mirror_uv.x * sa2 + mirror_uv.y * ca2);
-        mirror_uv += head_uv01;
-        int mirrorSteps = int(2.0 + drop_hit * 5.0);
-        for (int i = 0; i < 8; i++) {
-            if (i >= mirrorSteps) break;
-            mirror_uv = (mirror_uv - head_uv01) * mirrorZoom + head_uv01;
-            mirror_uv = fract(mirror_uv);
-        }
-        vec3 mirror = getLastFrameColor(mirror_uv).rgb;
-        vec3 mh = rgb2hsl(mirror);
-        mh.y = clamp(mh.y * 1.6 + 0.2, 0.0, 1.0);
-        mh.x = fract(mh.x + drop_hit * 0.1);
-        mirror = hsl2rgb(mh);
-        float silhouette = max(body, coat);
-        col = mix(col, mirror, drop_hit * (1.0 - silhouette) * 0.55);
-    }
+    // ---- INFINITY MIRROR removed (spinning-tile repetition clashed with spacy ambient bg) ----
 
     // ---- FEEDBACK ----
     vec2 fb_uv = fragCoord / res;
@@ -570,10 +673,149 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float silhouette = max(body, coat);
     // knob_9: feedback/trails (0=crisp, 1=heavy smear)
     float feedback_amt = mix(mix(0.45, 0.05, knob_9), mix(0.15, 0.03, knob_9), silhouette);
+    // VJ GHOST ECHO — bass spikes briefly raise feedback for a coat afterimage
+    feedback_amt = mix(feedback_amt, 0.55, clamp(bassZScore - 0.4, 0.0, 1.0) * 0.5);
     if (beat) feedback_amt *= 0.6;
     if (frame < 30) feedback_amt = 0.0;
     col = mix(prev, col, feedback_amt);
 
+    // VJ TIME-ECHO — on energy surges, triple-expose previous frame around head
+    {
+        float echo = clamp(energyZScore - 0.5, 0.0, 1.0);
+        if (echo > 0.05) {
+            vec2 ec = P.head_c;
+            vec3 e1 = getLastFrameColor(fb_uv + vec2( 0.020,  0.006)).rgb;
+            vec3 e2 = getLastFrameColor(fb_uv + vec2(-0.024,  0.009)).rgb;
+            vec3 e3 = getLastFrameColor(fb_uv + vec2( 0.004, -0.018)).rgb;
+            vec3 echoed = (e1 * vec3(1.2, 0.7, 0.7) + e2 * vec3(0.7, 1.1, 0.9) + e3 * vec3(0.8, 0.9, 1.2)) * 0.34;
+            col = mix(col, col + echoed * 0.5, echo * 0.9);
+        }
+    }
+    // VJ BLACK HOLE — silhouette becomes a gravitational lens. Active on bassZ spikes.
+    {
+        float bh_strength = clamp(bassZScore - 0.3, 0.0, 1.5);
+        if (bh_strength > 0.05 && silhouette > 0.0) {
+            vec2 bh_center = P.head_c + vec2(0.0, -0.05);
+            vec2 to_center = bh_center - uv;
+            float bh_d = length(to_center);
+            vec2 dir_lens = to_center / max(bh_d, 0.001);
+            float lens_strength = bh_strength * 0.08 / max(bh_d * bh_d + 0.04, 0.04);
+            vec2 lens_uv = fb_uv + dir_lens * lens_strength * vec2(res.y / res.x, 1.0);
+            vec3 lensed = getLastFrameColor(lens_uv).rgb;
+            col = mix(col, lensed, bh_strength * (1.0 - silhouette) * 0.8);
+            col = mix(col, vec3(0.0), silhouette * bh_strength * 0.85);
+        }
+    }
+
+
+    // VJ RGB SPLIT — chromatic aberration on high entropy/roughness moments
+    {
+        float aber = clamp(spectralRoughnessNormalized * spectralEntropyNormalized, 0.0, 1.0) * 0.012;
+        if (aber > 0.0005) {
+            vec2 dir = normalize(uv + vec2(0.01, 0.0));
+            float r = prev.r / 0.88;  // reuse prev (prev was *= 0.88, undo for RGB split)
+            float b = getLastFrameColor(fb_uv - dir * aber * 2.0).b;
+            float g = col.g;
+            col = mix(col, vec3(mix(r, col.r, 0.4), g, mix(b, col.b, 0.4)), 0.55);
+        }
+    }
+
+    // VJ SCAN LINE — hi-hat driven horizontal band sweeps down
+    {
+        float hat = clamp(trebleZScore, 0.0, 2.0);
+        if (hat > 0.15) {
+            float scan_y = uv.y - fract(time * 0.35) * 2.0 + 1.0;
+            float scan = exp(-scan_y * scan_y * 800.0);
+            col += vec3(0.3, 0.8, 1.0) * scan * hat * 0.4;
+        }
+    }
+    // VJ LIGHTNING — jagged electric branches on big treble/flux spikes
+    {
+        float strike = max(clamp(trebleZScore - 0.5, 0.0, 1.5), clamp(spectralFluxZScore - 0.4, 0.0, 1.5));
+        if (strike > 0.05) {
+            // 3 offset branches, each a warped vertical line
+            float bolt = 0.0;
+            for (int bi = 0; bi < 3; bi++) {
+                float bf = float(bi);
+                float bolt_x = (hash(vec2(bf + floor(time * 4.0), 17.3)) - 0.5) * 1.6;
+                float warp = sin(uv.y * 6.0 + bf * 3.0 + time * 2.0) * 0.08
+                           + sin(uv.y * 18.0 + bf * 5.0) * 0.02;
+                float dx = uv.x - bolt_x - warp;
+                float b = exp(-dx * dx * 1200.0);
+                bolt = max(bolt, b);
+            }
+            float flicker = step(0.4, hash(vec2(floor(time * 20.0), 7.1)));
+            col += vec3(0.8, 0.95, 1.2) * bolt * strike * flicker * 1.8;
+        }
+    }
+
+    // VJ COSMIC SHOCKWAVE — one-shot expanding ring on true beat flux spikes
+    {
+        float shock_trigger = float(beat) * clamp(spectralFluxZScore, 0.0, 1.0);
+        // lock the start time at the beat moment using a hash keyed to coarse time
+        float shock_phase = fract(time * 0.7);
+        float shock_r = shock_phase * 1.4;
+        float shock_d = length(uv) - shock_r;
+        float shock_ring = exp(-shock_d * shock_d * 300.0);
+        float shock_fade = (1.0 - shock_phase);
+        shock_fade *= shock_fade;
+        col += vec3(1.0, 1.0, 1.2) * shock_ring * shock_fade * shock_trigger * 1.4;
+    }
+    // VJ WATER POOL — bottom-third reflective pool ripples in dark/deep phases
+    {
+        float pool_on = smoothstep(0.25, 0.05, spectralCentroidNormalized);
+        if (pool_on > 0.02 && uv.y < -0.15) {
+            // Reflect uv: below waterline, sample mirrored above + gentle ripple
+            float depth = clamp(-uv.y - 0.15, 0.0, 0.6);
+            float ripple_x = sin(uv.x * 10.0 + time * 1.2) * 0.006 * (1.0 + bassNormalized);
+            float ripple_y = sin(uv.x * 6.0 - time * 0.8) * 0.004;
+            vec2 refl_uv = fb_uv;
+            refl_uv.y = 0.5 - (fb_uv.y - 0.5) - 0.05;
+            refl_uv.x += ripple_x;
+            refl_uv.y += ripple_y;
+            vec3 pool = getLastFrameColor(refl_uv).rgb;
+            pool *= vec3(0.4, 0.7, 0.8); // teal tint
+            float pool_fade = smoothstep(0.0, 0.45, depth);
+            col = mix(col, pool, pool_on * pool_fade * 0.65);
+        }
+    }
+    // VJ VOLUMETRIC BEAMS — light shafts radiating from upper backlight through silhouette gaps
+    {
+        float beams_on = clamp((spectralCentroidNormalized - 0.4) * 2.0, 0.0, 1.0);
+        beams_on *= clamp(energyNormalized * 1.5, 0.0, 1.0);
+        if (beams_on > 0.02) {
+            vec2 light_origin = vec2(0.3, 0.9);
+            vec2 to_origin = light_origin - uv;
+            float beam_a = atan(to_origin.y, to_origin.x);
+            float beam = 0.5 + 0.5 * sin(beam_a * 30.0 + time * 0.3);
+            beam = pow(beam, 8.0);
+            float dist_fade = 1.0 - smoothstep(0.2, 1.4, length(to_origin));
+            float sil_mask = 1.0 - silhouette;
+            vec3 beam_col = vec3(0.95, 0.85, 0.55);
+            col += beam_col * beam * dist_fade * sil_mask * beams_on * 0.45;
+        }
+    }
+    // VJ TEARFALL — 5 bright teardrops streak downward. Mids-driven (vocal presence).
+    {
+        float tear_on = clamp(midsNormalized - 0.15, 0.0, 1.0);
+        if (tear_on > 0.02) {
+            float tear_bright = 0.0;
+            for (int ti = 0; ti < 5; ti++) {
+                float tf = float(ti);
+                float col_x = (hash(vec2(tf, 101.0)) - 0.5) * 1.7;
+                float speed = 0.5 + hash(vec2(tf, 202.0)) * 0.4;
+                float phase = fract(hash(vec2(tf, 303.0)) + time * speed * 0.4);
+                // y goes from 1.2 (above) to -1.0 (below)
+                float y0 = mix(1.2, -1.0, phase);
+                float dx = uv.x - col_x;
+                float dy = uv.y - y0;
+                // Streaky: elongated teardrop, longer as it falls
+                float streak = exp(-dx*dx * 900.0 - dy*dy * 20.0 * (1.0 - phase * 0.5));
+                tear_bright += streak;
+            }
+            col += vec3(0.7, 0.85, 1.2) * tear_bright * tear_on * 1.1;
+        }
+    }
     col *= 1.0 - smoothstep(0.7, 1.4, length(uv * vec2(1.0, 0.85)));
 
 #if DEBUG_OUTLINES

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-3.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-3.frag
@@ -833,6 +833,29 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
             col += vec3(0.7, 0.85, 1.2) * tear_bright * tear_on * 1.1;
         }
     }
+    // VJ GROUND QUAKE — concentric amber rings from floor, bass-driven, multiple wavefronts
+    {
+        float quake_on = clamp(bassNormalized - 0.3, 0.0, 1.0);
+        quake_on *= smoothstep(0.5, 0.15, spectralCentroidNormalized);
+        if (quake_on > 0.02) {
+            vec2 feet_c = vec2(0.0, -0.6);
+            vec2 dvec = uv - feet_c;
+            // Squash vertically so rings look like ground waves (elliptical)
+            dvec.y *= 2.0;
+            float r = length(dvec);
+            float wavefronts = 0.0;
+            for (int wi = 0; wi < 3; wi++) {
+                float wf = float(wi);
+                float ring_r = fract(time * 0.6 + wf * 0.33) * 1.2;
+                float dr = r - ring_r;
+                float w = exp(-dr * dr * 90.0);
+                float fade = 1.0 - ring_r / 1.2;
+                wavefronts += w * fade;
+            }
+            vec3 quake_col = mix(vec3(1.0, 0.35, 0.08), vec3(1.0, 0.75, 0.3), bassNormalized);
+            col += quake_col * wavefronts * quake_on * 0.55;
+        }
+    }
     col *= 1.0 - smoothstep(0.7, 1.4, length(uv * vec2(1.0, 0.85)));
 
 #if DEBUG_OUTLINES

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-3.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-3.frag
@@ -678,6 +678,23 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     if (beat) feedback_amt *= 0.6;
     if (frame < 30) feedback_amt = 0.0;
     col = mix(prev, col, feedback_amt);
+    // VJ MERCURY FLOW — bass-heavy low-centroid phases turn the coat into flowing liquid metal
+    {
+        float flow_on = clamp(bassNormalized - 0.25, 0.0, 1.0);
+        flow_on *= smoothstep(0.60, 0.25, spectralCentroidNormalized);
+        if (flow_on > 0.02 && silhouette > 0.05) {
+            float flow_t = time * (0.5 + bassNormalized * 1.5);
+            // Vertical flow: stripes drip downward at varying speeds
+            float stripe = sin(uv.x * 18.0 + sin(uv.y * 4.0 + flow_t) * 2.5 - flow_t * 2.0);
+            stripe = stripe * 0.5 + 0.5;
+            stripe = smoothstep(0.35, 0.95, stripe);
+            vec3 mercury_dark = vec3(0.05, 0.06, 0.1);
+            vec3 mercury_hi = vec3(0.92, 0.94, 1.0);
+            vec3 mercury = mix(mercury_dark, mercury_hi, stripe);
+            col = mix(col, mercury, flow_on * silhouette * 0.75);
+        }
+    }
+
 
     // VJ TIME-ECHO — on energy surges, triple-expose previous frame around head
     {

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-3.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-3.frag
@@ -812,27 +812,6 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
             col += beam_col * beam * dist_fade * sil_mask * beams_on * 0.45;
         }
     }
-    // VJ TEARFALL — 5 bright teardrops streak downward. Mids-driven (vocal presence).
-    {
-        float tear_on = clamp(midsNormalized - 0.15, 0.0, 1.0);
-        if (tear_on > 0.02) {
-            float tear_bright = 0.0;
-            for (int ti = 0; ti < 5; ti++) {
-                float tf = float(ti);
-                float col_x = (hash(vec2(tf, 101.0)) - 0.5) * 1.7;
-                float speed = 0.5 + hash(vec2(tf, 202.0)) * 0.4;
-                float phase = fract(hash(vec2(tf, 303.0)) + time * speed * 0.4);
-                // y goes from 1.2 (above) to -1.0 (below)
-                float y0 = mix(1.2, -1.0, phase);
-                float dx = uv.x - col_x;
-                float dy = uv.y - y0;
-                // Streaky: elongated teardrop, longer as it falls
-                float streak = exp(-dx*dx * 900.0 - dy*dy * 20.0 * (1.0 - phase * 0.5));
-                tear_bright += streak;
-            }
-            col += vec3(0.7, 0.85, 1.2) * tear_bright * tear_on * 1.1;
-        }
-    }
     // VJ GROUND QUAKE — concentric amber rings from floor, bass-driven, multiple wavefronts
     {
         float quake_on = clamp(bassNormalized - 0.3, 0.0, 1.0);

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-5.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-5.frag
@@ -793,6 +793,27 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
             col += particle_col * particle * near_sil * dissolve * 1.2;
         }
     }
+    // VJ HYPERSPACE — radial streaks rushing outward from head on mid-high energy
+    {
+        float hyper_on = clamp(energyNormalized - 0.3, 0.0, 1.0);
+        hyper_on *= clamp(trebleNormalized - 0.2, 0.0, 1.0) * 1.8;
+        if (hyper_on > 0.02) {
+            vec2 hp2 = uv - P.head_c;
+            float hr = length(hp2);
+            float ha = atan(hp2.y, hp2.x);
+            // Streak density — high angular frequency for hyperspace feel
+            float streaks = 0.5 + 0.5 * sin(ha * 48.0 + hash(vec2(floor(ha * 8.0), 0.0)) * 6.28);
+            streaks = pow(streaks, 6.0);
+            // Animate outward: faster toward center
+            float flow = fract(hr * 2.0 - time * 1.2);
+            float streak_life = 1.0 - flow;
+            streak_life = streak_life * streak_life;
+            // Mask: fade near the silhouette and at screen edge
+            float mask = smoothstep(0.18, 0.35, hr) * (1.0 - smoothstep(0.9, 1.3, hr));
+            vec3 streak_col = mix(vec3(0.6, 0.7, 1.0), vec3(1.0, 0.9, 0.7), trebleNormalized);
+            col += streak_col * streaks * streak_life * mask * hyper_on * 0.55;
+        }
+    }
     col *= 1.0 - smoothstep(0.7, 1.4, length(uv * vec2(1.0, 0.85)));
 
 #if DEBUG_OUTLINES

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-5.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-5.frag
@@ -637,24 +637,6 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Coat rim pulses with spectral flux — brighter on timbral changes
     float rim_boost = RIM_BOOST;
     col += coat_rim * chrome * rim_boost * (1.0 - curls);
-    // VJ CRYSTALLINE FACETS — on high entropy, coat turns to iridescent obsidian shards
-    {
-        float facet_on = clamp(spectralEntropyNormalized - 0.55, 0.0, 0.5) * 2.0;
-        if (facet_on > 0.02 && coat > 0.05) {
-            vec2 fp_c = uv * 9.0 + vec2(time * 0.15, -time * 0.07);
-            vec2 fcell = floor(fp_c);
-            vec2 ffrac = fract(fp_c) - 0.5;
-            float fh = hash(fcell);
-            float face_d = abs(ffrac.x) + abs(ffrac.y);
-            float facet = smoothstep(0.55, 0.15, face_d);
-            float iri_hue = fract(fh + time * 0.2 + spectralCentroidNormalized * 0.5);
-            vec3 iri = hsl2rgb(vec3(iri_hue, 0.9, 0.55));
-            vec3 obsidian = vec3(0.02, 0.02, 0.04);
-            vec3 shard = mix(obsidian, iri, facet * 0.8);
-            col = mix(col, shard, facet_on * coat * (1.0 - curls) * 0.8);
-        }
-    }
-
     // Button seam glow — chrome line down the center
     col += seam_glow * coat * chrome * 0.25 * (1.0 - curls);
     col += eyes * hot * 2.2;
@@ -724,35 +706,6 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
         }
     }
 
-
-    // VJ SCAN LINE — hi-hat driven horizontal band sweeps down
-    {
-        float hat = clamp(trebleZScore, 0.0, 2.0);
-        if (hat > 0.15) {
-            float scan_y = uv.y - fract(time * 0.35) * 2.0 + 1.0;
-            float scan = exp(-scan_y * scan_y * 800.0);
-            col += vec3(0.3, 0.8, 1.0) * scan * hat * 0.4;
-        }
-    }
-    // VJ LIGHTNING — jagged electric branches on big treble/flux spikes
-    {
-        float strike = max(clamp(trebleZScore - 0.5, 0.0, 1.5), clamp(spectralFluxZScore - 0.4, 0.0, 1.5));
-        if (strike > 0.05) {
-            // 3 offset branches, each a warped vertical line
-            float bolt = 0.0;
-            for (int bi = 0; bi < 3; bi++) {
-                float bf = float(bi);
-                float bolt_x = (hash(vec2(bf + floor(time * 4.0), 17.3)) - 0.5) * 1.6;
-                float warp = sin(uv.y * 6.0 + bf * 3.0 + time * 2.0) * 0.08
-                           + sin(uv.y * 18.0 + bf * 5.0) * 0.02;
-                float dx = uv.x - bolt_x - warp;
-                float b = exp(-dx * dx * 1200.0);
-                bolt = max(bolt, b);
-            }
-            float flicker = step(0.4, hash(vec2(floor(time * 20.0), 7.1)));
-            col += vec3(0.8, 0.95, 1.2) * bolt * strike * flicker * 1.8;
-        }
-    }
 
     // VJ COSMIC SHOCKWAVE — one-shot expanding ring on true beat flux spikes
     {

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-5.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-5.frag
@@ -1,0 +1,837 @@
+// @fullscreen: true
+// @mobile: true
+// the-coat-5: forked from the-coat-3 during /vj session (dramatic mode). RGB split removed.
+// Knob defaults captured: knob_2=-0.346, knob_7=0.98, knob_12=0.669, knob_15=0.46
+// Use with controller=the-coat for sustained drop glow
+uniform float drop_glow; // from the-coat controller — sustained drop with decay
+#define PI 3.14159265
+
+#define DEBUG_OUTLINES 0
+
+// ============================================================================
+// KNOB CONTROLS — knobs override baked defaults from the jam session
+// knob_1: zoom (0=wide, 1=tight) — live-remapped
+// knob_3: god ray intensity override
+// knob_4: eye wash override
+// knob_5: drop zoom override
+// knob_6: camera tilt swagger
+// knob_7: fur thickness
+// knob_13: sustain decay (via controller)
+// ============================================================================
+
+// --- ZOOM ---
+// Baked from knob_2=-0.346 session value
+// knob_1: 0=wide, 1=tight — live-remapped from knob_2
+#define BASE_ZOOM (mix(0.1, 2.5, knob_1) + energyNormalized * 0.4)
+
+// --- COAT SHAPE ---
+#define SHOULDER_Y      (-0.02 + max(bassZScore, 0.0) * 0.015)
+#define SHOULDER_SPREAD (0.158 + bassNormalized * 0.02)
+#define SLEEVE_RADIUS   (0.04 + max(trebleZScore, 0.0) * 0.015)
+#define SHOULDER_CAP     0.042
+#define CHEST_W_BASE    (0.12 + bassNormalized * 0.03)
+#define CHEST_H_BASE    (0.065 + bassNormalized * 0.01)
+// Fur puffs up with energy — thick on drops, lean on quiet
+#define FUR_THICK       (0.06 + clamp(energyZScore, 0.0, 1.0) * 0.04)
+// V-neck opens on energy spikes — reveals more chest on drops
+#define VNECK_WIDTH     (0.10 + clamp(energyZScore, 0.0, 1.0) * 0.06)
+#define VNECK_BOTTOM    (-0.013 - clamp(energyZScore, 0.0, 1.0) * 0.03)
+
+// --- MOTION ---
+// Heavy pump from bass — body bounces with the kick drum
+#define PUMP (bassNormalized * 0.6 + clamp(bassSlope * bassRSquared, 0.0, 0.5) * 3.0)
+#define BEAT_PHASE (time * 2.2)
+// Treble drives snap gestures — hi-hats make hands twitch
+#define SNAP (clamp(trebleZScore, 0.0, 1.5))
+#define HIP_SWAY (sin(time * 1.1))
+// Mids drive groove — melodic content makes the body sway
+#define GROOVE (midsNormalized * 0.8 + spectralCentroidNormalized * 0.2)
+
+// --- DROP DETECTION ---
+// Confident energy build = drop approaching
+#define BUILD (clamp(energySlope * energyRSquared * 10.0, 0.0, 1.0))
+#define IS_DROP clamp(BUILD + smoothstep(0.6, 1.0, energyZScore) * 0.5, 0.0, 1.0)
+#define DROP_TRIGGER_THRESH 0.8
+#define SUSTAIN_GAIN 1.2
+
+// --- DROP VISUALS ---
+// Drop zoom punches in hard — learned from wooli-drop preset (knob_5=0.764)
+#define DROP_ZOOM 0.9
+// God rays — quiet below average energy, bloom above it
+#define GODRAY_INTENSITY (clamp(energyZScore, 0.0, 1.5) * 2.5 + clamp(trebleZScore, 0.0, 1.0) * 1.0)
+// Eye wash — kicks in above-average energy, scales up from there
+#define EYE_WASH_STRENGTH (clamp(energyZScore, 0.0, 1.0) * 0.5 + clamp(bassZScore, 0.0, 1.0) * 0.2)
+// Continuous zoom breathes with intensity
+#define INTENSITY_ZOOM (energyNormalized * 0.3)
+
+// --- COLOR ---
+// Base hue shifts with pitch class — different notes = different colors
+// VJ breathing rainbow — full cycle every ~60s, mids nudge the hue
+#define HUE_BASE (fract(0.78 + time * 0.0167 + pitchClassNormalized * 0.15 + midsNormalized * 0.20))
+// Drop shifts toward hot orange/yellow
+#define HUE_DROP (fract(0.99 + spectralCentroidNormalized * 0.05))
+
+// --- COAT SURFACE (the star of the show) ---
+// Fluff bristles up on energy spikes AND spectral roughness
+#define FLUFF_AGITATION (clamp(energyZScore, 0.0, 1.0) * 0.5 + spectralRoughnessNormalized * 0.5)
+// Bass pulse drives color warmth — kicks make the coat glow
+#define BASS_PULSE_AMT (clamp(bassZScore, 0.0, 1.0) * 0.8)
+// Color shift driven by drops AND energy — more reactive than before
+#define DROP_COLOR_AMT clamp(IS_DROP + clamp(energyZScore, 0.0, 1.0) * 0.4 + clamp(bassZScore, 0.0, 1.0) * 0.2, 0.0, 1.0)
+// Shoulder gleam pulses with spectral flux — light catches on timbral changes
+#define GLEAM_INTENSITY (0.15 + spectralFluxNormalized * 0.35)
+
+// Fractal fur — THE signature feature (living-coat preset)
+// Entropy (chaos) + roughness (grit) + kurtosis (peaked) trigger the fur fibers
+// Lower threshold than before so it's visible more often
+#define FUR_TRIGGER clamp(spectralEntropyNormalized * 0.7 + spectralRoughnessNormalized * 0.5 + clamp(spectralKurtosisZScore, 0.0, 1.0) * 0.2, 0.0, 1.0)
+// Warp speed driven by centroid — brighter sounds = faster swirl
+#define WARP_SPEED (spectralCentroidNormalized * 0.6 + spectralFluxNormalized * 0.2)
+// Rim boost: flux + bass make the chrome edge blaze
+#define RIM_BOOST (2.5 + spectralFluxNormalized * 2.0 + clamp(bassZScore, 0.0, 1.0) * 1.0)
+
+// --- DERIVED ---
+#define DROP_TRIGGER clamp(max(energyZScore, BUILD), 0.0, 1.0)
+
+// ============================================================================
+// SDFs
+// ============================================================================
+
+float sdCircle(vec2 p, float r) { return length(p) - r; }
+
+float sdEllipse(vec2 p, vec2 r) {
+    float k1 = length(p / r);
+    float k2 = length(p / (r * r));
+    return k1 * (k1 - 1.0) / max(k2, 1e-4);
+}
+
+float smin(float a, float b, float k) {
+    float h = clamp(0.5 + 0.5 * (b - a) / k, 0.0, 1.0);
+    return mix(b, a, h) - k * h * (1.0 - h);
+}
+
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+// Smooth value noise for fur texture
+float vnoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+float fbm(vec2 p) {
+    float s = 0.0;
+    float a = 0.5;
+    for (int i = 0; i < 4; i++) {
+        s += a * vnoise(p);
+        p *= 2.03;
+        a *= 0.5;
+    }
+    return s;
+}
+
+struct Pose {
+    float bob;
+    float tilt;
+    float hip;
+    vec2  head_c;
+    vec2  l_hand;
+    vec2  r_hand;
+    float l_open;
+    float r_open;
+};
+
+Pose makePose(float beat_phase, float hip_sway, float snap, float groove) {
+    Pose P;
+    P.bob = -abs(sin(beat_phase)) * 0.025 + groove * 0.005;
+    P.tilt = hip_sway * 0.18 + sin(beat_phase * 0.5) * 0.05;
+    P.hip = sign(hip_sway) * pow(abs(hip_sway), 0.6) * 0.05;
+    P.head_c = vec2(P.hip * 0.6, 0.24 + P.bob);
+    float l_gesture = snap * 1.2;
+    float r_gesture = snap * 1.2;
+    P.l_open = l_gesture;
+    P.r_open = r_gesture;
+    // Arms hang naturally at the sides, symmetric, proportional length.
+    // Hands end just past the hips (y ≈ -0.38).
+    P.l_hand = vec2(-0.30 - l_gesture * 0.15, -0.38 + l_gesture * 0.25);
+    P.r_hand = vec2( 0.30 + r_gesture * 0.15, -0.38 + r_gesture * 0.25 + sin(beat_phase) * 0.01);
+    return P;
+}
+
+float sdCapsule(vec2 p, vec2 a, vec2 b, float r) {
+    vec2 pa = p - a, ba = b - a;
+    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-4), 0.0, 1.0);
+    return length(pa - ba * h) - r;
+}
+
+// Slimmer daddy — smaller frame, no bulging biceps
+float sdDaddy(vec2 p, float pump, Pose P) {
+    float ct = cos(P.tilt), st = sin(P.tilt);
+    vec2 hp = p - P.head_c;
+    hp = vec2(hp.x * ct - hp.y * st, hp.x * st + hp.y * ct);
+
+    float head = sdEllipse(hp, vec2(0.13, 0.15));
+    float jaw = sdEllipse(hp - vec2(0.0, -0.05), vec2(0.11, 0.09));
+    head = smin(head, jaw, 0.04);
+
+    vec2 np = p - vec2(P.hip * 0.7, 0.11);
+    float neck = sdEllipse(np, vec2(0.035, 0.045));
+
+    // Slimmer chest
+    float chest_w = 0.23 + pump * 0.04;
+    float chest_h = 0.17 + pump * 0.02;
+    vec2 cp = p - vec2(P.hip * 0.7, -0.02);
+    float chest = sdEllipse(cp, vec2(chest_w, chest_h));
+
+    // Slimmer hips
+    vec2 wp = p - vec2(P.hip * 1.4, -0.22);
+    float hips = sdEllipse(wp, vec2(0.20, 0.09));
+
+    // Shoulders at the natural resting line — not raised (no shrugging)
+    float coat_edge = SHOULDER_SPREAD;
+    vec2 ls = vec2(-coat_edge + P.hip * 0.4, SHOULDER_Y);
+    vec2 rs = vec2( coat_edge + P.hip * 0.4, SHOULDER_Y);
+    float lshoulder = sdCircle(p - ls, SHOULDER_CAP);
+    float rshoulder = sdCircle(p - rs, SHOULDER_CAP);
+
+    // Arms hang proportionally — elbow at the midpoint between shoulder and
+    // hand, slightly biased inward so the lower arm curves toward the body
+    vec2 l_mid = mix(ls, P.l_hand, 0.5);
+    vec2 r_mid = mix(rs, P.r_hand, 0.5);
+    vec2 l_elbow = l_mid + vec2(0.015, 0.0) + vec2(-0.02, 0.02) * P.l_open;
+    vec2 r_elbow = r_mid + vec2(-0.015, 0.0) + vec2(0.02, 0.02) * P.r_open;
+    float l_upper = sdCapsule(p, ls, l_elbow, 0.04);
+    float l_lower = sdCapsule(p, l_elbow, P.l_hand, 0.035);
+    float r_upper = sdCapsule(p, rs, r_elbow, 0.04);
+    float r_lower = sdCapsule(p, r_elbow, P.r_hand, 0.035);
+
+    float l_fist = sdCircle(p - P.l_hand, 0.055 + P.l_open * 0.01);
+    float r_fist = sdCircle(p - P.r_hand, 0.055 + P.r_open * 0.01);
+
+    float d = head;
+    d = smin(d, neck, 0.035);
+    d = smin(d, chest, 0.05);
+    d = smin(d, hips, 0.05);
+    d = smin(d, lshoulder, 0.04);
+    d = smin(d, rshoulder, 0.04);
+    d = smin(d, l_upper, 0.035);
+    d = smin(d, l_lower, 0.035);
+    d = smin(d, r_upper, 0.035);
+    d = smin(d, r_lower, 0.035);
+    d = smin(d, l_fist, 0.025);
+    d = smin(d, r_fist, 0.025);
+    return d;
+}
+
+// Torso-only SDF: chest + shoulders + hips, NO head/neck/arms/hands.
+// Used as the base shape the fur coat inflates from, so arms poke out.
+// Chest is intentionally shorter than the body's chest so that when the coat
+// inflates outward by fur_thickness, its top sits below the neck — no hard
+// cut needed, no visible "back of collar" line.
+float sdTorso(vec2 p, float pump, Pose P) {
+    // Tailored torso: narrower chest, pinched waist, slight hip flare so
+    // the coat silhouette reads as a fitted garment instead of a sack.
+    float chest_w = CHEST_W_BASE + pump * 0.04;
+    float chest_h = CHEST_H_BASE + pump * 0.02;
+    vec2 cp = p - vec2(P.hip * 0.7, 0.01);
+    float chest = sdEllipse(cp, vec2(chest_w, chest_h));
+
+    // Waist — narrower pinch at midsection
+    vec2 wpn = p - vec2(P.hip * 0.8, -0.12);
+    float waist = sdEllipse(wpn, vec2(0.16, 0.08));
+
+    vec2 wp = p - vec2(P.hip * 1.4, -0.24);
+    float hips = sdEllipse(wp, vec2(0.17, 0.09));
+
+    float d = chest;
+    d = smin(d, waist, 0.08);
+    d = smin(d, hips, 0.08);
+    return d;
+}
+
+// Fur coat: inflates the torso AND arms (long sleeves) by a fur thickness,
+// caps at the neckline with a V, lets the hem run off-screen.
+float sdFurCoat(vec2 p, Pose P, float pump) {
+    float d_torso = sdTorso(p, pump, P);
+
+    // Long sleeves — capsules from shoulder to WRIST (not hand), so the
+    // fists poke out of the cuffs. Wrist = 80% of the way from shoulder to hand.
+    float coat_edge = SHOULDER_SPREAD;
+    vec2 ls = vec2(-coat_edge + P.hip * 0.4, SHOULDER_Y);
+    vec2 rs = vec2( coat_edge + P.hip * 0.4, SHOULDER_Y);
+    vec2 l_wrist = mix(ls, P.l_hand, 0.55);
+    vec2 r_wrist = mix(rs, P.r_hand, 0.55);
+    float l_sleeve = sdCapsule(p, ls, l_wrist, SLEEVE_RADIUS);
+    float r_sleeve = sdCapsule(p, rs, r_wrist, SLEEVE_RADIUS);
+
+    // Shoulder caps smin'd with both torso and sleeves
+    float l_cap = sdCircle(p - ls, SHOULDER_CAP);
+    float r_cap = sdCircle(p - rs, SHOULDER_CAP);
+    float coat_base = min(d_torso, l_sleeve);
+    coat_base = min(coat_base, r_sleeve);
+    coat_base = smin(coat_base, l_cap, 0.04);
+    coat_base = smin(coat_base, r_cap, 0.04);
+
+    // Looser, straighter fit (not form-fitting) — more fur thickness so the
+    // coat hangs straight down rather than hugging every curve.
+    float fur_thickness = FUR_THICK + pump * 0.005;
+    float inflated = coat_base - fur_thickness;
+
+    // Straight hem: a tall narrow rectangle-ish ellipse that gives the coat a
+    // straight drop through the hips and off the bottom. Not wider than the
+    // shoulders, so it reads as "long coat" not "ball gown."
+    vec2 hem_c = vec2(P.hip * 1.0, -0.55);
+    float hem = sdEllipse(p - hem_c, vec2(0.26, 0.45));
+    inflated = smin(inflated, hem, 0.06);
+
+    // V-neckline: opens from the sternum to the top of the coat. The V is
+    // bounded so it only carves within its y-range — outside the range,
+    // v_wedge stays positive so `-v_wedge` is negative and max() ignores it.
+    // V-neck carved with a smooth subtraction. Wedge is unbounded at the top
+    // so its sides continue upward past the coat top — this means the wedge
+    // has NO visible "top corners" inside the coat, so rim lighting can't
+    // trace a phantom collar back-edge at the top of the V.
+    float cx = P.hip * 0.7;
+    float v_bottom = VNECK_BOTTOM;
+    float v_half_at_top = VNECK_WIDTH;
+    // Slope of the V: widens as y increases, no upper bound
+    float v_slope = v_half_at_top / 0.17;  // reaches 0.07 at y=0.15
+    float v_half = max(0.0, (p.y - v_bottom)) * v_slope;
+    float v_horiz = abs(p.x - cx) - v_half;
+    float v_vert = v_bottom - p.y;  // only the bottom is a hard wall
+    float v_wedge = max(v_horiz, v_vert);
+
+    // Smooth subtraction (smooth max via -smin)
+    float d = -smin(-inflated, v_wedge, 0.015);
+    return d;
+}
+
+float sdCurls(vec2 p, Pose P, float beat_phase, float pump) {
+    float ct = cos(P.tilt), st = sin(P.tilt);
+    vec2 hp = p - P.head_c;
+    hp = vec2(hp.x * ct - hp.y * st, hp.x * st + hp.y * ct);
+
+    float d = 1e6;
+    for (int i = 0; i < 8; i++) {
+        float fi = float(i);
+        float t = fi / 7.0;
+        float ang = mix(PI * 1.05, PI * -0.05, t);
+        float radius = 0.155;
+        float jx = hash(vec2(fi, 1.0)) - 0.5;
+        float jy = hash(vec2(fi, 2.0)) - 0.5;
+        vec2 c = vec2(cos(ang), sin(ang)) * radius + vec2(jx, jy) * 0.025;
+        float crown_bias = sin(t * PI);
+        float r = 0.045 + crown_bias * 0.015 + hash(vec2(fi, 3.0)) * 0.01;
+        float ph = hash(vec2(fi, 4.0)) * 6.28;
+        float bounce = sin(beat_phase * 1.0 + ph) * 0.012 + pump * 0.008;
+        c.y += bounce;
+        d = smin(d, sdCircle(hp - c, r), 0.025);
+    }
+    return d;
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = (fragCoord - 0.5 * res) / min(res.x, res.y);
+
+    float pump = PUMP;
+    Pose P = makePose(BEAT_PHASE, HIP_SWAY, SNAP, GROOVE);
+
+    vec2 raw_uv01 = fragCoord / res;
+
+    // --- DROP SUSTAIN ---
+    // drop_glow is a controller-computed uniform with exponential decay.
+    // It latches high on energy spikes and decays smoothly over ~1-2 seconds.
+    // Falls back to instantaneous IS_DROP if no controller is loaded.
+    float drop_spike = smoothstep(DROP_TRIGGER_THRESH, DROP_TRIGGER_THRESH + 0.5, BUILD);
+    float sustain_signal = BUILD * SUSTAIN_GAIN;
+    float drop_now = clamp(max(drop_spike, max(IS_DROP, sustain_signal)), 0.0, 1.0);
+    drop_now = smoothstep(0.15, 0.5, drop_now);
+    // drop_glow = controller-driven sustained drop glow (exponential decay)
+    float drop_hit = max(drop_now, drop_glow);
+
+    float intensity = max(PUMP, GROOVE);
+    // Cubic ease-in: crushes twitchy low-end values, lets big moments punch through.
+    // smoothstep(0.2, 0.9) maps to 0-1, then cube kills anything below ~0.5
+    float zoom_intensity = smoothstep(0.2, 0.9, intensity);
+    zoom_intensity = zoom_intensity * zoom_intensity * zoom_intensity;
+    float zoomAmount = BASE_ZOOM + zoom_intensity * INTENSITY_ZOOM + drop_hit * DROP_ZOOM;
+    vec2 zoomCenter = P.head_c;
+    // VJ CAMERA DRIFT — slow lateral sway + flux nudge so the frame never sits locked
+    vec2 cam_drift = vec2(
+        sin(time * 0.12) * 0.015 + spectralFluxZScore * 0.012,
+        sin(time * 0.09 + 1.3) * 0.010
+    );
+    zoomCenter += cam_drift;
+    uv = (uv - zoomCenter) / zoomAmount + zoomCenter;
+
+    // Camera tilt — knob_6 controls how much swagger
+    float tilt_angle = (sin(time * 0.7) * 0.15
+                     + (spectralCentroidNormalized - 0.5) * 0.2
+                     + bassZScore * 0.075) * knob_6;
+    float ca = cos(tilt_angle), sa = sin(tilt_angle);
+    uv -= zoomCenter;
+    uv = vec2(uv.x * ca - uv.y * sa, uv.x * sa + uv.y * ca);
+    uv += zoomCenter;
+
+    // ---- BACKDROP ----
+    float bg_grad = smoothstep(-0.8, 0.8, uv.y);
+    vec3 bg = mix(vec3(0.04, 0.02, 0.10), vec3(0.01, 0.00, 0.04), bg_grad);
+    float spot = exp(-uv.x*uv.x * 4.0) * smoothstep(-0.3, -0.6, uv.y);
+    bg += spot * vec3(0.5, 0.2, 0.6) * (0.5 + 0.5 * sin(BEAT_PHASE * 2.0)) * (0.8 + clamp(energyZScore, -0.5, 2.0) * 0.6);
+    // VJ STARFIELD — sparkle crosses in the upper sky, twinkle faster on treble
+    {
+        vec2 sp = uv * 14.0;
+        vec2 scell = floor(sp);
+        vec2 scf = fract(sp) - 0.5;
+        float sr = hash(scell);
+        float sr2 = hash(scell + vec2(3.7, 1.3));
+        float star_active = step(0.80, sr);
+        vec2 spos = (vec2(sr2, hash(scell + vec2(2.1, 5.9))) - 0.5) * 0.4;
+        vec2 delta = scf - spos;
+        float sd = length(delta);
+        float cross_h = exp(-delta.y*delta.y * 2500.0) * exp(-abs(delta.x) * 15.0);
+        float cross_v = exp(-delta.x*delta.x * 2500.0) * exp(-abs(delta.y) * 15.0);
+        float core = exp(-sd * sd * 800.0);
+        float tw_s = 0.5 + 0.5 * sin(time * (2.0 + sr * 4.0 + trebleNormalized * 6.0 + max(trebleZScore, 0.0) * 5.0) + sr * 30.0);
+        float twinkle = 0.35 + 0.65 * tw_s * tw_s;
+        float star = (core + (cross_h + cross_v) * 0.6) * star_active * twinkle;
+        float sky_mask = smoothstep(-0.2, 0.3, uv.y);
+        bg += vec3(1.0, 0.95, 0.85) * star * sky_mask * (1.3 + clamp(trebleZScore, 0.0, 2.5) * 0.8);
+    }
+
+    // VJ NEBULA FOG — slow drifting cosmic haze, no per-frame hashing
+    {
+        float t = time * 0.05 + trebleNormalized * 0.08;
+        vec2 np = uv * 1.3;
+        float n1 = sin(np.x * 1.7 + t * 1.3) * sin(np.y * 2.1 - t * 0.9);
+        float n2 = sin(np.x * 3.1 - t * 0.7) * sin(np.y * 2.7 + t * 1.1);
+        float n3 = sin((np.x + np.y) * 0.9 + t * 0.6);
+        float fog = (n1 + n2 * 0.6 + n3 * 0.4) * 0.25 + 0.5;
+        fog = smoothstep(0.25, 0.95, fog);
+        vec3 nebula_a = vec3(0.35, 0.15, 0.55);
+        vec3 nebula_b = vec3(0.10, 0.35, 0.70);
+        vec3 nebula = mix(nebula_a, nebula_b, sin(np.x * 0.7 + t) * 0.5 + 0.5);
+        // knob_2: nebula fog density (0 = clear, 1 = thick cosmic cloud) — auto-wired when twisted
+        float fog_pulse = 1.0 + clamp(bassZScore, 0.0, 2.0) * 0.35;
+        bg += nebula * fog * mix(0.04, 0.45, knob_2) * (0.7 + midsNormalized * 0.4) * fog_pulse;
+    }
+        // VJ AURORA VEILS — glowing green-teal curtains in dark/wonky phases (low centroid)
+    {
+        float aurora_on = smoothstep(0.35, 0.10, spectralCentroidNormalized);
+        if (aurora_on > 0.02) {
+            float t = time * 0.35;
+            float v1 = sin(uv.x * 2.3 + t) * 0.5 + sin(uv.x * 1.1 - t * 0.7) * 0.25;
+            float v2 = sin(uv.x * 3.7 - t * 0.6) * 0.35;
+            float curtain1 = exp(-pow(uv.y - 0.35 - v1 * 0.25, 2.0) * 14.0);
+            float curtain2 = exp(-pow(uv.y - 0.20 - v2 * 0.3, 2.0) * 10.0);
+            float intensity = aurora_on * (0.5 + bassNormalized * 0.6);
+            bg += vec3(0.25, 0.85, 0.55) * curtain1 * intensity * 0.7;
+            bg += vec3(0.15, 0.55, 0.95) * curtain2 * intensity * 0.5;
+        }
+    }
+    // VJ ROTOR GEAR — stepped 8-spoke halo behind head, ticks on treble-heavy phases
+    {
+        float gear_on = clamp((spectralCentroidNormalized - 0.45) * 2.0, 0.0, 1.0);
+        gear_on *= clamp(trebleNormalized - 0.3, 0.0, 1.0) * 1.8;
+        if (gear_on > 0.02) {
+            vec2 gear_p = uv - P.head_c;
+            float gear_r = length(gear_p);
+            float gear_a = atan(gear_p.y, gear_p.x);
+            // Stepped rotation — 2Hz clock, 8 positions
+            float step_rot = floor(time * 2.0) * (PI / 4.0);
+            float rot_a = gear_a + step_rot;
+            // 8 spokes
+            float spoke = 0.5 + 0.5 * cos(rot_a * 8.0);
+            spoke = smoothstep(0.72, 0.95, spoke);
+            // Only within a ring band behind head
+            float band = smoothstep(0.18, 0.21, gear_r) * smoothstep(0.33, 0.28, gear_r);
+            float gear = spoke * band;
+            // Masked outside the silhouette — radial falloff instead of silhouette ref (not defined yet here)
+            gear *= smoothstep(0.17, 0.20, gear_r);
+            bg += vec3(0.95, 0.75, 0.25) * gear * gear_on * 1.2;
+        }
+    }
+    float rays = pow(max(0.0, 1.0 - abs(uv.x) * 1.2), 4.0) * smoothstep(0.0, 1.0, uv.y);
+    bg += rays * vec3(1.0, 0.7, 0.3) * IS_DROP * 0.6;
+
+    // ---- DADDY ----
+    float d_body  = sdDaddy(uv, pump, P);
+    float d_curls = sdCurls(uv, P, BEAT_PHASE, pump);
+    float d_coat  = sdFurCoat(uv, P, pump);
+
+    // Fur "fluff" — perturb the coat distance with noise so its edge is shaggy
+    // Noise coords wobble with beat so the fur looks alive
+    vec2 fur_p = uv * 38.0 + vec2(0.0, sin(BEAT_PHASE) * 0.15);
+    float fur_n = fbm(fur_p);
+    // Fur edge gets much more agitated on drops/bass — bristles up
+    float fluff_amp = 0.018 + pump * 0.015 + SNAP * 0.012 + FLUFF_AGITATION * 0.02;
+    float d_coat_fluff = d_coat - (fur_n - 0.5) * fluff_amp;
+
+    float d = min(d_body, d_curls);
+
+    float body  = smoothstep(0.005, -0.005, d);
+    float curls = smoothstep(0.005, -0.005, d_curls);
+    float coat  = smoothstep(0.006, -0.006, d_coat_fluff);
+
+    // Rim light — body
+    float rim_w = 0.006 + IS_DROP * 0.012 + SNAP * 0.006;
+    float rim = smoothstep(rim_w, 0.0, abs(d));
+    float edge_gate = body * (1.0 - body) * 4.0;
+    rim *= edge_gate;
+
+    // Rim light — coat (same chrome treatment on the fluffy edge)
+    float coat_rim = smoothstep(rim_w, 0.0, abs(d_coat_fluff));
+    float coat_edge_gate = coat * (1.0 - coat) * 4.0;
+    coat_rim *= coat_edge_gate;
+
+    float chest_glow_d = length(uv - vec2(P.hip * 0.7, -0.02)) * 3.0;
+    float chest_glow = exp(-chest_glow_d*chest_glow_d);
+    chest_glow *= smoothstep(0.005, -0.005, d_body) * (0.3 + pump * 0.7);
+
+    // Eyes
+    float ct = cos(P.tilt), st = sin(P.tilt);
+    vec2 le_local = vec2(-0.045, 0.02);
+    vec2 re_local = vec2( 0.045, 0.02);
+    vec2 le = P.head_c + vec2(le_local.x * ct + le_local.y * st, -le_local.x * st + le_local.y * ct);
+    vec2 re = P.head_c + vec2(re_local.x * ct + re_local.y * st, -re_local.x * st + re_local.y * ct);
+
+    float eyes = exp(-dot(uv - le, uv - le) * 2500.0) + exp(-dot(uv - re, uv - re) * 2500.0);
+    eyes *= (0.25 + drop_hit * 1.8 + SNAP * 0.6);
+
+    vec2 d_le2 = uv - le;
+    vec2 d_re2 = uv - re;
+    float r_le = length(d_le2);
+    float r_re = length(d_re2);
+    float a_le = atan(d_le2.y, d_le2.x);
+    float a_re = atan(d_re2.y, d_re2.x);
+    float fan_le = pow(abs(cos(a_le * 6.0 + time * 0.8)), 14.0);
+    float fan_re = pow(abs(cos(a_re * 6.0 - time * 0.7 + 1.3)), 14.0);
+    float fall_le = exp(-r_le * 1.2);
+    float fall_re = exp(-r_re * 1.2);
+    float up_le = smoothstep(-1.0, 0.3, d_le2.y / max(r_le, 0.001));
+    float up_re = smoothstep(-1.0, 0.3, d_re2.y / max(r_re, 0.001));
+    float god_rays = (fan_le * fall_le * up_le + fan_re * fall_re * up_re) * drop_hit;
+    god_rays += (exp(-r_le * 10.0) + exp(-r_re * 10.0)) * drop_hit * 0.6;
+
+    float wash_le = exp(-r_le * 0.8);
+    float wash_re = exp(-r_re * 0.8);
+    float eye_wash = (wash_le + wash_re) * drop_hit * EYE_WASH_STRENGTH;
+
+    // ---- COLOR ----
+    float hue = mix(HUE_BASE, HUE_DROP, IS_DROP);
+    vec3 leather = hsl2rgb(vec3(hue, 0.8, mix(0.06, 0.14, spectralCentroidNormalized)));
+    // VJ prism rim — chrome cycles its own rainbow based on uv angle + time
+    float chrome_hue = fract(atan(uv.y - P.head_c.y, uv.x) / 6.2831 + time * (0.10 + pitchClassNormalized * 0.25) + hue * 0.3);
+    vec3 chrome  = hsl2rgb(vec3(chrome_hue, 1.0, 0.65));
+    vec3 hair    = hsl2rgb(vec3(0.06, 0.7, 0.12));
+    vec3 hot     = hsl2rgb(vec3(0.08, 1.0, 0.6));
+
+    // Coat fill — audio-reactive color. Base is deep blue, but:
+    // - Lightness pulses brighter on bass hits
+    // - Hue shifts toward electric cyan on drops
+    // - Saturation dips slightly on quiet passages (more white/pastel)
+    float coat_grad = smoothstep(0.15, -0.4, uv.y);
+    float bass_pulse = BASS_PULSE_AMT;
+    float drop_color = DROP_COLOR_AMT;
+    // Hue slides from deep blue (0.62) toward electric cyan (0.50) on drops
+    float fur_hue_hi = mix(0.62, 0.50, drop_color * 0.6);
+    float fur_hue_lo = mix(0.58, 0.48, drop_color * 0.5);
+    // Lightness pumps up on bass
+    float fur_l_hi = 0.65 + bass_pulse * 0.15;
+    float fur_l_lo = 0.45 + bass_pulse * 0.10;
+    vec3 fur_hi = hsl2rgb(vec3(fur_hue_hi, 0.95, clamp(fur_l_hi, 0.0, 0.95)));
+    vec3 fur_lo = hsl2rgb(vec3(fur_hue_lo, 0.9, clamp(fur_l_lo, 0.0, 0.85)));
+    vec3 fur_col = mix(fur_hi, fur_lo, coat_grad);
+    // Shoulder gleam pulses with spectral flux — light catching the coat
+    float shoulder_gleam_d = (uv.y - 0.08) * 10.0;
+    float shoulder_gleam = exp(-shoulder_gleam_d*shoulder_gleam_d);
+    float gleam_intensity = GLEAM_INTENSITY;
+    fur_col += shoulder_gleam * vec3(gleam_intensity * 0.5, gleam_intensity * 0.8, gleam_intensity * 1.5);
+    // ---- FRACTAL FUR FIBERS ----
+    // Swirling domain-warped fractal that appears inside the coat when the
+    // music is "interesting" — triggered by spectral entropy (chaos) and
+    // spectral roughness (dissonance). These are independent from the
+    // energy/bass features that drive the eyes, so the coat and eyes
+    // react to DIFFERENT musical qualities.
+    float fur_trigger = FUR_TRIGGER;
+    // Only show when musically interesting (above baseline)
+    float fur_fractal_amt = smoothstep(0.15, 0.55, fur_trigger);
+    if (fur_fractal_amt > 0.01) {
+        // Domain warp: swirl the coords with low-freq noise so the fibers
+        // look like curling fur strands, not a static grid
+        vec2 fp = uv * 18.0;
+        float warp_t = time * 0.3 + WARP_SPEED;
+        vec2 warp = vec2(
+            fbm(fp + vec2(warp_t, 0.0)),
+            fbm(fp + vec2(0.0, warp_t + 3.7))
+        );
+        // Second domain warp for deeper swirl
+        vec2 fp2 = fp + warp * 3.5;
+        float fibers = fbm(fp2 + vec2(
+            fbm(fp2 + vec2(warp_t * 0.7, 1.3)),
+            fbm(fp2 + vec2(2.1, warp_t * 0.5))
+        ) * 1.5);
+        // Shape the fibers: sharp ridges that look like individual strands
+        float strand = pow(abs(sin(fibers * PI * (4.0 + spectralFluxZScore * 1.5))), 3.0);
+        // Color the strands: lighter than the base coat, tinted toward
+        // cyan/white so they read as light catching individual fur fibers
+        vec3 strand_col = mix(fur_col * 1.5, vec3(0.7, 0.9, 1.0), 0.3 + strand * 0.4);
+        // Blend into the coat color, gated by the trigger amount
+        fur_col = mix(fur_col, strand_col, strand * fur_fractal_amt * 0.85);
+    }
+
+    // Seam strength computed here; chrome glow added after compositing
+    // so it matches the rim-light aesthetic. Thin + subtle.
+    float seam_x_pos = P.hip * 0.7;
+    float seam_dx = uv.x - seam_x_pos;
+    float seam_glow = exp(-seam_dx * seam_dx * 40000.0);
+    seam_glow *= smoothstep(-0.02, -0.10, uv.y) * 0.3;
+
+    vec3 col = bg;
+    // Body silhouette — warm plum skin that reads against the dark background
+    // and complements the pink coat
+    vec3 skin = hsl2rgb(vec3(0.92, 0.45, 0.18));
+    col = mix(col, skin, body);
+    // Coat sits OVER the body but UNDER the hair (so curls still fall)
+    col = mix(col, fur_col, coat * (1.0 - curls));
+    col = mix(col, hair, curls);
+    col += rim * chrome * 1.3 * (1.0 - coat);
+    // VJ SUB RING — expanding cone ring on bass spikes (gated by bassZScore)
+    {
+        float bass_hit = clamp(bassZScore, 0.0, 2.5);
+        if (bass_hit > 0.3) {
+            vec2 sub_c = vec2(0.0, -0.15);
+            float sd = length(uv - sub_c);
+            float ring_speed = 1.2 + clamp(energyZScore, -0.5, 1.5) * 0.6;
+            float ring_radius = 0.2 + fract(time * ring_speed) * 0.5;
+            float ring_d = sd - ring_radius;
+            float ring = exp(-ring_d*ring_d * 400.0);
+            float ring_fade = 1.0 - fract(time * ring_speed);
+            col += vec3(1.0, 0.3, 0.1) * ring * bass_hit * ring_fade * 0.7;
+        }
+    }
+    // VJ HEART PULSE — red glow from chest center, pulses on bass
+    {
+        vec2 heart_c = vec2(P.hip * 0.7, -0.08);
+        float heart_d = length((uv - heart_c) * vec2(1.2, 1.0));
+        // Heart-shape-ish falloff
+        float heart = exp(-heart_d * 6.0);
+        float heart_pulse = 0.3 + clamp(bassZScore, 0., 2.) * 1.2 + bassNormalized * 0.5 + midsNormalized * 0.4;
+        vec3 heart_col = hsl2rgb(vec3(fract(0.92 + pitchClassNormalized * 0.10 + sin(time * 0.4) * 0.03), 1.0, 0.55));
+        col += heart * heart_col * heart_pulse * coat * 0.6;
+    }
+    col += chest_glow * chrome * 0.8 * (1.0 - coat);
+    // Coat rim — chrome edge hugs the shaggy outline (boosted for visibility)
+    // Coat rim pulses with spectral flux — brighter on timbral changes
+    float rim_boost = RIM_BOOST;
+    col += coat_rim * chrome * rim_boost * (1.0 - curls);
+    // VJ CRYSTALLINE FACETS — on high entropy, coat turns to iridescent obsidian shards
+    {
+        float facet_on = clamp(spectralEntropyNormalized - 0.55, 0.0, 0.5) * 2.0;
+        if (facet_on > 0.02 && coat > 0.05) {
+            vec2 fp_c = uv * 9.0 + vec2(time * 0.15, -time * 0.07);
+            vec2 fcell = floor(fp_c);
+            vec2 ffrac = fract(fp_c) - 0.5;
+            float fh = hash(fcell);
+            float face_d = abs(ffrac.x) + abs(ffrac.y);
+            float facet = smoothstep(0.55, 0.15, face_d);
+            float iri_hue = fract(fh + time * 0.2 + spectralCentroidNormalized * 0.5);
+            vec3 iri = hsl2rgb(vec3(iri_hue, 0.9, 0.55));
+            vec3 obsidian = vec3(0.02, 0.02, 0.04);
+            vec3 shard = mix(obsidian, iri, facet * 0.8);
+            col = mix(col, shard, facet_on * coat * (1.0 - curls) * 0.8);
+        }
+    }
+
+    // Button seam glow — chrome line down the center
+    col += seam_glow * coat * chrome * 0.25 * (1.0 - curls);
+    col += eyes * hot * 2.2;
+    col = mix(col, col + hot * 0.6, eye_wash);
+    col += eye_wash * hot * 0.4;
+    vec3 ray_col = mix(hot, vec3(0.4, 0.85, 1.0), smoothstep(0.45, 0.85, spectralCentroidNormalized));
+    col += god_rays * ray_col * GODRAY_INTENSITY;
+
+    // ---- INFINITY MIRROR removed (spinning-tile repetition clashed with spacy ambient bg) ----
+
+    // ---- FEEDBACK ----
+    vec2 fb_uv = fragCoord / res;
+    fb_uv.x -= P.hip * 0.01;
+    fb_uv.y -= 0.002 + pump * 0.003;
+    vec3 prev = getLastFrameColor(fb_uv).rgb * 0.88;
+    float silhouette = max(body, coat);
+    // knob_9: feedback/trails (0=crisp, 1=heavy smear)
+    float feedback_amt = mix(mix(0.45, 0.05, knob_9), mix(0.15, 0.03, knob_9), silhouette);
+    // VJ GHOST ECHO — bass spikes briefly raise feedback for a coat afterimage
+    feedback_amt = mix(feedback_amt, 0.55, clamp(bassZScore - 0.4, 0.0, 1.0) * 0.5);
+    if (beat) feedback_amt *= 0.6;
+    if (frame < 30) feedback_amt = 0.0;
+    col = mix(prev, col, feedback_amt);
+    // VJ MERCURY FLOW — bass-heavy low-centroid phases turn the coat into flowing liquid metal
+    {
+        float flow_on = clamp(bassNormalized - 0.25, 0.0, 1.0);
+        flow_on *= smoothstep(0.60, 0.25, spectralCentroidNormalized);
+        if (flow_on > 0.02 && silhouette > 0.05) {
+            float flow_t = time * (0.5 + bassNormalized * 1.5);
+            // Vertical flow: stripes drip downward at varying speeds
+            float stripe = sin(uv.x * 18.0 + sin(uv.y * 4.0 + flow_t) * 2.5 - flow_t * 2.0);
+            stripe = stripe * 0.5 + 0.5;
+            stripe = smoothstep(0.35, 0.95, stripe);
+            vec3 mercury_dark = vec3(0.05, 0.06, 0.1);
+            vec3 mercury_hi = vec3(0.92, 0.94, 1.0);
+            vec3 mercury = mix(mercury_dark, mercury_hi, stripe);
+            col = mix(col, mercury, flow_on * silhouette * 0.75);
+        }
+    }
+
+
+    // VJ TIME-ECHO — on energy surges, triple-expose previous frame around head
+    {
+        float echo = clamp(energyZScore - 0.5, 0.0, 1.0);
+        if (echo > 0.05) {
+            vec2 ec = P.head_c;
+            vec3 e1 = getLastFrameColor(fb_uv + vec2( 0.020,  0.006)).rgb;
+            vec3 e2 = getLastFrameColor(fb_uv + vec2(-0.024,  0.009)).rgb;
+            vec3 e3 = getLastFrameColor(fb_uv + vec2( 0.004, -0.018)).rgb;
+            vec3 echoed = (e1 * vec3(1.2, 0.7, 0.7) + e2 * vec3(0.7, 1.1, 0.9) + e3 * vec3(0.8, 0.9, 1.2)) * 0.34;
+            col = mix(col, col + echoed * 0.5, echo * 0.9);
+        }
+    }
+    // VJ BLACK HOLE — silhouette becomes a gravitational lens. Active on bassZ spikes.
+    {
+        float bh_strength = clamp(bassZScore - 0.3, 0.0, 1.5);
+        if (bh_strength > 0.05 && silhouette > 0.0) {
+            vec2 bh_center = P.head_c + vec2(0.0, -0.05);
+            vec2 to_center = bh_center - uv;
+            float bh_d = length(to_center);
+            vec2 dir_lens = to_center / max(bh_d, 0.001);
+            float lens_strength = bh_strength * 0.08 / max(bh_d * bh_d + 0.04, 0.04);
+            vec2 lens_uv = fb_uv + dir_lens * lens_strength * vec2(res.y / res.x, 1.0);
+            vec3 lensed = getLastFrameColor(lens_uv).rgb;
+            col = mix(col, lensed, bh_strength * (1.0 - silhouette) * 0.8);
+            col = mix(col, vec3(0.0), silhouette * bh_strength * 0.85);
+        }
+    }
+
+
+    // VJ SCAN LINE — hi-hat driven horizontal band sweeps down
+    {
+        float hat = clamp(trebleZScore, 0.0, 2.0);
+        if (hat > 0.15) {
+            float scan_y = uv.y - fract(time * 0.35) * 2.0 + 1.0;
+            float scan = exp(-scan_y * scan_y * 800.0);
+            col += vec3(0.3, 0.8, 1.0) * scan * hat * 0.4;
+        }
+    }
+    // VJ LIGHTNING — jagged electric branches on big treble/flux spikes
+    {
+        float strike = max(clamp(trebleZScore - 0.5, 0.0, 1.5), clamp(spectralFluxZScore - 0.4, 0.0, 1.5));
+        if (strike > 0.05) {
+            // 3 offset branches, each a warped vertical line
+            float bolt = 0.0;
+            for (int bi = 0; bi < 3; bi++) {
+                float bf = float(bi);
+                float bolt_x = (hash(vec2(bf + floor(time * 4.0), 17.3)) - 0.5) * 1.6;
+                float warp = sin(uv.y * 6.0 + bf * 3.0 + time * 2.0) * 0.08
+                           + sin(uv.y * 18.0 + bf * 5.0) * 0.02;
+                float dx = uv.x - bolt_x - warp;
+                float b = exp(-dx * dx * 1200.0);
+                bolt = max(bolt, b);
+            }
+            float flicker = step(0.4, hash(vec2(floor(time * 20.0), 7.1)));
+            col += vec3(0.8, 0.95, 1.2) * bolt * strike * flicker * 1.8;
+        }
+    }
+
+    // VJ COSMIC SHOCKWAVE — one-shot expanding ring on true beat flux spikes
+    {
+        float shock_trigger = float(beat) * clamp(spectralFluxZScore, 0.0, 1.0);
+        // lock the start time at the beat moment using a hash keyed to coarse time
+        float shock_phase = fract(time * 0.7);
+        float shock_r = shock_phase * 1.4;
+        float shock_d = length(uv) - shock_r;
+        float shock_ring = exp(-shock_d * shock_d * 300.0);
+        float shock_fade = (1.0 - shock_phase);
+        shock_fade *= shock_fade;
+        col += vec3(1.0, 1.0, 1.2) * shock_ring * shock_fade * shock_trigger * 1.4;
+    }
+    // VJ WATER POOL — bottom-third reflective pool ripples in dark/deep phases
+    {
+        float pool_on = smoothstep(0.25, 0.05, spectralCentroidNormalized);
+        if (pool_on > 0.02 && uv.y < -0.15) {
+            // Reflect uv: below waterline, sample mirrored above + gentle ripple
+            float depth = clamp(-uv.y - 0.15, 0.0, 0.6);
+            float ripple_x = sin(uv.x * 10.0 + time * 1.2) * 0.006 * (1.0 + bassNormalized);
+            float ripple_y = sin(uv.x * 6.0 - time * 0.8) * 0.004;
+            vec2 refl_uv = fb_uv;
+            refl_uv.y = 0.5 - (fb_uv.y - 0.5) - 0.05;
+            refl_uv.x += ripple_x;
+            refl_uv.y += ripple_y;
+            vec3 pool = getLastFrameColor(refl_uv).rgb;
+            pool *= vec3(0.4, 0.7, 0.8); // teal tint
+            float pool_fade = smoothstep(0.0, 0.45, depth);
+            col = mix(col, pool, pool_on * pool_fade * 0.65);
+        }
+    }
+    // VJ VOLUMETRIC BEAMS — light shafts radiating from upper backlight through silhouette gaps
+    {
+        float beams_on = clamp((spectralCentroidNormalized - 0.4) * 2.0, 0.0, 1.0);
+        beams_on *= clamp(energyNormalized * 1.5, 0.0, 1.0);
+        if (beams_on > 0.02) {
+            vec2 light_origin = vec2(0.3, 0.9);
+            vec2 to_origin = light_origin - uv;
+            float beam_a = atan(to_origin.y, to_origin.x);
+            float beam = 0.5 + 0.5 * sin(beam_a * 30.0 + time * 0.3);
+            beam = pow(beam, 8.0);
+            float dist_fade = 1.0 - smoothstep(0.2, 1.4, length(to_origin));
+            float sil_mask = 1.0 - silhouette;
+            vec3 beam_col = vec3(0.95, 0.85, 0.55);
+            col += beam_col * beam * dist_fade * sil_mask * beams_on * 0.45;
+        }
+    }
+    // VJ GROUND QUAKE — concentric amber rings from floor, bass-driven, multiple wavefronts
+    {
+        float quake_on = clamp(bassNormalized - 0.3, 0.0, 1.0);
+        quake_on *= smoothstep(0.5, 0.15, spectralCentroidNormalized);
+        if (quake_on > 0.02) {
+            vec2 feet_c = vec2(0.0, -0.6);
+            vec2 dvec = uv - feet_c;
+            // Squash vertically so rings look like ground waves (elliptical)
+            dvec.y *= 2.0;
+            float r = length(dvec);
+            float wavefronts = 0.0;
+            for (int wi = 0; wi < 3; wi++) {
+                float wf = float(wi);
+                float ring_r = fract(time * 0.6 + wf * 0.33) * 1.2;
+                float dr = r - ring_r;
+                float w = exp(-dr * dr * 90.0);
+                float fade = 1.0 - ring_r / 1.2;
+                wavefronts += w * fade;
+            }
+            vec3 quake_col = mix(vec3(1.0, 0.35, 0.08), vec3(1.0, 0.75, 0.3), bassNormalized);
+            col += quake_col * wavefronts * quake_on * 0.55;
+        }
+    }
+    col *= 1.0 - smoothstep(0.7, 1.4, length(uv * vec2(1.0, 0.85)));
+
+#if DEBUG_OUTLINES
+    col *= 0.25;
+    float body_outline = smoothstep(0.003, 0.0, abs(d_body));
+    float coat_outline = smoothstep(0.003, 0.0, abs(d_coat));
+    col += body_outline * vec3(0.0, 1.0, 1.0);
+    col += coat_outline * vec3(1.0, 1.0, 0.0);
+#endif
+
+    fragColor = vec4(clamp(col, 0.0, 1.0), 1.0);
+}

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-5.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-5.frag
@@ -823,6 +823,23 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
             col += quake_col * wavefronts * quake_on * 0.55;
         }
     }
+    // VJ DISSOLUTION — character sheds drifting particles upward on bright high-treble phases
+    {
+        float dissolve = clamp(trebleNormalized - 0.3, 0.0, 1.0);
+        dissolve *= clamp(spectralCentroidNormalized - 0.5, 0.0, 1.0) * 2.0;
+        if (dissolve > 0.02) {
+            vec2 pp = uv * vec2(12.0, 8.0) + vec2(sin(time * 0.3) * 0.3, time * -0.8);
+            vec2 pcell = floor(pp);
+            vec2 pfrac = fract(pp) - 0.5;
+            float ph = hash(pcell);
+            float alive = step(0.82, ph);
+            float pd = length(pfrac * vec2(2.5, 1.2));
+            float particle = exp(-pd * pd * 25.0) * alive;
+            float near_sil = smoothstep(0.0, 0.15, silhouette) * (1.0 - silhouette);
+            vec3 particle_col = mix(vec3(0.9, 0.95, 1.0), vec3(1.0, 0.85, 0.6), hash(pcell + vec2(1.1, 3.3)));
+            col += particle_col * particle * near_sil * dissolve * 1.2;
+        }
+    }
     col *= 1.0 - smoothstep(0.7, 1.4, length(uv * vec2(1.0, 0.85)));
 
 #if DEBUG_OUTLINES

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-5.md
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-5.md
@@ -1,0 +1,35 @@
+# the-coat-5
+
+Forked from `the-coat-3.frag` during a `/vj` live session (dramatic-mode run, iteration ~35).
+
+## Why
+
+User didn't like the RGB-split chromatic aberration reading as a "checkerboard" on the coat. Forked to preserve the rest of the dramatic-mode evolution (black hole, aurora, rotor gear, mercury flow, ground quake, volumetric beams, crystalline facets, cosmic shockwave, time-echo, water pool, scan line, sub-ring, heart pulse, fur shimmer) without the RGB split layer.
+
+## What changed vs the-coat-3
+
+- **Removed** the `VJ RGB SPLIT` block (was `if (aber > 0.0005) col = mix(col, rgb-offset, 0.55)` on roughness × entropy). That was producing the chromatic checkerboard on the silhouette.
+
+## Baked knob state at fork time
+
+| Knob | Value | Role |
+|---|---|---|
+| knob_1 | 0.291 | zoom (0=wide, 1=tight) |
+| knob_2 | 0.646 | nebula fog density |
+| knob_3 | 0.953 | god ray intensity override |
+| knob_4 | 0.764 | eye wash override |
+| knob_5 | 0.457 | drop zoom override |
+| knob_6 | 0 | camera tilt swagger (off) |
+| knob_7 | 1 | fur thickness |
+| knob_8 | 0 | unwired |
+| knob_9 | 0 | feedback/trails (crisp) |
+| knob_10 | 0 | unwired |
+| knob_11 | 0 | unwired |
+
+## Preset URL
+
+`?shader=redaphid/wip/the-coat-fur-coat/the-coat-5&controller=the-coat&knob_1=0.291&knob_2=0.646&knob_3=0.953&knob_4=0.764&knob_5=0.457&knob_6=0&knob_7=1&knob_8=0&knob_9=0&knob_10=0&knob_11=0`
+
+## Controller
+
+`controllers/the-coat.js` — drop-sustain with exponential decay.

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
@@ -879,5 +879,14 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     col += coat_outline * vec3(1.0, 1.0, 0.0);
 #endif
 
+    // VJ FLUX HUE DRIFT — sustained spectral flux slowly rotates overall hue
+    {
+        float drift = clamp(spectralFluxNormalized - 0.15, 0.0, 0.7) * 0.18;
+        if (drift > 0.005) {
+            vec3 hsl_col = rgb2hsl(col);
+            hsl_col.x = fract(hsl_col.x + drift);
+            col = hsl2rgb(hsl_col);
+        }
+    }
     fragColor = vec4(clamp(col, 0.0, 1.0), 1.0);
 }

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
@@ -814,6 +814,26 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
             col += streak_col * streaks * streak_life * mask * hyper_on * 0.55;
         }
     }
+    // VJ SEARCHLIGHT — rotating police-style beam, red/blue alternating on bass
+    {
+        float search_on = clamp(midsNormalized - 0.2, 0.0, 1.0);
+        if (search_on > 0.02) {
+            // Beam anchored above the frame, sweeps angle
+            vec2 origin = vec2(sin(time * 0.7) * 0.5, 1.1);
+            vec2 to_pix = uv - origin;
+            float beam_a = atan(to_pix.y, to_pix.x);
+            // Beam target angle (rotates)
+            float target_a = -PI * 0.5 + sin(time * 1.1) * 0.45;
+            float beam_width = 0.12;
+            float beam = smoothstep(beam_width, 0.0, abs(beam_a - target_a));
+            beam *= smoothstep(0.0, 0.3, length(to_pix));
+            beam *= 1.0 - smoothstep(0.8, 1.3, length(to_pix));
+            // Alternate red/blue every half-cycle
+            float flash = step(0.0, sin(time * 2.5 + clamp(bassZScore, 0.0, 2.0) * 4.0));
+            vec3 beam_col = mix(vec3(0.2, 0.4, 1.0), vec3(1.0, 0.2, 0.3), flash);
+            col += beam_col * beam * search_on * 0.7;
+        }
+    }
     col *= 1.0 - smoothstep(0.7, 1.4, length(uv * vec2(1.0, 0.85)));
 
 #if DEBUG_OUTLINES

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
@@ -640,6 +640,18 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Button seam glow — chrome line down the center
     col += seam_glow * coat * chrome * 0.25 * (1.0 - curls);
     col += eyes * hot * 2.2;
+    // VJ MOUTH GLOW — soft glow where the mouth would be, pulsing on mids (vocal presence)
+    {
+        float mouth_on = clamp(midsNormalized - 0.15, 0.0, 1.0);
+        if (mouth_on > 0.02) {
+            vec2 mouth_c = P.head_c + vec2(0.0, -0.06);
+            float md = length((uv - mouth_c) * vec2(1.4, 2.0));
+            float mouth_blob = exp(-md * md * 80.0);
+            float pulse = 0.5 + 0.5 * sin(time * 4.0 + pitchClassNormalized * 6.28);
+            vec3 mouth_col = hsl2rgb(vec3(fract(0.05 + pitchClassNormalized * 0.15), 0.9, 0.55));
+            col += mouth_col * mouth_blob * mouth_on * pulse * 0.8;
+        }
+    }
     col = mix(col, col + hot * 0.6, eye_wash);
     col += eye_wash * hot * 0.4;
     vec3 ray_col = mix(hot, vec3(0.4, 0.85, 1.0), smoothstep(0.45, 0.85, spectralCentroidNormalized));

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
@@ -424,7 +424,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
         vec3 nebula_b = vec3(0.10, 0.35, 0.70);
         vec3 nebula = mix(nebula_a, nebula_b, sin(np.x * 0.7 + t) * 0.5 + 0.5);
         // knob_2: nebula fog density (0 = clear, 1 = thick cosmic cloud) — auto-wired when twisted
-        float fog_pulse = 1.0 + clamp(bassZScore, 0.0, 2.0) * 0.35;
+        float fog_pulse = 1.0 + clamp(bassZScore, 0.0, 2.0) * 0.50;
         bg += nebula * fog * mix(0.04, 0.45, knob_2) * (0.7 + midsNormalized * 0.4) * fog_pulse;
     }
         // VJ AURORA VEILS — glowing green-teal curtains in dark/wonky phases (low centroid)

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
@@ -834,6 +834,29 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
             col += beam_col * beam * search_on * 0.7;
         }
     }
+    // VJ CONFETTI — falling spinning squares on treble × entropy (bright-chaotic-playful)
+    {
+        float confetti_on = clamp(trebleNormalized - 0.35, 0.0, 1.0);
+        confetti_on *= clamp(spectralEntropyNormalized - 0.5, 0.0, 1.0) * 2.0;
+        if (confetti_on > 0.02) {
+            vec2 cp = uv * vec2(10.0, 6.0);
+            cp.y += time * 0.6;
+            cp.x += sin(time * 0.4 + uv.y * 3.0) * 0.3;
+            vec2 ccell = floor(cp);
+            vec2 cfrac = fract(cp) - 0.5;
+            float ch = hash(ccell);
+            float has_piece = step(0.75, ch);
+            // Rotate each square
+            float spin_angle = time * (1.5 + ch * 3.0) + ch * 6.28;
+            float cs = cos(spin_angle), ss = sin(spin_angle);
+            vec2 rp = vec2(cfrac.x * cs - cfrac.y * ss, cfrac.x * ss + cfrac.y * cs);
+            float square = step(abs(rp.x), 0.11) * step(abs(rp.y), 0.11);
+            // Color from pitch class — music's note → confetti hue
+            float c_hue = fract(pitchClassNormalized + ch * 0.3);
+            vec3 c_col = hsl2rgb(vec3(c_hue, 0.85, 0.6));
+            col += c_col * square * has_piece * confetti_on * 0.9;
+        }
+    }
     col *= 1.0 - smoothstep(0.7, 1.4, length(uv * vec2(1.0, 0.85)));
 
 #if DEBUG_OUTLINES

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
@@ -150,7 +150,7 @@ struct Pose {
 
 Pose makePose(float beat_phase, float hip_sway, float snap, float groove) {
     Pose P;
-    P.bob = -abs(sin(beat_phase)) * 0.025 + groove * 0.005;
+    P.bob = -abs(sin(beat_phase)) * 0.025 + groove * 0.005 - clamp(bassZScore, 0.0, 2.0) * 0.04;
     P.tilt = hip_sway * 0.18 + sin(beat_phase * 0.5) * 0.05;
     P.hip = sign(hip_sway) * pow(abs(hip_sway), 0.6) * 0.05;
     P.head_c = vec2(P.hip * 0.6, 0.24 + P.bob);

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.frag
@@ -1,0 +1,828 @@
+// @fullscreen: true
+// @mobile: true
+// the-coat-6: forked from the-coat-5 mid-/vj-session after iter 38 (hyperspace). Fresh baseline.
+// Knob defaults captured: knob_2=-0.346, knob_7=0.98, knob_12=0.669, knob_15=0.46
+// Use with controller=the-coat for sustained drop glow
+uniform float drop_glow; // from the-coat controller — sustained drop with decay
+#define PI 3.14159265
+
+#define DEBUG_OUTLINES 0
+
+// ============================================================================
+// KNOB CONTROLS — knobs override baked defaults from the jam session
+// knob_1: zoom (0=wide, 1=tight) — live-remapped
+// knob_3: god ray intensity override
+// knob_4: eye wash override
+// knob_5: drop zoom override
+// knob_6: camera tilt swagger
+// knob_7: fur thickness
+// knob_13: sustain decay (via controller)
+// ============================================================================
+
+// --- ZOOM ---
+// Baked from knob_2=-0.346 session value
+// knob_1: 0=wide, 1=tight — live-remapped from knob_2
+#define BASE_ZOOM (mix(0.1, 2.5, knob_1) + energyNormalized * 0.4)
+
+// --- COAT SHAPE ---
+#define SHOULDER_Y      (-0.02 + max(bassZScore, 0.0) * 0.015)
+#define SHOULDER_SPREAD (0.158 + bassNormalized * 0.02)
+#define SLEEVE_RADIUS   (0.04 + max(trebleZScore, 0.0) * 0.015)
+#define SHOULDER_CAP     0.042
+#define CHEST_W_BASE    (0.12 + bassNormalized * 0.03)
+#define CHEST_H_BASE    (0.065 + bassNormalized * 0.01)
+// Fur puffs up with energy — thick on drops, lean on quiet
+#define FUR_THICK       (0.06 + clamp(energyZScore, 0.0, 1.0) * 0.04)
+// V-neck opens on energy spikes — reveals more chest on drops
+#define VNECK_WIDTH     (0.10 + clamp(energyZScore, 0.0, 1.0) * 0.06)
+#define VNECK_BOTTOM    (-0.013 - clamp(energyZScore, 0.0, 1.0) * 0.03)
+
+// --- MOTION ---
+// Heavy pump from bass — body bounces with the kick drum
+#define PUMP (bassNormalized * 0.6 + clamp(bassSlope * bassRSquared, 0.0, 0.5) * 3.0)
+#define BEAT_PHASE (time * 2.2)
+// Treble drives snap gestures — hi-hats make hands twitch
+#define SNAP (clamp(trebleZScore, 0.0, 1.5))
+#define HIP_SWAY (sin(time * 1.1))
+// Mids drive groove — melodic content makes the body sway
+#define GROOVE (midsNormalized * 0.8 + spectralCentroidNormalized * 0.2)
+
+// --- DROP DETECTION ---
+// Confident energy build = drop approaching
+#define BUILD (clamp(energySlope * energyRSquared * 10.0, 0.0, 1.0))
+#define IS_DROP clamp(BUILD + smoothstep(0.6, 1.0, energyZScore) * 0.5, 0.0, 1.0)
+#define DROP_TRIGGER_THRESH 0.8
+#define SUSTAIN_GAIN 1.2
+
+// --- DROP VISUALS ---
+// Drop zoom punches in hard — learned from wooli-drop preset (knob_5=0.764)
+#define DROP_ZOOM 0.9
+// God rays — quiet below average energy, bloom above it
+#define GODRAY_INTENSITY (clamp(energyZScore, 0.0, 1.5) * 2.5 + clamp(trebleZScore, 0.0, 1.0) * 1.0)
+// Eye wash — kicks in above-average energy, scales up from there
+#define EYE_WASH_STRENGTH (clamp(energyZScore, 0.0, 1.0) * 0.5 + clamp(bassZScore, 0.0, 1.0) * 0.2)
+// Continuous zoom breathes with intensity
+#define INTENSITY_ZOOM (energyNormalized * 0.3)
+
+// --- COLOR ---
+// Base hue shifts with pitch class — different notes = different colors
+// VJ breathing rainbow — full cycle every ~60s, mids nudge the hue
+#define HUE_BASE (fract(0.78 + time * 0.0167 + pitchClassNormalized * 0.15 + midsNormalized * 0.20))
+// Drop shifts toward hot orange/yellow
+#define HUE_DROP (fract(0.99 + spectralCentroidNormalized * 0.05))
+
+// --- COAT SURFACE (the star of the show) ---
+// Fluff bristles up on energy spikes AND spectral roughness
+#define FLUFF_AGITATION (clamp(energyZScore, 0.0, 1.0) * 0.5 + spectralRoughnessNormalized * 0.5)
+// Bass pulse drives color warmth — kicks make the coat glow
+#define BASS_PULSE_AMT (clamp(bassZScore, 0.0, 1.0) * 0.8)
+// Color shift driven by drops AND energy — more reactive than before
+#define DROP_COLOR_AMT clamp(IS_DROP + clamp(energyZScore, 0.0, 1.0) * 0.4 + clamp(bassZScore, 0.0, 1.0) * 0.2, 0.0, 1.0)
+// Shoulder gleam pulses with spectral flux — light catches on timbral changes
+#define GLEAM_INTENSITY (0.15 + spectralFluxNormalized * 0.35)
+
+// Fractal fur — THE signature feature (living-coat preset)
+// Entropy (chaos) + roughness (grit) + kurtosis (peaked) trigger the fur fibers
+// Lower threshold than before so it's visible more often
+#define FUR_TRIGGER clamp(spectralEntropyNormalized * 0.7 + spectralRoughnessNormalized * 0.5 + clamp(spectralKurtosisZScore, 0.0, 1.0) * 0.2, 0.0, 1.0)
+// Warp speed driven by centroid — brighter sounds = faster swirl
+#define WARP_SPEED (spectralCentroidNormalized * 0.6 + spectralFluxNormalized * 0.2)
+// Rim boost: flux + bass make the chrome edge blaze
+#define RIM_BOOST (2.5 + spectralFluxNormalized * 2.0 + clamp(bassZScore, 0.0, 1.0) * 1.0)
+
+// --- DERIVED ---
+#define DROP_TRIGGER clamp(max(energyZScore, BUILD), 0.0, 1.0)
+
+// ============================================================================
+// SDFs
+// ============================================================================
+
+float sdCircle(vec2 p, float r) { return length(p) - r; }
+
+float sdEllipse(vec2 p, vec2 r) {
+    float k1 = length(p / r);
+    float k2 = length(p / (r * r));
+    return k1 * (k1 - 1.0) / max(k2, 1e-4);
+}
+
+float smin(float a, float b, float k) {
+    float h = clamp(0.5 + 0.5 * (b - a) / k, 0.0, 1.0);
+    return mix(b, a, h) - k * h * (1.0 - h);
+}
+
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+// Smooth value noise for fur texture
+float vnoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+float fbm(vec2 p) {
+    float s = 0.0;
+    float a = 0.5;
+    for (int i = 0; i < 4; i++) {
+        s += a * vnoise(p);
+        p *= 2.03;
+        a *= 0.5;
+    }
+    return s;
+}
+
+struct Pose {
+    float bob;
+    float tilt;
+    float hip;
+    vec2  head_c;
+    vec2  l_hand;
+    vec2  r_hand;
+    float l_open;
+    float r_open;
+};
+
+Pose makePose(float beat_phase, float hip_sway, float snap, float groove) {
+    Pose P;
+    P.bob = -abs(sin(beat_phase)) * 0.025 + groove * 0.005;
+    P.tilt = hip_sway * 0.18 + sin(beat_phase * 0.5) * 0.05;
+    P.hip = sign(hip_sway) * pow(abs(hip_sway), 0.6) * 0.05;
+    P.head_c = vec2(P.hip * 0.6, 0.24 + P.bob);
+    float l_gesture = snap * 1.2;
+    float r_gesture = snap * 1.2;
+    P.l_open = l_gesture;
+    P.r_open = r_gesture;
+    // Arms hang naturally at the sides, symmetric, proportional length.
+    // Hands end just past the hips (y ≈ -0.38).
+    P.l_hand = vec2(-0.30 - l_gesture * 0.15, -0.38 + l_gesture * 0.25);
+    P.r_hand = vec2( 0.30 + r_gesture * 0.15, -0.38 + r_gesture * 0.25 + sin(beat_phase) * 0.01);
+    return P;
+}
+
+float sdCapsule(vec2 p, vec2 a, vec2 b, float r) {
+    vec2 pa = p - a, ba = b - a;
+    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-4), 0.0, 1.0);
+    return length(pa - ba * h) - r;
+}
+
+// Slimmer daddy — smaller frame, no bulging biceps
+float sdDaddy(vec2 p, float pump, Pose P) {
+    float ct = cos(P.tilt), st = sin(P.tilt);
+    vec2 hp = p - P.head_c;
+    hp = vec2(hp.x * ct - hp.y * st, hp.x * st + hp.y * ct);
+
+    float head = sdEllipse(hp, vec2(0.13, 0.15));
+    float jaw = sdEllipse(hp - vec2(0.0, -0.05), vec2(0.11, 0.09));
+    head = smin(head, jaw, 0.04);
+
+    vec2 np = p - vec2(P.hip * 0.7, 0.11);
+    float neck = sdEllipse(np, vec2(0.035, 0.045));
+
+    // Slimmer chest
+    float chest_w = 0.23 + pump * 0.04;
+    float chest_h = 0.17 + pump * 0.02;
+    vec2 cp = p - vec2(P.hip * 0.7, -0.02);
+    float chest = sdEllipse(cp, vec2(chest_w, chest_h));
+
+    // Slimmer hips
+    vec2 wp = p - vec2(P.hip * 1.4, -0.22);
+    float hips = sdEllipse(wp, vec2(0.20, 0.09));
+
+    // Shoulders at the natural resting line — not raised (no shrugging)
+    float coat_edge = SHOULDER_SPREAD;
+    vec2 ls = vec2(-coat_edge + P.hip * 0.4, SHOULDER_Y);
+    vec2 rs = vec2( coat_edge + P.hip * 0.4, SHOULDER_Y);
+    float lshoulder = sdCircle(p - ls, SHOULDER_CAP);
+    float rshoulder = sdCircle(p - rs, SHOULDER_CAP);
+
+    // Arms hang proportionally — elbow at the midpoint between shoulder and
+    // hand, slightly biased inward so the lower arm curves toward the body
+    vec2 l_mid = mix(ls, P.l_hand, 0.5);
+    vec2 r_mid = mix(rs, P.r_hand, 0.5);
+    vec2 l_elbow = l_mid + vec2(0.015, 0.0) + vec2(-0.02, 0.02) * P.l_open;
+    vec2 r_elbow = r_mid + vec2(-0.015, 0.0) + vec2(0.02, 0.02) * P.r_open;
+    float l_upper = sdCapsule(p, ls, l_elbow, 0.04);
+    float l_lower = sdCapsule(p, l_elbow, P.l_hand, 0.035);
+    float r_upper = sdCapsule(p, rs, r_elbow, 0.04);
+    float r_lower = sdCapsule(p, r_elbow, P.r_hand, 0.035);
+
+    float l_fist = sdCircle(p - P.l_hand, 0.055 + P.l_open * 0.01);
+    float r_fist = sdCircle(p - P.r_hand, 0.055 + P.r_open * 0.01);
+
+    float d = head;
+    d = smin(d, neck, 0.035);
+    d = smin(d, chest, 0.05);
+    d = smin(d, hips, 0.05);
+    d = smin(d, lshoulder, 0.04);
+    d = smin(d, rshoulder, 0.04);
+    d = smin(d, l_upper, 0.035);
+    d = smin(d, l_lower, 0.035);
+    d = smin(d, r_upper, 0.035);
+    d = smin(d, r_lower, 0.035);
+    d = smin(d, l_fist, 0.025);
+    d = smin(d, r_fist, 0.025);
+    return d;
+}
+
+// Torso-only SDF: chest + shoulders + hips, NO head/neck/arms/hands.
+// Used as the base shape the fur coat inflates from, so arms poke out.
+// Chest is intentionally shorter than the body's chest so that when the coat
+// inflates outward by fur_thickness, its top sits below the neck — no hard
+// cut needed, no visible "back of collar" line.
+float sdTorso(vec2 p, float pump, Pose P) {
+    // Tailored torso: narrower chest, pinched waist, slight hip flare so
+    // the coat silhouette reads as a fitted garment instead of a sack.
+    float chest_w = CHEST_W_BASE + pump * 0.04;
+    float chest_h = CHEST_H_BASE + pump * 0.02;
+    vec2 cp = p - vec2(P.hip * 0.7, 0.01);
+    float chest = sdEllipse(cp, vec2(chest_w, chest_h));
+
+    // Waist — narrower pinch at midsection
+    vec2 wpn = p - vec2(P.hip * 0.8, -0.12);
+    float waist = sdEllipse(wpn, vec2(0.16, 0.08));
+
+    vec2 wp = p - vec2(P.hip * 1.4, -0.24);
+    float hips = sdEllipse(wp, vec2(0.17, 0.09));
+
+    float d = chest;
+    d = smin(d, waist, 0.08);
+    d = smin(d, hips, 0.08);
+    return d;
+}
+
+// Fur coat: inflates the torso AND arms (long sleeves) by a fur thickness,
+// caps at the neckline with a V, lets the hem run off-screen.
+float sdFurCoat(vec2 p, Pose P, float pump) {
+    float d_torso = sdTorso(p, pump, P);
+
+    // Long sleeves — capsules from shoulder to WRIST (not hand), so the
+    // fists poke out of the cuffs. Wrist = 80% of the way from shoulder to hand.
+    float coat_edge = SHOULDER_SPREAD;
+    vec2 ls = vec2(-coat_edge + P.hip * 0.4, SHOULDER_Y);
+    vec2 rs = vec2( coat_edge + P.hip * 0.4, SHOULDER_Y);
+    vec2 l_wrist = mix(ls, P.l_hand, 0.55);
+    vec2 r_wrist = mix(rs, P.r_hand, 0.55);
+    float l_sleeve = sdCapsule(p, ls, l_wrist, SLEEVE_RADIUS);
+    float r_sleeve = sdCapsule(p, rs, r_wrist, SLEEVE_RADIUS);
+
+    // Shoulder caps smin'd with both torso and sleeves
+    float l_cap = sdCircle(p - ls, SHOULDER_CAP);
+    float r_cap = sdCircle(p - rs, SHOULDER_CAP);
+    float coat_base = min(d_torso, l_sleeve);
+    coat_base = min(coat_base, r_sleeve);
+    coat_base = smin(coat_base, l_cap, 0.04);
+    coat_base = smin(coat_base, r_cap, 0.04);
+
+    // Looser, straighter fit (not form-fitting) — more fur thickness so the
+    // coat hangs straight down rather than hugging every curve.
+    float fur_thickness = FUR_THICK + pump * 0.005;
+    float inflated = coat_base - fur_thickness;
+
+    // Straight hem: a tall narrow rectangle-ish ellipse that gives the coat a
+    // straight drop through the hips and off the bottom. Not wider than the
+    // shoulders, so it reads as "long coat" not "ball gown."
+    vec2 hem_c = vec2(P.hip * 1.0, -0.55);
+    float hem = sdEllipse(p - hem_c, vec2(0.26, 0.45));
+    inflated = smin(inflated, hem, 0.06);
+
+    // V-neckline: opens from the sternum to the top of the coat. The V is
+    // bounded so it only carves within its y-range — outside the range,
+    // v_wedge stays positive so `-v_wedge` is negative and max() ignores it.
+    // V-neck carved with a smooth subtraction. Wedge is unbounded at the top
+    // so its sides continue upward past the coat top — this means the wedge
+    // has NO visible "top corners" inside the coat, so rim lighting can't
+    // trace a phantom collar back-edge at the top of the V.
+    float cx = P.hip * 0.7;
+    float v_bottom = VNECK_BOTTOM;
+    float v_half_at_top = VNECK_WIDTH;
+    // Slope of the V: widens as y increases, no upper bound
+    float v_slope = v_half_at_top / 0.17;  // reaches 0.07 at y=0.15
+    float v_half = max(0.0, (p.y - v_bottom)) * v_slope;
+    float v_horiz = abs(p.x - cx) - v_half;
+    float v_vert = v_bottom - p.y;  // only the bottom is a hard wall
+    float v_wedge = max(v_horiz, v_vert);
+
+    // Smooth subtraction (smooth max via -smin)
+    float d = -smin(-inflated, v_wedge, 0.015);
+    return d;
+}
+
+float sdCurls(vec2 p, Pose P, float beat_phase, float pump) {
+    float ct = cos(P.tilt), st = sin(P.tilt);
+    vec2 hp = p - P.head_c;
+    hp = vec2(hp.x * ct - hp.y * st, hp.x * st + hp.y * ct);
+
+    float d = 1e6;
+    for (int i = 0; i < 8; i++) {
+        float fi = float(i);
+        float t = fi / 7.0;
+        float ang = mix(PI * 1.05, PI * -0.05, t);
+        float radius = 0.155;
+        float jx = hash(vec2(fi, 1.0)) - 0.5;
+        float jy = hash(vec2(fi, 2.0)) - 0.5;
+        vec2 c = vec2(cos(ang), sin(ang)) * radius + vec2(jx, jy) * 0.025;
+        float crown_bias = sin(t * PI);
+        float r = 0.045 + crown_bias * 0.015 + hash(vec2(fi, 3.0)) * 0.01;
+        float ph = hash(vec2(fi, 4.0)) * 6.28;
+        float bounce = sin(beat_phase * 1.0 + ph) * 0.012 + pump * 0.008;
+        c.y += bounce;
+        d = smin(d, sdCircle(hp - c, r), 0.025);
+    }
+    return d;
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = (fragCoord - 0.5 * res) / min(res.x, res.y);
+
+    float pump = PUMP;
+    Pose P = makePose(BEAT_PHASE, HIP_SWAY, SNAP, GROOVE);
+
+    vec2 raw_uv01 = fragCoord / res;
+
+    // --- DROP SUSTAIN ---
+    // drop_glow is a controller-computed uniform with exponential decay.
+    // It latches high on energy spikes and decays smoothly over ~1-2 seconds.
+    // Falls back to instantaneous IS_DROP if no controller is loaded.
+    float drop_spike = smoothstep(DROP_TRIGGER_THRESH, DROP_TRIGGER_THRESH + 0.5, BUILD);
+    float sustain_signal = BUILD * SUSTAIN_GAIN;
+    float drop_now = clamp(max(drop_spike, max(IS_DROP, sustain_signal)), 0.0, 1.0);
+    drop_now = smoothstep(0.15, 0.5, drop_now);
+    // drop_glow = controller-driven sustained drop glow (exponential decay)
+    float drop_hit = max(drop_now, drop_glow);
+
+    float intensity = max(PUMP, GROOVE);
+    // Cubic ease-in: crushes twitchy low-end values, lets big moments punch through.
+    // smoothstep(0.2, 0.9) maps to 0-1, then cube kills anything below ~0.5
+    float zoom_intensity = smoothstep(0.2, 0.9, intensity);
+    zoom_intensity = zoom_intensity * zoom_intensity * zoom_intensity;
+    float zoomAmount = BASE_ZOOM + zoom_intensity * INTENSITY_ZOOM + drop_hit * DROP_ZOOM;
+    vec2 zoomCenter = P.head_c;
+    // VJ CAMERA DRIFT — slow lateral sway + flux nudge so the frame never sits locked
+    vec2 cam_drift = vec2(
+        sin(time * 0.12) * 0.015 + spectralFluxZScore * 0.012,
+        sin(time * 0.09 + 1.3) * 0.010
+    );
+    zoomCenter += cam_drift;
+    uv = (uv - zoomCenter) / zoomAmount + zoomCenter;
+
+    // Camera tilt — knob_6 controls how much swagger
+    float tilt_angle = (sin(time * 0.7) * 0.15
+                     + (spectralCentroidNormalized - 0.5) * 0.2
+                     + bassZScore * 0.075) * knob_6;
+    float ca = cos(tilt_angle), sa = sin(tilt_angle);
+    uv -= zoomCenter;
+    uv = vec2(uv.x * ca - uv.y * sa, uv.x * sa + uv.y * ca);
+    uv += zoomCenter;
+
+    // ---- BACKDROP ----
+    float bg_grad = smoothstep(-0.8, 0.8, uv.y);
+    vec3 bg = mix(vec3(0.04, 0.02, 0.10), vec3(0.01, 0.00, 0.04), bg_grad);
+    float spot = exp(-uv.x*uv.x * 4.0) * smoothstep(-0.3, -0.6, uv.y);
+    bg += spot * vec3(0.5, 0.2, 0.6) * (0.5 + 0.5 * sin(BEAT_PHASE * 2.0)) * (0.8 + clamp(energyZScore, -0.5, 2.0) * 0.6);
+    // VJ STARFIELD — sparkle crosses in the upper sky, twinkle faster on treble
+    {
+        vec2 sp = uv * 14.0;
+        vec2 scell = floor(sp);
+        vec2 scf = fract(sp) - 0.5;
+        float sr = hash(scell);
+        float sr2 = hash(scell + vec2(3.7, 1.3));
+        float star_active = step(0.80, sr);
+        vec2 spos = (vec2(sr2, hash(scell + vec2(2.1, 5.9))) - 0.5) * 0.4;
+        vec2 delta = scf - spos;
+        float sd = length(delta);
+        float cross_h = exp(-delta.y*delta.y * 2500.0) * exp(-abs(delta.x) * 15.0);
+        float cross_v = exp(-delta.x*delta.x * 2500.0) * exp(-abs(delta.y) * 15.0);
+        float core = exp(-sd * sd * 800.0);
+        float tw_s = 0.5 + 0.5 * sin(time * (2.0 + sr * 4.0 + trebleNormalized * 6.0 + max(trebleZScore, 0.0) * 5.0) + sr * 30.0);
+        float twinkle = 0.35 + 0.65 * tw_s * tw_s;
+        float star = (core + (cross_h + cross_v) * 0.6) * star_active * twinkle;
+        float sky_mask = smoothstep(-0.2, 0.3, uv.y);
+        bg += vec3(1.0, 0.95, 0.85) * star * sky_mask * (1.3 + clamp(trebleZScore, 0.0, 2.5) * 0.8);
+    }
+
+    // VJ NEBULA FOG — slow drifting cosmic haze, no per-frame hashing
+    {
+        float t = time * 0.05 + trebleNormalized * 0.08;
+        vec2 np = uv * 1.3;
+        float n1 = sin(np.x * 1.7 + t * 1.3) * sin(np.y * 2.1 - t * 0.9);
+        float n2 = sin(np.x * 3.1 - t * 0.7) * sin(np.y * 2.7 + t * 1.1);
+        float n3 = sin((np.x + np.y) * 0.9 + t * 0.6);
+        float fog = (n1 + n2 * 0.6 + n3 * 0.4) * 0.25 + 0.5;
+        fog = smoothstep(0.25, 0.95, fog);
+        vec3 nebula_a = vec3(0.35, 0.15, 0.55);
+        vec3 nebula_b = vec3(0.10, 0.35, 0.70);
+        vec3 nebula = mix(nebula_a, nebula_b, sin(np.x * 0.7 + t) * 0.5 + 0.5);
+        // knob_2: nebula fog density (0 = clear, 1 = thick cosmic cloud) — auto-wired when twisted
+        float fog_pulse = 1.0 + clamp(bassZScore, 0.0, 2.0) * 0.35;
+        bg += nebula * fog * mix(0.04, 0.45, knob_2) * (0.7 + midsNormalized * 0.4) * fog_pulse;
+    }
+        // VJ AURORA VEILS — glowing green-teal curtains in dark/wonky phases (low centroid)
+    {
+        float aurora_on = smoothstep(0.35, 0.10, spectralCentroidNormalized);
+        if (aurora_on > 0.02) {
+            float t = time * 0.35;
+            float v1 = sin(uv.x * 2.3 + t) * 0.5 + sin(uv.x * 1.1 - t * 0.7) * 0.25;
+            float v2 = sin(uv.x * 3.7 - t * 0.6) * 0.35;
+            float curtain1 = exp(-pow(uv.y - 0.35 - v1 * 0.25, 2.0) * 14.0);
+            float curtain2 = exp(-pow(uv.y - 0.20 - v2 * 0.3, 2.0) * 10.0);
+            float intensity = aurora_on * (0.5 + bassNormalized * 0.6);
+            bg += vec3(0.25, 0.85, 0.55) * curtain1 * intensity * 0.7;
+            bg += vec3(0.15, 0.55, 0.95) * curtain2 * intensity * 0.5;
+        }
+    }
+    // VJ ROTOR GEAR — stepped 8-spoke halo behind head, ticks on treble-heavy phases
+    {
+        float gear_on = clamp((spectralCentroidNormalized - 0.45) * 2.0, 0.0, 1.0);
+        gear_on *= clamp(trebleNormalized - 0.3, 0.0, 1.0) * 1.8;
+        if (gear_on > 0.02) {
+            vec2 gear_p = uv - P.head_c;
+            float gear_r = length(gear_p);
+            float gear_a = atan(gear_p.y, gear_p.x);
+            // Stepped rotation — 2Hz clock, 8 positions
+            float step_rot = floor(time * 2.0) * (PI / 4.0);
+            float rot_a = gear_a + step_rot;
+            // 8 spokes
+            float spoke = 0.5 + 0.5 * cos(rot_a * 8.0);
+            spoke = smoothstep(0.72, 0.95, spoke);
+            // Only within a ring band behind head
+            float band = smoothstep(0.18, 0.21, gear_r) * smoothstep(0.33, 0.28, gear_r);
+            float gear = spoke * band;
+            // Masked outside the silhouette — radial falloff instead of silhouette ref (not defined yet here)
+            gear *= smoothstep(0.17, 0.20, gear_r);
+            bg += vec3(0.95, 0.75, 0.25) * gear * gear_on * 1.2;
+        }
+    }
+    float rays = pow(max(0.0, 1.0 - abs(uv.x) * 1.2), 4.0) * smoothstep(0.0, 1.0, uv.y);
+    bg += rays * vec3(1.0, 0.7, 0.3) * IS_DROP * 0.6;
+
+    // ---- DADDY ----
+    float d_body  = sdDaddy(uv, pump, P);
+    float d_curls = sdCurls(uv, P, BEAT_PHASE, pump);
+    float d_coat  = sdFurCoat(uv, P, pump);
+
+    // Fur "fluff" — perturb the coat distance with noise so its edge is shaggy
+    // Noise coords wobble with beat so the fur looks alive
+    vec2 fur_p = uv * 38.0 + vec2(0.0, sin(BEAT_PHASE) * 0.15);
+    float fur_n = fbm(fur_p);
+    // Fur edge gets much more agitated on drops/bass — bristles up
+    float fluff_amp = 0.018 + pump * 0.015 + SNAP * 0.012 + FLUFF_AGITATION * 0.02;
+    float d_coat_fluff = d_coat - (fur_n - 0.5) * fluff_amp;
+
+    float d = min(d_body, d_curls);
+
+    float body  = smoothstep(0.005, -0.005, d);
+    float curls = smoothstep(0.005, -0.005, d_curls);
+    float coat  = smoothstep(0.006, -0.006, d_coat_fluff);
+
+    // Rim light — body
+    float rim_w = 0.006 + IS_DROP * 0.012 + SNAP * 0.006;
+    float rim = smoothstep(rim_w, 0.0, abs(d));
+    float edge_gate = body * (1.0 - body) * 4.0;
+    rim *= edge_gate;
+
+    // Rim light — coat (same chrome treatment on the fluffy edge)
+    float coat_rim = smoothstep(rim_w, 0.0, abs(d_coat_fluff));
+    float coat_edge_gate = coat * (1.0 - coat) * 4.0;
+    coat_rim *= coat_edge_gate;
+
+    float chest_glow_d = length(uv - vec2(P.hip * 0.7, -0.02)) * 3.0;
+    float chest_glow = exp(-chest_glow_d*chest_glow_d);
+    chest_glow *= smoothstep(0.005, -0.005, d_body) * (0.3 + pump * 0.7);
+
+    // Eyes
+    float ct = cos(P.tilt), st = sin(P.tilt);
+    vec2 le_local = vec2(-0.045, 0.02);
+    vec2 re_local = vec2( 0.045, 0.02);
+    vec2 le = P.head_c + vec2(le_local.x * ct + le_local.y * st, -le_local.x * st + le_local.y * ct);
+    vec2 re = P.head_c + vec2(re_local.x * ct + re_local.y * st, -re_local.x * st + re_local.y * ct);
+
+    float eyes = exp(-dot(uv - le, uv - le) * 2500.0) + exp(-dot(uv - re, uv - re) * 2500.0);
+    eyes *= (0.25 + drop_hit * 1.8 + SNAP * 0.6);
+
+    vec2 d_le2 = uv - le;
+    vec2 d_re2 = uv - re;
+    float r_le = length(d_le2);
+    float r_re = length(d_re2);
+    float a_le = atan(d_le2.y, d_le2.x);
+    float a_re = atan(d_re2.y, d_re2.x);
+    float fan_le = pow(abs(cos(a_le * 6.0 + time * 0.8)), 14.0);
+    float fan_re = pow(abs(cos(a_re * 6.0 - time * 0.7 + 1.3)), 14.0);
+    float fall_le = exp(-r_le * 1.2);
+    float fall_re = exp(-r_re * 1.2);
+    float up_le = smoothstep(-1.0, 0.3, d_le2.y / max(r_le, 0.001));
+    float up_re = smoothstep(-1.0, 0.3, d_re2.y / max(r_re, 0.001));
+    float god_rays = (fan_le * fall_le * up_le + fan_re * fall_re * up_re) * drop_hit;
+    god_rays += (exp(-r_le * 10.0) + exp(-r_re * 10.0)) * drop_hit * 0.6;
+
+    float wash_le = exp(-r_le * 0.8);
+    float wash_re = exp(-r_re * 0.8);
+    float eye_wash = (wash_le + wash_re) * drop_hit * EYE_WASH_STRENGTH;
+
+    // ---- COLOR ----
+    float hue = mix(HUE_BASE, HUE_DROP, IS_DROP);
+    vec3 leather = hsl2rgb(vec3(hue, 0.8, mix(0.06, 0.14, spectralCentroidNormalized)));
+    // VJ prism rim — chrome cycles its own rainbow based on uv angle + time
+    float chrome_hue = fract(atan(uv.y - P.head_c.y, uv.x) / 6.2831 + time * (0.10 + pitchClassNormalized * 0.25) + hue * 0.3);
+    vec3 chrome  = hsl2rgb(vec3(chrome_hue, 1.0, 0.65));
+    vec3 hair    = hsl2rgb(vec3(0.06, 0.7, 0.12));
+    vec3 hot     = hsl2rgb(vec3(0.08, 1.0, 0.6));
+
+    // Coat fill — audio-reactive color. Base is deep blue, but:
+    // - Lightness pulses brighter on bass hits
+    // - Hue shifts toward electric cyan on drops
+    // - Saturation dips slightly on quiet passages (more white/pastel)
+    float coat_grad = smoothstep(0.15, -0.4, uv.y);
+    float bass_pulse = BASS_PULSE_AMT;
+    float drop_color = DROP_COLOR_AMT;
+    // Hue slides from deep blue (0.62) toward electric cyan (0.50) on drops
+    float fur_hue_hi = mix(0.62, 0.50, drop_color * 0.6);
+    float fur_hue_lo = mix(0.58, 0.48, drop_color * 0.5);
+    // Lightness pumps up on bass
+    float fur_l_hi = 0.65 + bass_pulse * 0.15;
+    float fur_l_lo = 0.45 + bass_pulse * 0.10;
+    vec3 fur_hi = hsl2rgb(vec3(fur_hue_hi, 0.95, clamp(fur_l_hi, 0.0, 0.95)));
+    vec3 fur_lo = hsl2rgb(vec3(fur_hue_lo, 0.9, clamp(fur_l_lo, 0.0, 0.85)));
+    vec3 fur_col = mix(fur_hi, fur_lo, coat_grad);
+    // Shoulder gleam pulses with spectral flux — light catching the coat
+    float shoulder_gleam_d = (uv.y - 0.08) * 10.0;
+    float shoulder_gleam = exp(-shoulder_gleam_d*shoulder_gleam_d);
+    float gleam_intensity = GLEAM_INTENSITY;
+    fur_col += shoulder_gleam * vec3(gleam_intensity * 0.5, gleam_intensity * 0.8, gleam_intensity * 1.5);
+    // ---- FRACTAL FUR FIBERS ----
+    // Swirling domain-warped fractal that appears inside the coat when the
+    // music is "interesting" — triggered by spectral entropy (chaos) and
+    // spectral roughness (dissonance). These are independent from the
+    // energy/bass features that drive the eyes, so the coat and eyes
+    // react to DIFFERENT musical qualities.
+    float fur_trigger = FUR_TRIGGER;
+    // Only show when musically interesting (above baseline)
+    float fur_fractal_amt = smoothstep(0.15, 0.55, fur_trigger);
+    if (fur_fractal_amt > 0.01) {
+        // Domain warp: swirl the coords with low-freq noise so the fibers
+        // look like curling fur strands, not a static grid
+        vec2 fp = uv * 18.0;
+        float warp_t = time * 0.3 + WARP_SPEED;
+        vec2 warp = vec2(
+            fbm(fp + vec2(warp_t, 0.0)),
+            fbm(fp + vec2(0.0, warp_t + 3.7))
+        );
+        // Second domain warp for deeper swirl
+        vec2 fp2 = fp + warp * 3.5;
+        float fibers = fbm(fp2 + vec2(
+            fbm(fp2 + vec2(warp_t * 0.7, 1.3)),
+            fbm(fp2 + vec2(2.1, warp_t * 0.5))
+        ) * 1.5);
+        // Shape the fibers: sharp ridges that look like individual strands
+        float strand = pow(abs(sin(fibers * PI * (4.0 + spectralFluxZScore * 1.5))), 3.0);
+        // Color the strands: lighter than the base coat, tinted toward
+        // cyan/white so they read as light catching individual fur fibers
+        vec3 strand_col = mix(fur_col * 1.5, vec3(0.7, 0.9, 1.0), 0.3 + strand * 0.4);
+        // Blend into the coat color, gated by the trigger amount
+        fur_col = mix(fur_col, strand_col, strand * fur_fractal_amt * 0.85);
+    }
+
+    // Seam strength computed here; chrome glow added after compositing
+    // so it matches the rim-light aesthetic. Thin + subtle.
+    float seam_x_pos = P.hip * 0.7;
+    float seam_dx = uv.x - seam_x_pos;
+    float seam_glow = exp(-seam_dx * seam_dx * 40000.0);
+    seam_glow *= smoothstep(-0.02, -0.10, uv.y) * 0.3;
+
+    vec3 col = bg;
+    // Body silhouette — warm plum skin that reads against the dark background
+    // and complements the pink coat
+    vec3 skin = hsl2rgb(vec3(0.92, 0.45, 0.18));
+    col = mix(col, skin, body);
+    // Coat sits OVER the body but UNDER the hair (so curls still fall)
+    col = mix(col, fur_col, coat * (1.0 - curls));
+    col = mix(col, hair, curls);
+    col += rim * chrome * 1.3 * (1.0 - coat);
+    // VJ SUB RING — expanding cone ring on bass spikes (gated by bassZScore)
+    {
+        float bass_hit = clamp(bassZScore, 0.0, 2.5);
+        if (bass_hit > 0.3) {
+            vec2 sub_c = vec2(0.0, -0.15);
+            float sd = length(uv - sub_c);
+            float ring_speed = 1.2 + clamp(energyZScore, -0.5, 1.5) * 0.6;
+            float ring_radius = 0.2 + fract(time * ring_speed) * 0.5;
+            float ring_d = sd - ring_radius;
+            float ring = exp(-ring_d*ring_d * 400.0);
+            float ring_fade = 1.0 - fract(time * ring_speed);
+            col += vec3(1.0, 0.3, 0.1) * ring * bass_hit * ring_fade * 0.7;
+        }
+    }
+    // VJ HEART PULSE — red glow from chest center, pulses on bass
+    {
+        vec2 heart_c = vec2(P.hip * 0.7, -0.08);
+        float heart_d = length((uv - heart_c) * vec2(1.2, 1.0));
+        // Heart-shape-ish falloff
+        float heart = exp(-heart_d * 6.0);
+        float heart_pulse = 0.3 + clamp(bassZScore, 0., 2.) * 1.2 + bassNormalized * 0.5 + midsNormalized * 0.4;
+        vec3 heart_col = hsl2rgb(vec3(fract(0.92 + pitchClassNormalized * 0.10 + sin(time * 0.4) * 0.03), 1.0, 0.55));
+        col += heart * heart_col * heart_pulse * coat * 0.6;
+    }
+    col += chest_glow * chrome * 0.8 * (1.0 - coat);
+    // Coat rim — chrome edge hugs the shaggy outline (boosted for visibility)
+    // Coat rim pulses with spectral flux — brighter on timbral changes
+    float rim_boost = RIM_BOOST;
+    col += coat_rim * chrome * rim_boost * (1.0 - curls);
+    // Button seam glow — chrome line down the center
+    col += seam_glow * coat * chrome * 0.25 * (1.0 - curls);
+    col += eyes * hot * 2.2;
+    col = mix(col, col + hot * 0.6, eye_wash);
+    col += eye_wash * hot * 0.4;
+    vec3 ray_col = mix(hot, vec3(0.4, 0.85, 1.0), smoothstep(0.45, 0.85, spectralCentroidNormalized));
+    col += god_rays * ray_col * GODRAY_INTENSITY;
+
+    // ---- INFINITY MIRROR removed (spinning-tile repetition clashed with spacy ambient bg) ----
+
+    // ---- FEEDBACK ----
+    vec2 fb_uv = fragCoord / res;
+    fb_uv.x -= P.hip * 0.01;
+    fb_uv.y -= 0.002 + pump * 0.003;
+    vec3 prev = getLastFrameColor(fb_uv).rgb * 0.88;
+    float silhouette = max(body, coat);
+    // knob_9: feedback/trails (0=crisp, 1=heavy smear)
+    float feedback_amt = mix(mix(0.45, 0.05, knob_9), mix(0.15, 0.03, knob_9), silhouette);
+    // VJ GHOST ECHO — bass spikes briefly raise feedback for a coat afterimage
+    feedback_amt = mix(feedback_amt, 0.55, clamp(bassZScore - 0.4, 0.0, 1.0) * 0.5);
+    if (beat) feedback_amt *= 0.6;
+    if (frame < 30) feedback_amt = 0.0;
+    col = mix(prev, col, feedback_amt);
+    // VJ MERCURY FLOW — bass-heavy low-centroid phases turn the coat into flowing liquid metal
+    {
+        float flow_on = clamp(bassNormalized - 0.25, 0.0, 1.0);
+        flow_on *= smoothstep(0.60, 0.25, spectralCentroidNormalized);
+        if (flow_on > 0.02 && silhouette > 0.05) {
+            float flow_t = time * (0.5 + bassNormalized * 1.5);
+            // Vertical flow: stripes drip downward at varying speeds
+            float stripe = sin(uv.x * 18.0 + sin(uv.y * 4.0 + flow_t) * 2.5 - flow_t * 2.0);
+            stripe = stripe * 0.5 + 0.5;
+            stripe = smoothstep(0.35, 0.95, stripe);
+            vec3 mercury_dark = vec3(0.05, 0.06, 0.1);
+            vec3 mercury_hi = vec3(0.92, 0.94, 1.0);
+            vec3 mercury = mix(mercury_dark, mercury_hi, stripe);
+            col = mix(col, mercury, flow_on * silhouette * 0.75);
+        }
+    }
+
+
+    // VJ TIME-ECHO — on energy surges, triple-expose previous frame around head
+    {
+        float echo = clamp(energyZScore - 0.5, 0.0, 1.0);
+        if (echo > 0.05) {
+            vec2 ec = P.head_c;
+            vec3 e1 = getLastFrameColor(fb_uv + vec2( 0.020,  0.006)).rgb;
+            vec3 e2 = getLastFrameColor(fb_uv + vec2(-0.024,  0.009)).rgb;
+            vec3 e3 = getLastFrameColor(fb_uv + vec2( 0.004, -0.018)).rgb;
+            vec3 echoed = (e1 * vec3(1.2, 0.7, 0.7) + e2 * vec3(0.7, 1.1, 0.9) + e3 * vec3(0.8, 0.9, 1.2)) * 0.34;
+            col = mix(col, col + echoed * 0.5, echo * 0.9);
+        }
+    }
+    // VJ BLACK HOLE — silhouette becomes a gravitational lens. Active on bassZ spikes.
+    {
+        float bh_strength = clamp(bassZScore - 0.3, 0.0, 1.5);
+        if (bh_strength > 0.05 && silhouette > 0.0) {
+            vec2 bh_center = P.head_c + vec2(0.0, -0.05);
+            vec2 to_center = bh_center - uv;
+            float bh_d = length(to_center);
+            vec2 dir_lens = to_center / max(bh_d, 0.001);
+            float lens_strength = bh_strength * 0.08 / max(bh_d * bh_d + 0.04, 0.04);
+            vec2 lens_uv = fb_uv + dir_lens * lens_strength * vec2(res.y / res.x, 1.0);
+            vec3 lensed = getLastFrameColor(lens_uv).rgb;
+            col = mix(col, lensed, bh_strength * (1.0 - silhouette) * 0.8);
+            col = mix(col, vec3(0.0), silhouette * bh_strength * 0.85);
+        }
+    }
+
+
+    // VJ COSMIC SHOCKWAVE — one-shot expanding ring on true beat flux spikes
+    {
+        float shock_trigger = float(beat) * clamp(spectralFluxZScore, 0.0, 1.0);
+        // lock the start time at the beat moment using a hash keyed to coarse time
+        float shock_phase = fract(time * 0.7);
+        float shock_r = shock_phase * 1.4;
+        float shock_d = length(uv) - shock_r;
+        float shock_ring = exp(-shock_d * shock_d * 300.0);
+        float shock_fade = (1.0 - shock_phase);
+        shock_fade *= shock_fade;
+        col += vec3(1.0, 1.0, 1.2) * shock_ring * shock_fade * shock_trigger * 1.4;
+    }
+    // VJ WATER POOL — bottom-third reflective pool ripples in dark/deep phases
+    {
+        float pool_on = smoothstep(0.25, 0.05, spectralCentroidNormalized);
+        if (pool_on > 0.02 && uv.y < -0.15) {
+            // Reflect uv: below waterline, sample mirrored above + gentle ripple
+            float depth = clamp(-uv.y - 0.15, 0.0, 0.6);
+            float ripple_x = sin(uv.x * 10.0 + time * 1.2) * 0.006 * (1.0 + bassNormalized);
+            float ripple_y = sin(uv.x * 6.0 - time * 0.8) * 0.004;
+            vec2 refl_uv = fb_uv;
+            refl_uv.y = 0.5 - (fb_uv.y - 0.5) - 0.05;
+            refl_uv.x += ripple_x;
+            refl_uv.y += ripple_y;
+            vec3 pool = getLastFrameColor(refl_uv).rgb;
+            pool *= vec3(0.4, 0.7, 0.8); // teal tint
+            float pool_fade = smoothstep(0.0, 0.45, depth);
+            col = mix(col, pool, pool_on * pool_fade * 0.65);
+        }
+    }
+    // VJ VOLUMETRIC BEAMS — light shafts radiating from upper backlight through silhouette gaps
+    {
+        float beams_on = clamp((spectralCentroidNormalized - 0.4) * 2.0, 0.0, 1.0);
+        beams_on *= clamp(energyNormalized * 1.5, 0.0, 1.0);
+        if (beams_on > 0.02) {
+            vec2 light_origin = vec2(0.3, 0.9);
+            vec2 to_origin = light_origin - uv;
+            float beam_a = atan(to_origin.y, to_origin.x);
+            float beam = 0.5 + 0.5 * sin(beam_a * 30.0 + time * 0.3);
+            beam = pow(beam, 8.0);
+            float dist_fade = 1.0 - smoothstep(0.2, 1.4, length(to_origin));
+            float sil_mask = 1.0 - silhouette;
+            vec3 beam_col = vec3(0.95, 0.85, 0.55);
+            col += beam_col * beam * dist_fade * sil_mask * beams_on * 0.45;
+        }
+    }
+    // VJ GROUND QUAKE — concentric amber rings from floor, bass-driven, multiple wavefronts
+    {
+        float quake_on = clamp(bassNormalized - 0.3, 0.0, 1.0);
+        quake_on *= smoothstep(0.5, 0.15, spectralCentroidNormalized);
+        if (quake_on > 0.02) {
+            vec2 feet_c = vec2(0.0, -0.6);
+            vec2 dvec = uv - feet_c;
+            // Squash vertically so rings look like ground waves (elliptical)
+            dvec.y *= 2.0;
+            float r = length(dvec);
+            float wavefronts = 0.0;
+            for (int wi = 0; wi < 3; wi++) {
+                float wf = float(wi);
+                float ring_r = fract(time * 0.6 + wf * 0.33) * 1.2;
+                float dr = r - ring_r;
+                float w = exp(-dr * dr * 90.0);
+                float fade = 1.0 - ring_r / 1.2;
+                wavefronts += w * fade;
+            }
+            vec3 quake_col = mix(vec3(1.0, 0.35, 0.08), vec3(1.0, 0.75, 0.3), bassNormalized);
+            col += quake_col * wavefronts * quake_on * 0.55;
+        }
+    }
+    // VJ DISSOLUTION — character sheds drifting particles upward on bright high-treble phases
+    {
+        float dissolve = clamp(trebleNormalized - 0.3, 0.0, 1.0);
+        dissolve *= clamp(spectralCentroidNormalized - 0.5, 0.0, 1.0) * 2.0;
+        if (dissolve > 0.02) {
+            vec2 pp = uv * vec2(12.0, 8.0) + vec2(sin(time * 0.3) * 0.3, time * -0.8);
+            vec2 pcell = floor(pp);
+            vec2 pfrac = fract(pp) - 0.5;
+            float ph = hash(pcell);
+            float alive = step(0.82, ph);
+            float pd = length(pfrac * vec2(2.5, 1.2));
+            float particle = exp(-pd * pd * 25.0) * alive;
+            float near_sil = smoothstep(0.0, 0.15, silhouette) * (1.0 - silhouette);
+            vec3 particle_col = mix(vec3(0.9, 0.95, 1.0), vec3(1.0, 0.85, 0.6), hash(pcell + vec2(1.1, 3.3)));
+            col += particle_col * particle * near_sil * dissolve * 1.2;
+        }
+    }
+    // VJ HYPERSPACE — radial streaks rushing outward from head on mid-high energy
+    {
+        float hyper_on = clamp(energyNormalized - 0.3, 0.0, 1.0);
+        hyper_on *= clamp(trebleNormalized - 0.2, 0.0, 1.0) * 1.8;
+        if (hyper_on > 0.02) {
+            vec2 hp2 = uv - P.head_c;
+            float hr = length(hp2);
+            float ha = atan(hp2.y, hp2.x);
+            // Streak density — high angular frequency for hyperspace feel
+            float streaks = 0.5 + 0.5 * sin(ha * 48.0 + hash(vec2(floor(ha * 8.0), 0.0)) * 6.28);
+            streaks = pow(streaks, 6.0);
+            // Animate outward: faster toward center
+            float flow = fract(hr * 2.0 - time * 1.2);
+            float streak_life = 1.0 - flow;
+            streak_life = streak_life * streak_life;
+            // Mask: fade near the silhouette and at screen edge
+            float mask = smoothstep(0.18, 0.35, hr) * (1.0 - smoothstep(0.9, 1.3, hr));
+            vec3 streak_col = mix(vec3(0.6, 0.7, 1.0), vec3(1.0, 0.9, 0.7), trebleNormalized);
+            col += streak_col * streaks * streak_life * mask * hyper_on * 0.55;
+        }
+    }
+    col *= 1.0 - smoothstep(0.7, 1.4, length(uv * vec2(1.0, 0.85)));
+
+#if DEBUG_OUTLINES
+    col *= 0.25;
+    float body_outline = smoothstep(0.003, 0.0, abs(d_body));
+    float coat_outline = smoothstep(0.003, 0.0, abs(d_coat));
+    col += body_outline * vec3(0.0, 1.0, 1.0);
+    col += coat_outline * vec3(1.0, 1.0, 0.0);
+#endif
+
+    fragColor = vec4(clamp(col, 0.0, 1.0), 1.0);
+}

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.md
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-6.md
@@ -1,0 +1,31 @@
+# the-coat-6
+
+Forked from `the-coat-5.frag` during the `/vj` session, after iteration 38 (HYPERSPACE TUNNEL) while *Infinite – Shlump* → *Illegal – Makla, OMBRO* was playing.
+
+## Why
+
+Snapshot point after three removal passes cleaned up the composition (RGB-split, tearfall, lightning, scan-line, crystalline facets). What's left reads cleaner: nebula fog + aurora + black-hole distortion + sub-ring + heart pulse + rotor gear + mercury flow + ground quake + volumetric beams + time-echo + water pool + hyperspace tunnel + cosmic shockwave + ghost echo + fur shimmer + starfield. Fork before further evolution so this trimmed state is recoverable.
+
+## Baked knob state at fork time
+
+| Knob | Value | Role |
+|---|---|---|
+| knob_1 | 0.087 | zoom (wide) |
+| knob_2 | 0.236 | nebula fog density (light fog) |
+| knob_3 | 1.0 | god rays (max) |
+| knob_4 | 1.0 | eye wash (max) |
+| knob_5 | 0.457 | drop zoom |
+| knob_6 | 0 | camera tilt (off) |
+| knob_7 | 1 | fur thickness |
+| knob_8 | 0 | unwired |
+| knob_9 | 0 | feedback (crisp) |
+| knob_10 | 0 | unwired |
+| knob_11 | 0 | unwired |
+
+## Preset URL
+
+`?shader=redaphid/wip/the-coat-fur-coat/the-coat-6&controller=the-coat&knob_1=0.087&knob_2=0.236&knob_3=1&knob_4=1&knob_5=0.457&knob_6=0&knob_7=1&knob_8=0&knob_9=0&knob_10=0&knob_11=0`
+
+## Controller
+
+`controllers/the-coat.js` — drop-sustain with exponential decay.

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-7.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-7.frag
@@ -1,6 +1,6 @@
 // @fullscreen: true
 // @mobile: true
-// the-coat-6: forked from the-coat-5 mid-/vj-session after iter 38 (hyperspace). Fresh baseline.
+// the-coat-7: forked from the-coat-6 at iter 45. User: "pretty gorgeous" — capturing the state.
 // Knob defaults captured: knob_2=-0.346, knob_7=0.98, knob_12=0.669, knob_15=0.46
 // Use with controller=the-coat for sustained drop glow
 uniform float drop_glow; // from the-coat controller — sustained drop with decay

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-7.md
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-7.md
@@ -1,0 +1,35 @@
+# the-coat-7
+
+Forked from `the-coat-6.frag` at `/vj` iter 45. User called the state "pretty gorgeous" — capturing *before* any cleanup of the one thing they flagged (mercury-flow diamond artifact on the coat).
+
+## Why
+
+Preserve the working state. Everything except the mercury-flow lattice was landing well on *KEEP IT – BLOSSM* — nebula fog, aurora, hyperspace tunnel, rotor gear, ground quake, cosmic shockwave, heart pulse, mouth glow, warm breath, bouncing body, confetti, flux hue drift, time-echo, water pool, volumetric beams, dissolution particles, starfield, camera drift, black hole. The fork lets us remove the mercury diamonds in the-coat-7 without losing the-coat-6 as a reference.
+
+## Known issue in this fork (will be addressed next)
+
+**Mercury-flow diamond lattice on the coat.** The VJ MERCURY FLOW block uses `sin(uv.x * 18 + sin(uv.y * 4 + flow_t) * 2.5 - flow_t * 2)` which creates a diamond-cell pattern (stripes × stripes) that scrolls rapidly during bass-heavy low-centroid phases. User described it as "flannel-like, large diamonds with thick lines, like zooming into a microscope." Scoped to `silhouette > 0.05` so it's coat-only — but the coat is always there, so it's always visible when the gate fires.
+
+## Baked knob state at fork time
+
+| Knob | Value | Role |
+|---|---|---|
+| knob_1 | 0 | zoom (wide) |
+| knob_2 | 1.0 | nebula fog density (max) |
+| knob_3 | 0.835 | god rays |
+| knob_4 | 0.465 | eye wash |
+| knob_5 | 0.622 | drop zoom |
+| knob_6 | 0 | camera tilt (off) |
+| knob_7 | 1 | fur thickness |
+| knob_8 | 0 | unwired |
+| knob_9 | 0 | feedback (crisp) |
+| knob_10 | 0 | unwired |
+| knob_11 | 0 | unwired |
+
+## Preset URL
+
+`?shader=redaphid/wip/the-coat-fur-coat/the-coat-7&controller=the-coat&knob_1=0&knob_2=1&knob_3=0.835&knob_4=0.465&knob_5=0.622&knob_6=0&knob_7=1&knob_8=0&knob_9=0&knob_10=0&knob_11=0`
+
+## Music during fork
+
+*KEEP IT – BLOSSM*.

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-8.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-8.frag
@@ -691,11 +691,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
         float flow_on = clamp(bassNormalized - 0.25, 0.0, 1.0);
         flow_on *= smoothstep(0.60, 0.25, spectralCentroidNormalized);
         if (flow_on > 0.02 && silhouette > 0.05) {
-            float flow_t = time * (0.5 + bassNormalized * 1.5);
-            // Vertical flow: stripes drip downward at varying speeds
-            float stripe = sin(uv.x * 9.0 - flow_t * 2.0);
-            stripe = stripe * 0.5 + 0.5;
-            stripe = smoothstep(0.35, 0.95, stripe);
+            float flow_t = time * (0.3 + bassNormalized * 0.8);
+            // Mercury FLOW via fbm — no periodic lattice, no diamond artifacting.
+            // Vertical bias: sample at uv.xy shifted by (low-freq horizontal wobble, fast downward drift).
+            vec2 flow_p = uv * vec2(2.5, 3.5) + vec2(sin(flow_t * 0.7) * 0.4, flow_t * 1.1);
+            float stripe = fbm(flow_p);
+            stripe = smoothstep(0.40, 0.75, stripe);
             vec3 mercury_dark = vec3(0.05, 0.06, 0.1);
             vec3 mercury_hi = vec3(0.92, 0.94, 1.0);
             vec3 mercury = mix(mercury_dark, mercury_hi, stripe);

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-8.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-8.frag
@@ -651,7 +651,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
             float chest_d = length(uv - chest_c_world.xy) * 1.4;
             float glow = exp(-chest_d * chest_d * 6.0);
             vec3 warm_col = vec3(1.0, 0.55, 0.25);
-            col += warm_col * glow * warm_on * breath * 0.45;
+            col += warm_col * glow * warm_on * breath * 0.70;
         }
     }
     // VJ MOUTH GLOW — soft glow where the mouth would be, pulsing on mids (vocal presence)

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-8.frag
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-8.frag
@@ -1,0 +1,883 @@
+// @fullscreen: true
+// @mobile: true
+// the-coat-8: forked from the-coat-7 at iter 45. Confetti removed.
+// Knob defaults captured: knob_2=-0.346, knob_7=0.98, knob_12=0.669, knob_15=0.46
+// Use with controller=the-coat for sustained drop glow
+uniform float drop_glow; // from the-coat controller — sustained drop with decay
+#define PI 3.14159265
+
+#define DEBUG_OUTLINES 0
+
+// ============================================================================
+// KNOB CONTROLS — knobs override baked defaults from the jam session
+// knob_1: zoom (0=wide, 1=tight) — live-remapped
+// knob_3: god ray intensity override
+// knob_4: eye wash override
+// knob_5: drop zoom override
+// knob_6: camera tilt swagger
+// knob_7: fur thickness
+// knob_13: sustain decay (via controller)
+// ============================================================================
+
+// --- ZOOM ---
+// Baked from knob_2=-0.346 session value
+// knob_1: 0=wide, 1=tight — live-remapped from knob_2
+#define BASE_ZOOM (mix(0.1, 2.5, knob_1) + energyNormalized * 0.4)
+
+// --- COAT SHAPE ---
+#define SHOULDER_Y      (-0.02 + max(bassZScore, 0.0) * 0.015)
+#define SHOULDER_SPREAD (0.158 + bassNormalized * 0.02)
+#define SLEEVE_RADIUS   (0.04 + max(trebleZScore, 0.0) * 0.015)
+#define SHOULDER_CAP     0.042
+#define CHEST_W_BASE    (0.12 + bassNormalized * 0.03)
+#define CHEST_H_BASE    (0.065 + bassNormalized * 0.01)
+// Fur puffs up with energy — thick on drops, lean on quiet
+#define FUR_THICK       (0.06 + clamp(energyZScore, 0.0, 1.0) * 0.04)
+// V-neck opens on energy spikes — reveals more chest on drops
+#define VNECK_WIDTH     (0.10 + clamp(energyZScore, 0.0, 1.0) * 0.06)
+#define VNECK_BOTTOM    (-0.013 - clamp(energyZScore, 0.0, 1.0) * 0.03)
+
+// --- MOTION ---
+// Heavy pump from bass — body bounces with the kick drum
+#define PUMP (bassNormalized * 0.6 + clamp(bassSlope * bassRSquared, 0.0, 0.5) * 3.0)
+#define BEAT_PHASE (time * 2.2)
+// Treble drives snap gestures — hi-hats make hands twitch
+#define SNAP (clamp(trebleZScore, 0.0, 1.5))
+#define HIP_SWAY (sin(time * 1.1))
+// Mids drive groove — melodic content makes the body sway
+#define GROOVE (midsNormalized * 0.8 + spectralCentroidNormalized * 0.2)
+
+// --- DROP DETECTION ---
+// Confident energy build = drop approaching
+#define BUILD (clamp(energySlope * energyRSquared * 10.0, 0.0, 1.0))
+#define IS_DROP clamp(BUILD + smoothstep(0.6, 1.0, energyZScore) * 0.5, 0.0, 1.0)
+#define DROP_TRIGGER_THRESH 0.8
+#define SUSTAIN_GAIN 1.2
+
+// --- DROP VISUALS ---
+// Drop zoom punches in hard — learned from wooli-drop preset (knob_5=0.764)
+#define DROP_ZOOM 0.9
+// God rays — quiet below average energy, bloom above it
+#define GODRAY_INTENSITY (clamp(energyZScore, 0.0, 1.5) * 2.5 + clamp(trebleZScore, 0.0, 1.0) * 1.0)
+// Eye wash — kicks in above-average energy, scales up from there
+#define EYE_WASH_STRENGTH (clamp(energyZScore, 0.0, 1.0) * 0.5 + clamp(bassZScore, 0.0, 1.0) * 0.2)
+// Continuous zoom breathes with intensity
+#define INTENSITY_ZOOM (energyNormalized * 0.3)
+
+// --- COLOR ---
+// Base hue shifts with pitch class — different notes = different colors
+// VJ breathing rainbow — full cycle every ~60s, mids nudge the hue
+#define HUE_BASE (fract(0.78 + time * 0.0167 + pitchClassNormalized * 0.15 + midsNormalized * 0.20))
+// Drop shifts toward hot orange/yellow
+#define HUE_DROP (fract(0.99 + spectralCentroidNormalized * 0.05))
+
+// --- COAT SURFACE (the star of the show) ---
+// Fluff bristles up on energy spikes AND spectral roughness
+#define FLUFF_AGITATION (clamp(energyZScore, 0.0, 1.0) * 0.5 + spectralRoughnessNormalized * 0.5)
+// Bass pulse drives color warmth — kicks make the coat glow
+#define BASS_PULSE_AMT (clamp(bassZScore, 0.0, 1.0) * 0.8)
+// Color shift driven by drops AND energy — more reactive than before
+#define DROP_COLOR_AMT clamp(IS_DROP + clamp(energyZScore, 0.0, 1.0) * 0.4 + clamp(bassZScore, 0.0, 1.0) * 0.2, 0.0, 1.0)
+// Shoulder gleam pulses with spectral flux — light catches on timbral changes
+#define GLEAM_INTENSITY (0.15 + spectralFluxNormalized * 0.35)
+
+// Fractal fur — THE signature feature (living-coat preset)
+// Entropy (chaos) + roughness (grit) + kurtosis (peaked) trigger the fur fibers
+// Lower threshold than before so it's visible more often
+#define FUR_TRIGGER clamp(spectralEntropyNormalized * 0.7 + spectralRoughnessNormalized * 0.5 + clamp(spectralKurtosisZScore, 0.0, 1.0) * 0.2, 0.0, 1.0)
+// Warp speed driven by centroid — brighter sounds = faster swirl
+#define WARP_SPEED (spectralCentroidNormalized * 0.6 + spectralFluxNormalized * 0.2)
+// Rim boost: flux + bass make the chrome edge blaze
+#define RIM_BOOST (2.5 + spectralFluxNormalized * 2.0 + clamp(bassZScore, 0.0, 1.0) * 1.0)
+
+// --- DERIVED ---
+#define DROP_TRIGGER clamp(max(energyZScore, BUILD), 0.0, 1.0)
+
+// ============================================================================
+// SDFs
+// ============================================================================
+
+float sdCircle(vec2 p, float r) { return length(p) - r; }
+
+float sdEllipse(vec2 p, vec2 r) {
+    float k1 = length(p / r);
+    float k2 = length(p / (r * r));
+    return k1 * (k1 - 1.0) / max(k2, 1e-4);
+}
+
+float smin(float a, float b, float k) {
+    float h = clamp(0.5 + 0.5 * (b - a) / k, 0.0, 1.0);
+    return mix(b, a, h) - k * h * (1.0 - h);
+}
+
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+// Smooth value noise for fur texture
+float vnoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+float fbm(vec2 p) {
+    float s = 0.0;
+    float a = 0.5;
+    for (int i = 0; i < 4; i++) {
+        s += a * vnoise(p);
+        p *= 2.03;
+        a *= 0.5;
+    }
+    return s;
+}
+
+struct Pose {
+    float bob;
+    float tilt;
+    float hip;
+    vec2  head_c;
+    vec2  l_hand;
+    vec2  r_hand;
+    float l_open;
+    float r_open;
+};
+
+Pose makePose(float beat_phase, float hip_sway, float snap, float groove) {
+    Pose P;
+    P.bob = -abs(sin(beat_phase)) * 0.025 + groove * 0.005 - clamp(bassZScore, 0.0, 2.0) * 0.04;
+    P.tilt = hip_sway * 0.18 + sin(beat_phase * 0.5) * 0.05;
+    P.hip = sign(hip_sway) * pow(abs(hip_sway), 0.6) * 0.05;
+    P.head_c = vec2(P.hip * 0.6, 0.24 + P.bob);
+    float l_gesture = snap * 1.2;
+    float r_gesture = snap * 1.2;
+    P.l_open = l_gesture;
+    P.r_open = r_gesture;
+    // Arms hang naturally at the sides, symmetric, proportional length.
+    // Hands end just past the hips (y ≈ -0.38).
+    P.l_hand = vec2(-0.30 - l_gesture * 0.15, -0.38 + l_gesture * 0.25);
+    P.r_hand = vec2( 0.30 + r_gesture * 0.15, -0.38 + r_gesture * 0.25 + sin(beat_phase) * 0.01);
+    return P;
+}
+
+float sdCapsule(vec2 p, vec2 a, vec2 b, float r) {
+    vec2 pa = p - a, ba = b - a;
+    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-4), 0.0, 1.0);
+    return length(pa - ba * h) - r;
+}
+
+// Slimmer daddy — smaller frame, no bulging biceps
+float sdDaddy(vec2 p, float pump, Pose P) {
+    float ct = cos(P.tilt), st = sin(P.tilt);
+    vec2 hp = p - P.head_c;
+    hp = vec2(hp.x * ct - hp.y * st, hp.x * st + hp.y * ct);
+
+    float head = sdEllipse(hp, vec2(0.13, 0.15));
+    float jaw = sdEllipse(hp - vec2(0.0, -0.05), vec2(0.11, 0.09));
+    head = smin(head, jaw, 0.04);
+
+    vec2 np = p - vec2(P.hip * 0.7, 0.11);
+    float neck = sdEllipse(np, vec2(0.035, 0.045));
+
+    // Slimmer chest
+    float chest_w = 0.23 + pump * 0.04;
+    float chest_h = 0.17 + pump * 0.02;
+    vec2 cp = p - vec2(P.hip * 0.7, -0.02);
+    float chest = sdEllipse(cp, vec2(chest_w, chest_h));
+
+    // Slimmer hips
+    vec2 wp = p - vec2(P.hip * 1.4, -0.22);
+    float hips = sdEllipse(wp, vec2(0.20, 0.09));
+
+    // Shoulders at the natural resting line — not raised (no shrugging)
+    float coat_edge = SHOULDER_SPREAD;
+    vec2 ls = vec2(-coat_edge + P.hip * 0.4, SHOULDER_Y);
+    vec2 rs = vec2( coat_edge + P.hip * 0.4, SHOULDER_Y);
+    float lshoulder = sdCircle(p - ls, SHOULDER_CAP);
+    float rshoulder = sdCircle(p - rs, SHOULDER_CAP);
+
+    // Arms hang proportionally — elbow at the midpoint between shoulder and
+    // hand, slightly biased inward so the lower arm curves toward the body
+    vec2 l_mid = mix(ls, P.l_hand, 0.5);
+    vec2 r_mid = mix(rs, P.r_hand, 0.5);
+    vec2 l_elbow = l_mid + vec2(0.015, 0.0) + vec2(-0.02, 0.02) * P.l_open;
+    vec2 r_elbow = r_mid + vec2(-0.015, 0.0) + vec2(0.02, 0.02) * P.r_open;
+    float l_upper = sdCapsule(p, ls, l_elbow, 0.04);
+    float l_lower = sdCapsule(p, l_elbow, P.l_hand, 0.035);
+    float r_upper = sdCapsule(p, rs, r_elbow, 0.04);
+    float r_lower = sdCapsule(p, r_elbow, P.r_hand, 0.035);
+
+    float l_fist = sdCircle(p - P.l_hand, 0.055 + P.l_open * 0.01);
+    float r_fist = sdCircle(p - P.r_hand, 0.055 + P.r_open * 0.01);
+
+    float d = head;
+    d = smin(d, neck, 0.035);
+    d = smin(d, chest, 0.05);
+    d = smin(d, hips, 0.05);
+    d = smin(d, lshoulder, 0.04);
+    d = smin(d, rshoulder, 0.04);
+    d = smin(d, l_upper, 0.035);
+    d = smin(d, l_lower, 0.035);
+    d = smin(d, r_upper, 0.035);
+    d = smin(d, r_lower, 0.035);
+    d = smin(d, l_fist, 0.025);
+    d = smin(d, r_fist, 0.025);
+    return d;
+}
+
+// Torso-only SDF: chest + shoulders + hips, NO head/neck/arms/hands.
+// Used as the base shape the fur coat inflates from, so arms poke out.
+// Chest is intentionally shorter than the body's chest so that when the coat
+// inflates outward by fur_thickness, its top sits below the neck — no hard
+// cut needed, no visible "back of collar" line.
+float sdTorso(vec2 p, float pump, Pose P) {
+    // Tailored torso: narrower chest, pinched waist, slight hip flare so
+    // the coat silhouette reads as a fitted garment instead of a sack.
+    float chest_w = CHEST_W_BASE + pump * 0.04;
+    float chest_h = CHEST_H_BASE + pump * 0.02;
+    vec2 cp = p - vec2(P.hip * 0.7, 0.01);
+    float chest = sdEllipse(cp, vec2(chest_w, chest_h));
+
+    // Waist — narrower pinch at midsection
+    vec2 wpn = p - vec2(P.hip * 0.8, -0.12);
+    float waist = sdEllipse(wpn, vec2(0.16, 0.08));
+
+    vec2 wp = p - vec2(P.hip * 1.4, -0.24);
+    float hips = sdEllipse(wp, vec2(0.17, 0.09));
+
+    float d = chest;
+    d = smin(d, waist, 0.08);
+    d = smin(d, hips, 0.08);
+    return d;
+}
+
+// Fur coat: inflates the torso AND arms (long sleeves) by a fur thickness,
+// caps at the neckline with a V, lets the hem run off-screen.
+float sdFurCoat(vec2 p, Pose P, float pump) {
+    float d_torso = sdTorso(p, pump, P);
+
+    // Long sleeves — capsules from shoulder to WRIST (not hand), so the
+    // fists poke out of the cuffs. Wrist = 80% of the way from shoulder to hand.
+    float coat_edge = SHOULDER_SPREAD;
+    vec2 ls = vec2(-coat_edge + P.hip * 0.4, SHOULDER_Y);
+    vec2 rs = vec2( coat_edge + P.hip * 0.4, SHOULDER_Y);
+    vec2 l_wrist = mix(ls, P.l_hand, 0.55);
+    vec2 r_wrist = mix(rs, P.r_hand, 0.55);
+    float l_sleeve = sdCapsule(p, ls, l_wrist, SLEEVE_RADIUS);
+    float r_sleeve = sdCapsule(p, rs, r_wrist, SLEEVE_RADIUS);
+
+    // Shoulder caps smin'd with both torso and sleeves
+    float l_cap = sdCircle(p - ls, SHOULDER_CAP);
+    float r_cap = sdCircle(p - rs, SHOULDER_CAP);
+    float coat_base = min(d_torso, l_sleeve);
+    coat_base = min(coat_base, r_sleeve);
+    coat_base = smin(coat_base, l_cap, 0.04);
+    coat_base = smin(coat_base, r_cap, 0.04);
+
+    // Looser, straighter fit (not form-fitting) — more fur thickness so the
+    // coat hangs straight down rather than hugging every curve.
+    float fur_thickness = FUR_THICK + pump * 0.005;
+    float inflated = coat_base - fur_thickness;
+
+    // Straight hem: a tall narrow rectangle-ish ellipse that gives the coat a
+    // straight drop through the hips and off the bottom. Not wider than the
+    // shoulders, so it reads as "long coat" not "ball gown."
+    vec2 hem_c = vec2(P.hip * 1.0, -0.55);
+    float hem = sdEllipse(p - hem_c, vec2(0.26, 0.45));
+    inflated = smin(inflated, hem, 0.06);
+
+    // V-neckline: opens from the sternum to the top of the coat. The V is
+    // bounded so it only carves within its y-range — outside the range,
+    // v_wedge stays positive so `-v_wedge` is negative and max() ignores it.
+    // V-neck carved with a smooth subtraction. Wedge is unbounded at the top
+    // so its sides continue upward past the coat top — this means the wedge
+    // has NO visible "top corners" inside the coat, so rim lighting can't
+    // trace a phantom collar back-edge at the top of the V.
+    float cx = P.hip * 0.7;
+    float v_bottom = VNECK_BOTTOM;
+    float v_half_at_top = VNECK_WIDTH;
+    // Slope of the V: widens as y increases, no upper bound
+    float v_slope = v_half_at_top / 0.17;  // reaches 0.07 at y=0.15
+    float v_half = max(0.0, (p.y - v_bottom)) * v_slope;
+    float v_horiz = abs(p.x - cx) - v_half;
+    float v_vert = v_bottom - p.y;  // only the bottom is a hard wall
+    float v_wedge = max(v_horiz, v_vert);
+
+    // Smooth subtraction (smooth max via -smin)
+    float d = -smin(-inflated, v_wedge, 0.015);
+    return d;
+}
+
+float sdCurls(vec2 p, Pose P, float beat_phase, float pump) {
+    float ct = cos(P.tilt), st = sin(P.tilt);
+    vec2 hp = p - P.head_c;
+    hp = vec2(hp.x * ct - hp.y * st, hp.x * st + hp.y * ct);
+
+    float d = 1e6;
+    for (int i = 0; i < 8; i++) {
+        float fi = float(i);
+        float t = fi / 7.0;
+        float ang = mix(PI * 1.05, PI * -0.05, t);
+        float radius = 0.155;
+        float jx = hash(vec2(fi, 1.0)) - 0.5;
+        float jy = hash(vec2(fi, 2.0)) - 0.5;
+        vec2 c = vec2(cos(ang), sin(ang)) * radius + vec2(jx, jy) * 0.025;
+        float crown_bias = sin(t * PI);
+        float r = 0.045 + crown_bias * 0.015 + hash(vec2(fi, 3.0)) * 0.01;
+        float ph = hash(vec2(fi, 4.0)) * 6.28;
+        float bounce = sin(beat_phase * 1.0 + ph) * 0.012 + pump * 0.008;
+        c.y += bounce;
+        d = smin(d, sdCircle(hp - c, r), 0.025);
+    }
+    return d;
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = (fragCoord - 0.5 * res) / min(res.x, res.y);
+
+    float pump = PUMP;
+    Pose P = makePose(BEAT_PHASE, HIP_SWAY, SNAP, GROOVE);
+
+    vec2 raw_uv01 = fragCoord / res;
+
+    // --- DROP SUSTAIN ---
+    // drop_glow is a controller-computed uniform with exponential decay.
+    // It latches high on energy spikes and decays smoothly over ~1-2 seconds.
+    // Falls back to instantaneous IS_DROP if no controller is loaded.
+    float drop_spike = smoothstep(DROP_TRIGGER_THRESH, DROP_TRIGGER_THRESH + 0.5, BUILD);
+    float sustain_signal = BUILD * SUSTAIN_GAIN;
+    float drop_now = clamp(max(drop_spike, max(IS_DROP, sustain_signal)), 0.0, 1.0);
+    drop_now = smoothstep(0.15, 0.5, drop_now);
+    // drop_glow = controller-driven sustained drop glow (exponential decay)
+    float drop_hit = max(drop_now, drop_glow);
+
+    float intensity = max(PUMP, GROOVE);
+    // Cubic ease-in: crushes twitchy low-end values, lets big moments punch through.
+    // smoothstep(0.2, 0.9) maps to 0-1, then cube kills anything below ~0.5
+    float zoom_intensity = smoothstep(0.2, 0.9, intensity);
+    zoom_intensity = zoom_intensity * zoom_intensity * zoom_intensity;
+    float zoomAmount = BASE_ZOOM + zoom_intensity * INTENSITY_ZOOM + drop_hit * DROP_ZOOM;
+    vec2 zoomCenter = P.head_c;
+    // VJ CAMERA DRIFT — slow lateral sway + flux nudge so the frame never sits locked
+    vec2 cam_drift = vec2(
+        sin(time * 0.12) * 0.015 + spectralFluxZScore * 0.012,
+        sin(time * 0.09 + 1.3) * 0.010
+    );
+    zoomCenter += cam_drift;
+    uv = (uv - zoomCenter) / zoomAmount + zoomCenter;
+
+    // Camera tilt — knob_6 controls how much swagger
+    float tilt_angle = (sin(time * 0.7) * 0.15
+                     + (spectralCentroidNormalized - 0.5) * 0.2
+                     + bassZScore * 0.075) * knob_6;
+    float ca = cos(tilt_angle), sa = sin(tilt_angle);
+    uv -= zoomCenter;
+    uv = vec2(uv.x * ca - uv.y * sa, uv.x * sa + uv.y * ca);
+    uv += zoomCenter;
+
+    // ---- BACKDROP ----
+    float bg_grad = smoothstep(-0.8, 0.8, uv.y);
+    vec3 bg = mix(vec3(0.04, 0.02, 0.10), vec3(0.01, 0.00, 0.04), bg_grad);
+    float spot = exp(-uv.x*uv.x * 4.0) * smoothstep(-0.3, -0.6, uv.y);
+    bg += spot * vec3(0.5, 0.2, 0.6) * (0.5 + 0.5 * sin(BEAT_PHASE * 2.0)) * (0.8 + clamp(energyZScore, -0.5, 2.0) * 0.6);
+    // VJ STARFIELD — sparkle crosses in the upper sky, twinkle faster on treble
+    {
+        vec2 sp = uv * 14.0;
+        vec2 scell = floor(sp);
+        vec2 scf = fract(sp) - 0.5;
+        float sr = hash(scell);
+        float sr2 = hash(scell + vec2(3.7, 1.3));
+        float star_active = step(0.80, sr);
+        vec2 spos = (vec2(sr2, hash(scell + vec2(2.1, 5.9))) - 0.5) * 0.4;
+        vec2 delta = scf - spos;
+        float sd = length(delta);
+        float cross_h = exp(-delta.y*delta.y * 2500.0) * exp(-abs(delta.x) * 15.0);
+        float cross_v = exp(-delta.x*delta.x * 2500.0) * exp(-abs(delta.y) * 15.0);
+        float core = exp(-sd * sd * 800.0);
+        float tw_s = 0.5 + 0.5 * sin(time * (2.0 + sr * 4.0 + trebleNormalized * 6.0 + max(trebleZScore, 0.0) * 5.0) + sr * 30.0);
+        float twinkle = 0.35 + 0.65 * tw_s * tw_s;
+        float star = (core + (cross_h + cross_v) * 0.6) * star_active * twinkle;
+        float sky_mask = smoothstep(-0.2, 0.3, uv.y);
+        bg += vec3(1.0, 0.95, 0.85) * star * sky_mask * (1.3 + clamp(trebleZScore, 0.0, 2.5) * 0.8);
+    }
+
+    // VJ NEBULA FOG — slow drifting cosmic haze, no per-frame hashing
+    {
+        float t = time * 0.05 + trebleNormalized * 0.08;
+        vec2 np = uv * 1.3;
+        float n1 = sin(np.x * 1.7 + t * 1.3) * sin(np.y * 2.1 - t * 0.9);
+        float n2 = sin(np.x * 3.1 - t * 0.7) * sin(np.y * 2.7 + t * 1.1);
+        float n3 = sin((np.x + np.y) * 0.9 + t * 0.6);
+        float fog = (n1 + n2 * 0.6 + n3 * 0.4) * 0.25 + 0.5;
+        fog = smoothstep(0.25, 0.95, fog);
+        vec3 nebula_a = vec3(0.35, 0.15, 0.55);
+        vec3 nebula_b = vec3(0.10, 0.35, 0.70);
+        vec3 nebula = mix(nebula_a, nebula_b, sin(np.x * 0.7 + t) * 0.5 + 0.5);
+        // knob_2: nebula fog density (0 = clear, 1 = thick cosmic cloud) — auto-wired when twisted
+        float fog_pulse = 1.0 + clamp(bassZScore, 0.0, 2.0) * 0.50;
+        bg += nebula * fog * mix(0.04, 0.45, knob_2) * (0.7 + midsNormalized * 0.4) * fog_pulse;
+    }
+        // VJ AURORA VEILS — glowing green-teal curtains in dark/wonky phases (low centroid)
+    {
+        float aurora_on = smoothstep(0.35, 0.10, spectralCentroidNormalized);
+        if (aurora_on > 0.02) {
+            float t = time * 0.35;
+            float v1 = sin(uv.x * 2.3 + t) * 0.5 + sin(uv.x * 1.1 - t * 0.7) * 0.25;
+            float v2 = sin(uv.x * 3.7 - t * 0.6) * 0.35;
+            float curtain1 = exp(-pow(uv.y - 0.35 - v1 * 0.25, 2.0) * 14.0);
+            float curtain2 = exp(-pow(uv.y - 0.20 - v2 * 0.3, 2.0) * 10.0);
+            float intensity = aurora_on * (0.5 + bassNormalized * 0.6);
+            bg += vec3(0.25, 0.85, 0.55) * curtain1 * intensity * 0.7;
+            bg += vec3(0.15, 0.55, 0.95) * curtain2 * intensity * 0.5;
+        }
+    }
+    // VJ ROTOR GEAR — stepped 8-spoke halo behind head, ticks on treble-heavy phases
+    {
+        float gear_on = clamp((spectralCentroidNormalized - 0.45) * 2.0, 0.0, 1.0);
+        gear_on *= clamp(trebleNormalized - 0.3, 0.0, 1.0) * 1.8;
+        if (gear_on > 0.02) {
+            vec2 gear_p = uv - P.head_c;
+            float gear_r = length(gear_p);
+            float gear_a = atan(gear_p.y, gear_p.x);
+            // Stepped rotation — 2Hz clock, 8 positions
+            float step_rot = floor(time * 2.0) * (PI / 4.0);
+            float rot_a = gear_a + step_rot;
+            // 8 spokes
+            float spoke = 0.5 + 0.5 * cos(rot_a * 8.0);
+            spoke = smoothstep(0.72, 0.95, spoke);
+            // Only within a ring band behind head
+            float band = smoothstep(0.18, 0.21, gear_r) * smoothstep(0.33, 0.28, gear_r);
+            float gear = spoke * band;
+            // Masked outside the silhouette — radial falloff instead of silhouette ref (not defined yet here)
+            gear *= smoothstep(0.17, 0.20, gear_r);
+            bg += vec3(0.95, 0.75, 0.25) * gear * gear_on * 1.2;
+        }
+    }
+    float rays = pow(max(0.0, 1.0 - abs(uv.x) * 1.2), 4.0) * smoothstep(0.0, 1.0, uv.y);
+    bg += rays * vec3(1.0, 0.7, 0.3) * IS_DROP * 0.6;
+
+    // ---- DADDY ----
+    float d_body  = sdDaddy(uv, pump, P);
+    float d_curls = sdCurls(uv, P, BEAT_PHASE, pump);
+    float d_coat  = sdFurCoat(uv, P, pump);
+
+    // Fur "fluff" — perturb the coat distance with noise so its edge is shaggy
+    // Noise coords wobble with beat so the fur looks alive
+    vec2 fur_p = uv * 38.0 + vec2(0.0, sin(BEAT_PHASE) * 0.15);
+    float fur_n = fbm(fur_p);
+    // Fur edge gets much more agitated on drops/bass — bristles up
+    float fluff_amp = 0.018 + pump * 0.015 + SNAP * 0.012 + FLUFF_AGITATION * 0.02;
+    float d_coat_fluff = d_coat - (fur_n - 0.5) * fluff_amp;
+
+    float d = min(d_body, d_curls);
+
+    float body  = smoothstep(0.005, -0.005, d);
+    float curls = smoothstep(0.005, -0.005, d_curls);
+    float coat  = smoothstep(0.006, -0.006, d_coat_fluff);
+
+    // Rim light — body
+    float rim_w = 0.006 + IS_DROP * 0.012 + SNAP * 0.006;
+    float rim = smoothstep(rim_w, 0.0, abs(d));
+    float edge_gate = body * (1.0 - body) * 4.0;
+    rim *= edge_gate;
+
+    // Rim light — coat (same chrome treatment on the fluffy edge)
+    float coat_rim = smoothstep(rim_w, 0.0, abs(d_coat_fluff));
+    float coat_edge_gate = coat * (1.0 - coat) * 4.0;
+    coat_rim *= coat_edge_gate;
+
+    float chest_glow_d = length(uv - vec2(P.hip * 0.7, -0.02)) * 3.0;
+    float chest_glow = exp(-chest_glow_d*chest_glow_d);
+    chest_glow *= smoothstep(0.005, -0.005, d_body) * (0.3 + pump * 0.7);
+
+    // Eyes
+    float ct = cos(P.tilt), st = sin(P.tilt);
+    vec2 le_local = vec2(-0.045, 0.02);
+    vec2 re_local = vec2( 0.045, 0.02);
+    vec2 le = P.head_c + vec2(le_local.x * ct + le_local.y * st, -le_local.x * st + le_local.y * ct);
+    vec2 re = P.head_c + vec2(re_local.x * ct + re_local.y * st, -re_local.x * st + re_local.y * ct);
+
+    float eyes = exp(-dot(uv - le, uv - le) * 2500.0) + exp(-dot(uv - re, uv - re) * 2500.0);
+    eyes *= (0.25 + drop_hit * 1.8 + SNAP * 0.6);
+
+    vec2 d_le2 = uv - le;
+    vec2 d_re2 = uv - re;
+    float r_le = length(d_le2);
+    float r_re = length(d_re2);
+    float a_le = atan(d_le2.y, d_le2.x);
+    float a_re = atan(d_re2.y, d_re2.x);
+    float fan_le = pow(abs(cos(a_le * 6.0 + time * 0.8)), 14.0);
+    float fan_re = pow(abs(cos(a_re * 6.0 - time * 0.7 + 1.3)), 14.0);
+    float fall_le = exp(-r_le * 1.2);
+    float fall_re = exp(-r_re * 1.2);
+    float up_le = smoothstep(-1.0, 0.3, d_le2.y / max(r_le, 0.001));
+    float up_re = smoothstep(-1.0, 0.3, d_re2.y / max(r_re, 0.001));
+    float god_rays = (fan_le * fall_le * up_le + fan_re * fall_re * up_re) * drop_hit;
+    god_rays += (exp(-r_le * 10.0) + exp(-r_re * 10.0)) * drop_hit * 0.6;
+
+    float wash_le = exp(-r_le * 0.8);
+    float wash_re = exp(-r_re * 0.8);
+    float eye_wash = (wash_le + wash_re) * drop_hit * EYE_WASH_STRENGTH;
+
+    // ---- COLOR ----
+    float hue = mix(HUE_BASE, HUE_DROP, IS_DROP);
+    vec3 leather = hsl2rgb(vec3(hue, 0.8, mix(0.06, 0.14, spectralCentroidNormalized)));
+    // VJ prism rim — chrome cycles its own rainbow based on uv angle + time
+    float chrome_hue = fract(atan(uv.y - P.head_c.y, uv.x) / 6.2831 + time * (0.10 + pitchClassNormalized * 0.25) + hue * 0.3);
+    vec3 chrome  = hsl2rgb(vec3(chrome_hue, 1.0, 0.65));
+    vec3 hair    = hsl2rgb(vec3(0.06, 0.7, 0.12));
+    vec3 hot     = hsl2rgb(vec3(0.08, 1.0, 0.6));
+
+    // Coat fill — audio-reactive color. Base is deep blue, but:
+    // - Lightness pulses brighter on bass hits
+    // - Hue shifts toward electric cyan on drops
+    // - Saturation dips slightly on quiet passages (more white/pastel)
+    float coat_grad = smoothstep(0.15, -0.4, uv.y);
+    float bass_pulse = BASS_PULSE_AMT;
+    float drop_color = DROP_COLOR_AMT;
+    // Hue slides from deep blue (0.62) toward electric cyan (0.50) on drops
+    float fur_hue_hi = mix(0.62, 0.50, drop_color * 0.6);
+    float fur_hue_lo = mix(0.58, 0.48, drop_color * 0.5);
+    // Lightness pumps up on bass
+    float fur_l_hi = 0.65 + bass_pulse * 0.15;
+    float fur_l_lo = 0.45 + bass_pulse * 0.10;
+    vec3 fur_hi = hsl2rgb(vec3(fur_hue_hi, 0.95, clamp(fur_l_hi, 0.0, 0.95)));
+    vec3 fur_lo = hsl2rgb(vec3(fur_hue_lo, 0.9, clamp(fur_l_lo, 0.0, 0.85)));
+    vec3 fur_col = mix(fur_hi, fur_lo, coat_grad);
+    // Shoulder gleam pulses with spectral flux — light catching the coat
+    float shoulder_gleam_d = (uv.y - 0.08) * 10.0;
+    float shoulder_gleam = exp(-shoulder_gleam_d*shoulder_gleam_d);
+    float gleam_intensity = GLEAM_INTENSITY;
+    fur_col += shoulder_gleam * vec3(gleam_intensity * 0.5, gleam_intensity * 0.8, gleam_intensity * 1.5);
+    // ---- FRACTAL FUR FIBERS ----
+    // Swirling domain-warped fractal that appears inside the coat when the
+    // music is "interesting" — triggered by spectral entropy (chaos) and
+    // spectral roughness (dissonance). These are independent from the
+    // energy/bass features that drive the eyes, so the coat and eyes
+    // react to DIFFERENT musical qualities.
+    float fur_trigger = FUR_TRIGGER;
+    // Only show when musically interesting (above baseline)
+    float fur_fractal_amt = smoothstep(0.15, 0.55, fur_trigger);
+    if (fur_fractal_amt > 0.01) {
+        // Domain warp: swirl the coords with low-freq noise so the fibers
+        // look like curling fur strands, not a static grid
+        vec2 fp = uv * 18.0;
+        float warp_t = time * 0.3 + WARP_SPEED;
+        vec2 warp = vec2(
+            fbm(fp + vec2(warp_t, 0.0)),
+            fbm(fp + vec2(0.0, warp_t + 3.7))
+        );
+        // Second domain warp for deeper swirl
+        vec2 fp2 = fp + warp * 3.5;
+        float fibers = fbm(fp2 + vec2(
+            fbm(fp2 + vec2(warp_t * 0.7, 1.3)),
+            fbm(fp2 + vec2(2.1, warp_t * 0.5))
+        ) * 1.5);
+        // Shape the fibers: sharp ridges that look like individual strands
+        float strand = pow(abs(sin(fibers * PI * (4.0 + spectralFluxZScore * 1.5))), 3.0);
+        // Color the strands: lighter than the base coat, tinted toward
+        // cyan/white so they read as light catching individual fur fibers
+        vec3 strand_col = mix(fur_col * 1.5, vec3(0.7, 0.9, 1.0), 0.3 + strand * 0.4);
+        // Blend into the coat color, gated by the trigger amount
+        fur_col = mix(fur_col, strand_col, strand * fur_fractal_amt * 0.85);
+    }
+
+    // Seam strength computed here; chrome glow added after compositing
+    // so it matches the rim-light aesthetic. Thin + subtle.
+    float seam_x_pos = P.hip * 0.7;
+    float seam_dx = uv.x - seam_x_pos;
+    float seam_glow = exp(-seam_dx * seam_dx * 40000.0);
+    seam_glow *= smoothstep(-0.02, -0.10, uv.y) * 0.3;
+
+    vec3 col = bg;
+    // Body silhouette — warm plum skin that reads against the dark background
+    // and complements the pink coat
+    vec3 skin = hsl2rgb(vec3(0.92, 0.45, 0.18));
+    col = mix(col, skin, body);
+    // Coat sits OVER the body but UNDER the hair (so curls still fall)
+    col = mix(col, fur_col, coat * (1.0 - curls));
+    col = mix(col, hair, curls);
+    col += rim * chrome * 1.3 * (1.0 - coat);
+    // VJ SUB RING — expanding cone ring on bass spikes (gated by bassZScore)
+    {
+        float bass_hit = clamp(bassZScore, 0.0, 2.5);
+        if (bass_hit > 0.3) {
+            vec2 sub_c = vec2(0.0, -0.15);
+            float sd = length(uv - sub_c);
+            float ring_speed = 1.2 + clamp(energyZScore, -0.5, 1.5) * 0.6;
+            float ring_radius = 0.2 + fract(time * ring_speed) * 0.5;
+            float ring_d = sd - ring_radius;
+            float ring = exp(-ring_d*ring_d * 400.0);
+            float ring_fade = 1.0 - fract(time * ring_speed);
+            col += vec3(1.0, 0.3, 0.1) * ring * bass_hit * ring_fade * 0.7;
+        }
+    }
+    // VJ HEART PULSE — red glow from chest center, pulses on bass
+    {
+        vec2 heart_c = vec2(P.hip * 0.7, -0.08);
+        float heart_d = length((uv - heart_c) * vec2(1.2, 1.0));
+        // Heart-shape-ish falloff
+        float heart = exp(-heart_d * 6.0);
+        float heart_pulse = 0.3 + clamp(bassZScore, 0., 2.) * 1.2 + bassNormalized * 0.5 + midsNormalized * 0.4;
+        vec3 heart_col = hsl2rgb(vec3(fract(0.92 + pitchClassNormalized * 0.10 + sin(time * 0.4) * 0.03), 1.0, 0.55));
+        col += heart * heart_col * heart_pulse * coat * 0.6;
+    }
+    col += chest_glow * chrome * 0.8 * (1.0 - coat);
+    // Coat rim — chrome edge hugs the shaggy outline (boosted for visibility)
+    // Coat rim pulses with spectral flux — brighter on timbral changes
+    float rim_boost = RIM_BOOST;
+    col += coat_rim * chrome * rim_boost * (1.0 - curls);
+    // Button seam glow — chrome line down the center
+    col += seam_glow * coat * chrome * 0.25 * (1.0 - curls);
+    col += eyes * hot * 2.2;
+    // VJ WARM BREATH — slow amber chest glow breathing at 0.5Hz, gated on sustained mid-energy
+    // Fills the 'warm dark instrumental' slot (iter 39 journal hypothesis).
+    {
+        float warm_on = clamp(midsNormalized - 0.15, 0.0, 1.0);
+        warm_on *= smoothstep(0.8, 0.2, spectralCentroidNormalized);
+        if (warm_on > 0.02) {
+            float breath = 0.5 + 0.5 * sin(time * 3.14);
+            vec3 chest_c_world = vec3(P.hip * 0.7, -0.05, 0.0);
+            float chest_d = length(uv - chest_c_world.xy) * 1.4;
+            float glow = exp(-chest_d * chest_d * 6.0);
+            vec3 warm_col = vec3(1.0, 0.55, 0.25);
+            col += warm_col * glow * warm_on * breath * 0.45;
+        }
+    }
+    // VJ MOUTH GLOW — soft glow where the mouth would be, pulsing on mids (vocal presence)
+    {
+        float mouth_on = clamp(midsNormalized - 0.15, 0.0, 1.0);
+        if (mouth_on > 0.02) {
+            vec2 mouth_c = P.head_c + vec2(0.0, -0.06);
+            float md = length((uv - mouth_c) * vec2(1.4, 2.0));
+            float mouth_blob = exp(-md * md * 80.0);
+            float pulse = 0.5 + 0.5 * sin(time * 4.0 + pitchClassNormalized * 6.28);
+            vec3 mouth_col = hsl2rgb(vec3(fract(0.05 + pitchClassNormalized * 0.15), 0.9, 0.55));
+            col += mouth_col * mouth_blob * mouth_on * pulse * 0.8;
+        }
+    }
+    col = mix(col, col + hot * 0.6, eye_wash);
+    col += eye_wash * hot * 0.4;
+    vec3 ray_col = mix(hot, vec3(0.4, 0.85, 1.0), smoothstep(0.45, 0.85, spectralCentroidNormalized));
+    col += god_rays * ray_col * GODRAY_INTENSITY;
+
+    // ---- INFINITY MIRROR removed (spinning-tile repetition clashed with spacy ambient bg) ----
+
+    // ---- FEEDBACK ----
+    vec2 fb_uv = fragCoord / res;
+    fb_uv.x -= P.hip * 0.01;
+    fb_uv.y -= 0.002 + pump * 0.003;
+    vec3 prev = getLastFrameColor(fb_uv).rgb * 0.88;
+    float silhouette = max(body, coat);
+    // knob_9: feedback/trails (0=crisp, 1=heavy smear)
+    float feedback_amt = mix(mix(0.45, 0.05, knob_9), mix(0.15, 0.03, knob_9), silhouette);
+    // VJ GHOST ECHO — bass spikes briefly raise feedback for a coat afterimage
+    feedback_amt = mix(feedback_amt, 0.55, clamp(bassZScore - 0.4, 0.0, 1.0) * 0.5);
+    if (beat) feedback_amt *= 0.6;
+    if (frame < 30) feedback_amt = 0.0;
+    col = mix(prev, col, feedback_amt);
+    // VJ MERCURY FLOW — bass-heavy low-centroid phases turn the coat into flowing liquid metal
+    {
+        float flow_on = clamp(bassNormalized - 0.25, 0.0, 1.0);
+        flow_on *= smoothstep(0.60, 0.25, spectralCentroidNormalized);
+        if (flow_on > 0.02 && silhouette > 0.05) {
+            float flow_t = time * (0.5 + bassNormalized * 1.5);
+            // Vertical flow: stripes drip downward at varying speeds
+            float stripe = sin(uv.x * 9.0 - flow_t * 2.0);
+            stripe = stripe * 0.5 + 0.5;
+            stripe = smoothstep(0.35, 0.95, stripe);
+            vec3 mercury_dark = vec3(0.05, 0.06, 0.1);
+            vec3 mercury_hi = vec3(0.92, 0.94, 1.0);
+            vec3 mercury = mix(mercury_dark, mercury_hi, stripe);
+            col = mix(col, mercury, flow_on * silhouette * 0.75);
+        }
+    }
+
+
+    // VJ TIME-ECHO — on energy surges, triple-expose previous frame around head
+    {
+        float echo = clamp(energyZScore - 0.5, 0.0, 1.0);
+        if (echo > 0.05) {
+            vec2 ec = P.head_c;
+            vec3 e1 = getLastFrameColor(fb_uv + vec2( 0.020,  0.006)).rgb;
+            vec3 e2 = getLastFrameColor(fb_uv + vec2(-0.024,  0.009)).rgb;
+            vec3 e3 = getLastFrameColor(fb_uv + vec2( 0.004, -0.018)).rgb;
+            vec3 echoed = (e1 * vec3(1.2, 0.7, 0.7) + e2 * vec3(0.7, 1.1, 0.9) + e3 * vec3(0.8, 0.9, 1.2)) * 0.34;
+            col = mix(col, col + echoed * 0.5, echo * 0.9);
+        }
+    }
+    // VJ BLACK HOLE — silhouette becomes a gravitational lens. Active on bassZ spikes.
+    {
+        float bh_strength = clamp(bassZScore - 0.3, 0.0, 1.5);
+        if (bh_strength > 0.05 && silhouette > 0.0) {
+            vec2 bh_center = P.head_c + vec2(0.0, -0.05);
+            vec2 to_center = bh_center - uv;
+            float bh_d = length(to_center);
+            vec2 dir_lens = to_center / max(bh_d, 0.001);
+            float lens_strength = bh_strength * 0.08 / max(bh_d * bh_d + 0.04, 0.04);
+            vec2 lens_uv = fb_uv + dir_lens * lens_strength * vec2(res.y / res.x, 1.0);
+            vec3 lensed = getLastFrameColor(lens_uv).rgb;
+            col = mix(col, lensed, bh_strength * (1.0 - silhouette) * 0.8);
+            col = mix(col, vec3(0.0), silhouette * bh_strength * 0.85);
+        }
+    }
+
+
+    // VJ COSMIC SHOCKWAVE — one-shot expanding ring on true beat flux spikes
+    {
+        float shock_trigger = float(beat) * clamp(spectralFluxZScore, 0.0, 1.0);
+        // lock the start time at the beat moment using a hash keyed to coarse time
+        float shock_phase = fract(time * 0.7);
+        float shock_r = shock_phase * 1.4;
+        float shock_d = length(uv) - shock_r;
+        float shock_ring = exp(-shock_d * shock_d * 300.0);
+        float shock_fade = (1.0 - shock_phase);
+        shock_fade *= shock_fade;
+        col += vec3(1.0, 1.0, 1.2) * shock_ring * shock_fade * shock_trigger * 1.4;
+    }
+    // VJ WATER POOL — bottom-third reflective pool ripples in dark/deep phases
+    {
+        float pool_on = smoothstep(0.25, 0.05, spectralCentroidNormalized);
+        if (pool_on > 0.02 && uv.y < -0.15) {
+            // Reflect uv: below waterline, sample mirrored above + gentle ripple
+            float depth = clamp(-uv.y - 0.15, 0.0, 0.6);
+            float ripple_x = sin(uv.x * 10.0 + time * 1.2) * 0.006 * (1.0 + bassNormalized);
+            float ripple_y = sin(uv.x * 6.0 - time * 0.8) * 0.004;
+            vec2 refl_uv = fb_uv;
+            refl_uv.y = 0.5 - (fb_uv.y - 0.5) - 0.05;
+            refl_uv.x += ripple_x;
+            refl_uv.y += ripple_y;
+            vec3 pool = getLastFrameColor(refl_uv).rgb;
+            pool *= vec3(0.4, 0.7, 0.8); // teal tint
+            float pool_fade = smoothstep(0.0, 0.45, depth);
+            col = mix(col, pool, pool_on * pool_fade * 0.65);
+        }
+    }
+    // VJ VOLUMETRIC BEAMS — light shafts radiating from upper backlight through silhouette gaps
+    {
+        float beams_on = clamp((spectralCentroidNormalized - 0.4) * 2.0, 0.0, 1.0);
+        beams_on *= clamp(energyNormalized * 1.5, 0.0, 1.0);
+        if (beams_on > 0.02) {
+            vec2 light_origin = vec2(0.3, 0.9);
+            vec2 to_origin = light_origin - uv;
+            float beam_a = atan(to_origin.y, to_origin.x);
+            float beam = 0.5 + 0.5 * sin(beam_a * 30.0 + time * 0.3);
+            beam = pow(beam, 8.0);
+            float dist_fade = 1.0 - smoothstep(0.2, 1.4, length(to_origin));
+            float sil_mask = 1.0 - silhouette;
+            vec3 beam_col = vec3(0.95, 0.85, 0.55);
+            col += beam_col * beam * dist_fade * sil_mask * beams_on * 0.45;
+        }
+    }
+    // VJ GROUND QUAKE — concentric amber rings from floor, bass-driven, multiple wavefronts
+    {
+        float quake_on = clamp(bassNormalized - 0.3, 0.0, 1.0);
+        quake_on *= smoothstep(0.5, 0.15, spectralCentroidNormalized);
+        if (quake_on > 0.02) {
+            vec2 feet_c = vec2(0.0, -0.6);
+            vec2 dvec = uv - feet_c;
+            // Squash vertically so rings look like ground waves (elliptical)
+            dvec.y *= 2.0;
+            float r = length(dvec);
+            float wavefronts = 0.0;
+            for (int wi = 0; wi < 3; wi++) {
+                float wf = float(wi);
+                float ring_r = fract(time * 0.6 + wf * 0.33) * 1.2;
+                float dr = r - ring_r;
+                float w = exp(-dr * dr * 90.0);
+                float fade = 1.0 - ring_r / 1.2;
+                wavefronts += w * fade;
+            }
+            vec3 quake_col = mix(vec3(1.0, 0.35, 0.08), vec3(1.0, 0.75, 0.3), bassNormalized);
+            col += quake_col * wavefronts * quake_on * 0.55;
+        }
+    }
+    // VJ DISSOLUTION — character sheds drifting particles upward on bright high-treble phases
+    {
+        float dissolve = clamp(trebleNormalized - 0.3, 0.0, 1.0);
+        dissolve *= clamp(spectralCentroidNormalized - 0.5, 0.0, 1.0) * 2.0;
+        if (dissolve > 0.02) {
+            vec2 pp = uv * vec2(12.0, 8.0) + vec2(sin(time * 0.3) * 0.3, time * -0.8);
+            vec2 pcell = floor(pp);
+            vec2 pfrac = fract(pp) - 0.5;
+            float ph = hash(pcell);
+            float alive = step(0.82, ph);
+            float pd = length(pfrac * vec2(2.5, 1.2));
+            float particle = exp(-pd * pd * 25.0) * alive;
+            float near_sil = smoothstep(0.0, 0.15, silhouette) * (1.0 - silhouette);
+            vec3 particle_col = mix(vec3(0.9, 0.95, 1.0), vec3(1.0, 0.85, 0.6), hash(pcell + vec2(1.1, 3.3)));
+            col += particle_col * particle * near_sil * dissolve * 1.2;
+        }
+    }
+    // VJ HYPERSPACE — radial streaks rushing outward from head on mid-high energy
+    {
+        float hyper_on = clamp(energyNormalized - 0.3, 0.0, 1.0);
+        hyper_on *= clamp(trebleNormalized - 0.2, 0.0, 1.0) * 1.8;
+        if (hyper_on > 0.02) {
+            vec2 hp2 = uv - P.head_c;
+            float hr = length(hp2);
+            float ha = atan(hp2.y, hp2.x);
+            // Streak density — high angular frequency for hyperspace feel
+            float streaks = 0.5 + 0.5 * sin(ha * 48.0 + hash(vec2(floor(ha * 8.0), 0.0)) * 6.28);
+            streaks = pow(streaks, 6.0);
+            // Animate outward: faster toward center
+            float flow = fract(hr * 2.0 - time * 1.2);
+            float streak_life = 1.0 - flow;
+            streak_life = streak_life * streak_life;
+            // Mask: fade near the silhouette and at screen edge
+            float mask = smoothstep(0.18, 0.35, hr) * (1.0 - smoothstep(0.9, 1.3, hr));
+            vec3 streak_col = mix(vec3(0.6, 0.7, 1.0), vec3(1.0, 0.9, 0.7), trebleNormalized);
+            col += streak_col * streaks * streak_life * mask * hyper_on * 0.55;
+        }
+    }
+    // VJ SEARCHLIGHT — rotating police-style beam, red/blue alternating on bass
+    {
+        float search_on = clamp(midsNormalized - 0.2, 0.0, 1.0);
+        if (search_on > 0.02) {
+            // Beam anchored above the frame, sweeps angle
+            vec2 origin = vec2(sin(time * 0.7) * 0.5, 1.1);
+            vec2 to_pix = uv - origin;
+            float beam_a = atan(to_pix.y, to_pix.x);
+            // Beam target angle (rotates)
+            float target_a = -PI * 0.5 + sin(time * 1.1) * 0.45;
+            float beam_width = 0.12;
+            float beam = smoothstep(beam_width, 0.0, abs(beam_a - target_a));
+            beam *= smoothstep(0.0, 0.3, length(to_pix));
+            beam *= 1.0 - smoothstep(0.8, 1.3, length(to_pix));
+            // Alternate red/blue every half-cycle
+            float flash = step(0.0, sin(time * 2.5 + clamp(bassZScore, 0.0, 2.0) * 4.0));
+            vec3 beam_col = mix(vec3(0.2, 0.4, 1.0), vec3(1.0, 0.2, 0.3), flash);
+            col += beam_col * beam * search_on * 0.7;
+        }
+    }
+    col *= 1.0 - smoothstep(0.7, 1.4, length(uv * vec2(1.0, 0.85)));
+
+#if DEBUG_OUTLINES
+    col *= 0.25;
+    float body_outline = smoothstep(0.003, 0.0, abs(d_body));
+    float coat_outline = smoothstep(0.003, 0.0, abs(d_coat));
+    col += body_outline * vec3(0.0, 1.0, 1.0);
+    col += coat_outline * vec3(1.0, 1.0, 0.0);
+#endif
+
+    // VJ FLUX HUE DRIFT — sustained spectral flux slowly rotates overall hue
+    {
+        float drift = clamp(spectralFluxNormalized - 0.15, 0.0, 0.7) * 0.18;
+        if (drift > 0.005) {
+            vec3 hsl_col = rgb2hsl(col);
+            hsl_col.x = fract(hsl_col.x + drift);
+            col = hsl2rgb(hsl_col);
+        }
+    }
+    fragColor = vec4(clamp(col, 0.0, 1.0), 1.0);
+}

--- a/shaders/redaphid/wip/the-coat-fur-coat/the-coat-8.md
+++ b/shaders/redaphid/wip/the-coat-fur-coat/the-coat-8.md
@@ -1,0 +1,30 @@
+# the-coat-8
+
+Forked from `the-coat-7.frag` at `/vj` iter 45. Confetti block removed.
+
+## Changes vs the-coat-7
+
+- **Removed** `VJ CONFETTI` block (falling spinning pitch-colored squares, gated `treble > 0.35 AND entropy > 0.5`). User request mid-session.
+
+## Known issue carried over from the-coat-7
+
+**Mercury-flow diamond lattice** on the coat — the `VJ MERCURY FLOW` block creates a diamond-cell pattern from `sin(uv.x * 18 + sin(uv.y * 4 + flow_t) * 2.5 - flow_t * 2)` that scrolls fast during bass-heavy low-centroid phases. Coat-silhouette-gated, so always visible when the gate fires. Next fix.
+
+## Baked knob state at fork time
+
+| Knob | Value | Role |
+|---|---|---|
+| knob_1 | 0 | zoom (wide) |
+| knob_2 | 0.85 | nebula fog density |
+| knob_3 | 1.0 | god rays (max) |
+| knob_4 | 0.362 | eye wash |
+| knob_5 | 0.622 | drop zoom |
+| knob_7 | 1 | fur thickness |
+
+## Preset URL
+
+`?shader=redaphid/wip/the-coat-fur-coat/the-coat-8&controller=the-coat&knob_1=0&knob_2=0.85&knob_3=1&knob_4=0.362&knob_5=0.622&knob_6=0&knob_7=1&knob_8=0&knob_9=0&knob_10=0&knob_11=0`
+
+## Music during fork
+
+*Watch Me – Scorsi*.

--- a/src/worker-communication.js
+++ b/src/worker-communication.js
@@ -27,9 +27,10 @@ const RELOAD_GRACE = 5000
 
 const processServiceWorkerMessage = (event) => {
   if (event.data === 'reload') {
-      // The editor page handles shader updates via HMR — don't full-reload
+      // The editor and jam pages handle shader updates via HMR — don't full-reload
       // when the service worker detects a .frag file changed on disk.
       if (window.location.pathname.includes('edit')) return
+      if (window.location.pathname.includes('jam')) return
       if (reloadTimeout) return
       const lastReload = parseInt(sessionStorage.getItem('sw-last-reload') || '0')
       if (Date.now() - lastReload < RELOAD_GRACE) return

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,19 +5,11 @@ import { shaderPlugin } from './vite-plugins/shader-plugin.js'
 import { remoteWsPlugin } from './vite-plugins/remote-ws-plugin.js'
 import { editorSyncPlugin } from './vite-plugins/editor-sync-plugin.js'
 
-
-const branchToPort = (branch) => {
-  if (branch === 'main') return 6969
-  let hash = 0
-  for (const ch of branch) hash = ((hash << 5) - hash + ch.charCodeAt(0)) | 0
-  return 1024 + (Math.abs(hash) % 64511) // 1024–65534
-}
-
-const gitBranch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim()
+const port = parseInt(execSync('./scripts/dev-port', { encoding: 'utf-8' }))
 
 export default defineConfig({
   server: {
-    port: parseInt(process.env.PORT) || branchToPort(gitBranch),
+    port,
     host: '0.0.0.0',
     allowedHosts: true,
     watch: {


### PR DESCRIPTION
## Summary

Makes the `/vj` skill actually work end-to-end during a live jam, with 47 iterations run across `the-coat-3 → -5 → -6 → -7 → -8` while the skill itself was debugged and improved.

**Infrastructure**
- `scripts/dev-port` (shell wrapper) + `scripts/dev-port.js` (library with `branchToPort` / `getPort`, CLI-detection via `import.meta.url`) — single source of truth for the branch-derived dev server port. Vite config shells out to the wrapper (esbuild chokes on the shebang when inlining the library).
- `src/worker-communication.js` now excludes `jam.html` from the service-worker hard-reload path (it already excluded `edit.html`). This was the #1 flow-killer during `/vj` runs — page reloads were wiping tab audio capture every few minutes.

**Skills**
- `.claude/skills/vj/SKILL.md`: rewritten. No more hardcoded `:6969`. Drops the broken `ls .claude/scheduled_tasks.json` context probe. Stateful ticks via `.claude/vj-state.json` (job ID, iteration counter, knob snapshot, unwired-knob tracking, moveStyle). **Pre-save GL validation**: each tick wraps the edited shader with `shader-transformers/shader-wrapper.js`, compiles it in a throwaway WebGL2 context (`window.__vjValidate`), only POSTs to `/__save-shader` if `COMPILE_STATUS` passes — broken edits never reach HMR. **Accepts shader-path argument**: `/vj`, `/vj 60`, `/vj <path>`, `/vj 60 <name>`, `/vj stop`, `/vj tick`. **Per-shader journal as resume-state**: `journals/<shader-name>-cool-moments.md` with Status / Cool moments / Todo / History of changes / Forks / Design hypotheses sections. Skill reads the journal at setup and before dramatic moves so future sessions pick up with full context (what worked, what the user rejected, what's still open). Writes on cool moments, user flags, removals, and forks.
- `.claude/skills/remap/SKILL.md`: new `/remap` skill to clear `localStorage['cranes-midi-profiles']` so MIDI CC auto-assign starts fresh.

**Shaders**
- `the-coat-3.frag`: accumulated 30+ VJ motifs during the run.
- `the-coat-5 / -6 / -7 / -8` + `.md` companions: forks at meaningful session moments, each capturing baked knob state and motif lineage. the-coat-8 is the current head (RGB-split, tearfall, lightning, scan-line, crystalline-facet, infinity-mirror, confetti removed per user feedback; mercury-flow diamond artifact replaced with fbm-based flow).

**Journals**
- `journals/the-coat-6-cool-moments.md`, `the-coat-8-cool-moments.md`: capture the research that should feed the next shader — audio fingerprints that produced wins, hypotheses for what v(next) should do differently, removals-with-reasons so vetoed effects don't get re-added.
- `journals/2026-04-22-vj-skill-ergonomics.md`: notes on what broke flow and what to build next.

## Test plan

- [ ] `npm run dev` starts on the branch-derived port without hardcoded 6969
- [ ] `./scripts/dev-port` prints the same port the server binds to; `PORT=X ./scripts/dev-port` echoes X
- [ ] Open `/jam.html?shader=redaphid/wip/the-coat-fur-coat/the-coat-8&controller=the-coat`; edit the file on disk → HMR swaps, no full reload, tab audio survives
- [ ] `/remap` reports current device mappings, clears them, reloads
- [ ] `/vj <shader-name>` resolves the shader by name and runs 180 iters
- [ ] `/vj tick` on a stale state (different shader than current URL) picks up from state file
- [ ] Attempt a deliberate bad edit (undeclared var) → pre-save validator catches it, disk unchanged, renderer continues compiling the previous version
- [ ] `/vj` with an existing per-shader journal reads it during setup and doesn't re-add effects listed in "History of changes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)