### PR TITLE
Add /midi.html visual MIDI mapping page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ Controllers are JavaScript modules (`controllers/*.js`) that run once per frame 
 ### Available Knobs
 - `knob_1` through `knob_200` — all are available as float uniforms (0-1 range)
 - Set via URL query params (e.g., `?knob_1=0.5`), MIDI controllers, or the ParamsManager API
-- MIDI controllers auto-map CCs to knobs with per-device profiles persisted in localStorage. See [docs/midi-mapping.md](docs/midi-mapping.md)
+- MIDI controllers auto-map CCs to knobs with per-device profiles persisted in localStorage. Manage mappings visually at `/midi.html`. See [docs/midi-mapping.md](docs/midi-mapping.md)
 
 ### The #define Swap Pattern (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## What's New
 
+- **[MIDI mapping page](docs/midi-mapping.md#mapping-page-midihtml)** — Visual `/midi.html` UI: see every device + mapping at once, click-to-learn knobs, edit indices inline
 - **[Jam page](docs/jam-page.md)** — Lean live session page: fullscreen shader + knob drawer + spacebar snapshot queue. No editor overhead.
 - **[Multiplayer editor](docs/multiplayer-editor.md)** — Edit shaders together with live cursors and real-time sync
 - **[Tab audio capture](docs/tab-audio.md)** — Visualize Spotify or any browser tab with `?audio=tab`, no drivers needed
 - **[Editor-filesystem sync](docs/editor-filesystem-sync.md)** — Ctrl+S writes to disk, external edits push back to the browser
-- **[MIDI controller profiles](docs/midi-mapping.md)** — Plug in a controller, knobs auto-map and persist per device
 
 See the full [changelog](docs/CHANGELOG.md) for more.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable non-shader feature changes to this project will be documented in this file.
 
+## 2026-04-30
+
+### Features
+
+- **[MIDI mapping page (`/midi.html`)](midi-mapping.md#mapping-page-midihtml)** — Dedicated visual UI for managing controller mappings: device list, live CC→knob table with inline knob-index editing, and a knob grid you click to learn-bind the next incoming CC. Replaces the per-knob learn flow buried in the editor. ([#121](https://github.com/loqwai/paper-cranes/pull/121))
+
 ## 2026-04-25
 
 ### Features

--- a/docs/midi-mapping.md
+++ b/docs/midi-mapping.md
@@ -2,6 +2,16 @@
 
 Physical MIDI controllers (knobs, sliders, buttons) can drive shader parameters in real time. The system auto-maps MIDI CC messages to `knob_1`–`knob_200` uniforms and persists profiles per device in `localStorage`.
 
+## Mapping Page (`/midi.html`)
+
+Open `/midi.html` to manage mappings visually. Three columns:
+
+- **Devices** — every profile in `localStorage`, with a green dot for any device sending CCs in the current session
+- **CC → Knob** — every mapping for the selected device. Edit the knob index inline, watch live value bars when CCs fire, click `×` to unmap
+- **Knobs** — `knob_1`..`knob_N` grid. Click a tile to learn-bind: the next CC from any controller maps to that knob, replacing any prior mapping
+
+Mappings persist to the same `cranes-midi-profiles` localStorage key the rest of the app reads, so changes apply on the next shader page load.
+
 ## Auto-Assignment
 
 Plug in a MIDI controller and turn a knob. The first CC message from a new device gets assigned to `knob_1`, the second to `knob_2`, etc. Assignments persist across page reloads via `localStorage` under the key `cranes-midi-profiles`.
@@ -10,7 +20,7 @@ Plug in a MIDI controller and turn a knob. The first CC message from a new devic
 
 To map a specific MIDI CC to a specific knob index:
 
-1. Enter learn mode for the target knob (via the editor's knob UI)
+1. Enter learn mode for the target knob (via `/midi.html` or the editor's knob UI)
 2. Move the physical knob/slider on your controller
 3. The CC is mapped to that knob index, replacing any previous mapping
 

--- a/midi.html
+++ b/midi.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <title>Paper Cranes - MIDI Mapping</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: system-ui, sans-serif;
+      background: #0a0a0a;
+      color: #eee;
+      min-height: 100vh;
+      padding: 16px;
+    }
+
+    h1 { font-size: 18px; font-weight: 500; margin-bottom: 12px; }
+    h2 { font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #888; margin-bottom: 8px; }
+
+    .layout {
+      display: grid;
+      grid-template-columns: 220px 1fr 1fr;
+      gap: 16px;
+      height: calc(100vh - 80px);
+    }
+
+    .panel {
+      background: #151515;
+      border: 1px solid #222;
+      border-radius: 6px;
+      padding: 12px;
+      overflow-y: auto;
+    }
+
+    .device { padding: 8px 10px; border-radius: 4px; cursor: pointer; font-size: 13px; margin-bottom: 4px; border: 1px solid transparent; }
+    .device:hover { background: #1f1f1f; }
+    .device.active { background: #2a3a4a; border-color: #4a7aaa; }
+    .device.live::after { content: ' ●'; color: #4a4; }
+    .device .meta { color: #777; font-size: 11px; margin-top: 2px; }
+
+    .empty { color: #666; font-size: 13px; padding: 12px; text-align: center; }
+
+    .row {
+      display: grid;
+      grid-template-columns: 1fr 90px 60px 28px;
+      gap: 8px;
+      align-items: center;
+      padding: 6px 8px;
+      border-radius: 4px;
+      font-size: 13px;
+      margin-bottom: 2px;
+      transition: background 100ms;
+    }
+    .row:hover { background: #1c1c1c; }
+    .row.flash { background: #2d4030; }
+    .row .cc { font-family: ui-monospace, monospace; color: #ccc; }
+    .row .knob-input {
+      background: #0a0a0a;
+      border: 1px solid #333;
+      color: #eee;
+      padding: 3px 6px;
+      border-radius: 3px;
+      font-family: ui-monospace, monospace;
+      width: 100%;
+    }
+    .row .knob-input:focus { outline: none; border-color: #4a7aaa; }
+    .bar {
+      height: 6px;
+      background: #222;
+      border-radius: 3px;
+      overflow: hidden;
+      position: relative;
+    }
+    .bar-fill {
+      position: absolute;
+      left: 0; top: 0; bottom: 0;
+      background: linear-gradient(90deg, #4a7aaa, #7aa);
+      width: 0%;
+      transition: width 60ms linear;
+    }
+    .unmap {
+      background: none;
+      border: 1px solid #333;
+      color: #888;
+      width: 24px; height: 24px;
+      border-radius: 3px;
+      cursor: pointer;
+      font-size: 14px;
+      line-height: 1;
+    }
+    .unmap:hover { background: #3a1a1a; border-color: #6a3a3a; color: #faa; }
+
+    .knob-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+      gap: 6px;
+    }
+    .knob {
+      background: #0e0e0e;
+      border: 1px solid #2a2a2a;
+      border-radius: 4px;
+      padding: 8px 6px;
+      cursor: pointer;
+      text-align: center;
+      transition: all 100ms;
+    }
+    .knob:hover { border-color: #4a4a4a; }
+    .knob.mapped { border-color: #2a4a3a; }
+    .knob.learning {
+      border-color: #faa;
+      background: #2a1a1a;
+      animation: pulse 1s ease-in-out infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.6; }
+    }
+    .knob .idx { font-family: ui-monospace, monospace; font-size: 12px; color: #aaa; }
+    .knob .cc-label { font-family: ui-monospace, monospace; font-size: 10px; color: #6a8; margin-top: 4px; min-height: 12px; }
+    .knob .knob-bar { margin-top: 6px; }
+
+    .toolbar { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; }
+    .status { font-size: 12px; color: #888; }
+    .hint { font-size: 12px; color: #666; margin-bottom: 8px; font-style: italic; }
+  </style>
+</head>
+
+<body>
+  <h1>MIDI Mapping</h1>
+  <div class="toolbar">
+    <span class="status" id="status">Requesting MIDI access…</span>
+  </div>
+  <div class="layout">
+    <div class="panel">
+      <h2>Devices</h2>
+      <div id="devices"></div>
+    </div>
+    <div class="panel">
+      <h2>CC → Knob</h2>
+      <div class="hint">Edit the knob index inline. Wiggle a knob on your controller to auto-add it.</div>
+      <div id="mappings"></div>
+    </div>
+    <div class="panel">
+      <h2>Knobs</h2>
+      <div class="hint">Click a knob, then move a control on your MIDI device to bind it.</div>
+      <div id="knobs" class="knob-grid"></div>
+    </div>
+  </div>
+  <script type="module" src="./src/midi-mapping-page.js"></script>
+</body>
+
+</html>

--- a/src/midi-mapping-page.js
+++ b/src/midi-mapping-page.js
@@ -1,0 +1,263 @@
+import { createMidiMapper } from './midi/MidiMapper.js'
+
+const STORAGE_KEY = 'cranes-midi-profiles'
+const KNOB_GRID_SIZE = 32
+
+const mapper = createMidiMapper()
+
+const state = {
+  selectedDevice: null,
+  liveDevices: new Set(),
+  lastValues: {},
+  flashUntil: {},
+  learningIdx: null,
+}
+
+const els = {
+  status: document.getElementById('status'),
+  devices: document.getElementById('devices'),
+  mappings: document.getElementById('mappings'),
+  knobs: document.getElementById('knobs'),
+}
+
+const parseCCKey = (key) => {
+  const [cc, channel] = key.split('_')
+  return { cc: Number(cc), channel: channel ? Number(channel) : 1 }
+}
+
+const persist = () => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 1, profiles: mapper.getAllProfiles() }))
+}
+
+const ensureSelectedDevice = () => {
+  const names = Object.keys(mapper.getAllProfiles())
+  if (state.selectedDevice && !names.includes(state.selectedDevice)) state.selectedDevice = null
+  if (!state.selectedDevice && names.length > 0) state.selectedDevice = names[0]
+}
+
+const renderDevices = () => {
+  const profiles = mapper.getAllProfiles()
+  const names = Object.keys(profiles)
+
+  if (names.length === 0) {
+    els.devices.innerHTML = '<div class="empty">No devices yet.<br>Plug one in and wiggle a knob.</div>'
+    return
+  }
+
+  els.devices.innerHTML = ''
+  for (const name of names) {
+    const profile = profiles[name]
+    const count = Object.keys(profile.mappings).length
+    const div = document.createElement('div')
+    div.className = 'device'
+    if (name === state.selectedDevice) div.classList.add('active')
+    if (state.liveDevices.has(name)) div.classList.add('live')
+    div.dataset.device = name
+    div.innerHTML = `<div>${name}</div><div class="meta">${count} mapping${count === 1 ? '' : 's'}</div>`
+    div.addEventListener('click', () => {
+      state.selectedDevice = name
+      renderStructure()
+    })
+    els.devices.appendChild(div)
+  }
+}
+
+const renderMappings = () => {
+  const device = state.selectedDevice
+  if (!device) {
+    els.mappings.innerHTML = '<div class="empty">Select a device.</div>'
+    return
+  }
+  const profile = mapper.getProfile(device)
+  const entries = profile ? Object.entries(profile.mappings) : []
+  if (entries.length === 0) {
+    els.mappings.innerHTML = '<div class="empty">No mappings yet. Wiggle a knob on the device.</div>'
+    return
+  }
+  entries.sort((a, b) => a[1] - b[1])
+
+  els.mappings.innerHTML = ''
+  for (const [ccKey, knobIndex] of entries) {
+    const { cc, channel } = parseCCKey(ccKey)
+
+    const row = document.createElement('div')
+    row.className = 'row'
+    row.dataset.cckey = ccKey
+    row.innerHTML = `
+      <div class="cc">CC ${cc}${channel !== 1 ? ` ch${channel}` : ''}</div>
+      <input class="knob-input" type="number" min="1" max="200" value="${knobIndex}" />
+      <div class="bar"><div class="bar-fill"></div></div>
+      <button class="unmap" title="Remove mapping">×</button>
+    `
+    const input = row.querySelector('.knob-input')
+    input.addEventListener('change', () => {
+      const newIndex = parseInt(input.value, 10)
+      if (!Number.isFinite(newIndex) || newIndex < 1) {
+        input.value = knobIndex
+        return
+      }
+      remapCC(device, ccKey, newIndex)
+    })
+    row.querySelector('.unmap').addEventListener('click', () => {
+      unmapCC(device, ccKey)
+    })
+    els.mappings.appendChild(row)
+  }
+}
+
+const renderKnobs = () => {
+  const device = state.selectedDevice
+  const profile = device ? mapper.getProfile(device) : null
+  const knobToCC = {}
+  if (profile) {
+    for (const [ccKey, idx] of Object.entries(profile.mappings)) {
+      knobToCC[idx] = ccKey
+    }
+  }
+
+  const maxIdx = Math.max(KNOB_GRID_SIZE, ...Object.keys(knobToCC).map(Number))
+
+  els.knobs.innerHTML = ''
+  for (let i = 1; i <= maxIdx; i++) {
+    const ccKey = knobToCC[i]
+    const tile = document.createElement('div')
+    tile.className = 'knob'
+    if (ccKey) tile.classList.add('mapped')
+    if (state.learningIdx === i) tile.classList.add('learning')
+    tile.dataset.idx = String(i)
+    if (ccKey) tile.dataset.cckey = ccKey
+
+    const ccLabel = ccKey ? `CC ${parseCCKey(ccKey).cc}` : '—'
+    const label = state.learningIdx === i ? 'learning…' : ccLabel
+
+    tile.innerHTML = `
+      <div class="idx">knob_${i}</div>
+      <div class="cc-label">${label}</div>
+      <div class="bar knob-bar"><div class="bar-fill"></div></div>
+    `
+    tile.addEventListener('click', () => startLearn(i))
+    els.knobs.appendChild(tile)
+  }
+}
+
+const renderStructure = () => {
+  ensureSelectedDevice()
+  renderDevices()
+  renderMappings()
+  renderKnobs()
+}
+
+const updateLive = () => {
+  const device = state.selectedDevice
+  if (!device) return
+  const now = performance.now()
+
+  els.mappings.querySelectorAll('.row').forEach((row) => {
+    const ccKey = row.dataset.cckey
+    const value = state.lastValues[`${device}|${ccKey}`] ?? 0
+    const fill = row.querySelector('.bar-fill')
+    fill.style.width = `${(value / 127 * 100).toFixed(1)}%`
+    const flashing = (state.flashUntil[`${device}|${ccKey}`] ?? 0) > now
+    row.classList.toggle('flash', flashing)
+  })
+
+  els.knobs.querySelectorAll('.knob').forEach((tile) => {
+    const ccKey = tile.dataset.cckey
+    const value = ccKey ? (state.lastValues[`${device}|${ccKey}`] ?? 0) : 0
+    const fill = tile.querySelector('.bar-fill')
+    fill.style.width = `${(value / 127 * 100).toFixed(1)}%`
+  })
+}
+
+const remapCC = (device, ccKey, newIndex) => {
+  const profile = mapper.getProfile(device)
+  if (!profile) return
+  for (const [k, v] of Object.entries(profile.mappings)) {
+    if (v === newIndex) delete profile.mappings[k]
+  }
+  profile.mappings[ccKey] = newIndex
+  profile.updatedAt = new Date().toISOString()
+  persist()
+  renderStructure()
+}
+
+const unmapCC = (device, ccKey) => {
+  const profile = mapper.getProfile(device)
+  if (!profile) return
+  delete profile.mappings[ccKey]
+  profile.updatedAt = new Date().toISOString()
+  persist()
+  renderStructure()
+}
+
+const startLearn = (knobIndex) => {
+  if (mapper.isLearning()) mapper.cancelLearn()
+  state.learningIdx = knobIndex
+  mapper.startLearn(knobIndex).then(() => {
+    state.learningIdx = null
+    renderStructure()
+  }).catch(() => {
+    state.learningIdx = null
+    renderStructure()
+  })
+  renderStructure()
+}
+
+const handleCC = (deviceName, cc, channel, value) => {
+  const wasNewDevice = !state.liveDevices.has(deviceName)
+  state.liveDevices.add(deviceName)
+  const ccKey = channel === 1 ? `${cc}` : `${cc}_${channel}`
+
+  state.lastValues[`${deviceName}|${ccKey}`] = value
+  state.flashUntil[`${deviceName}|${ccKey}`] = performance.now() + 200
+
+  const profileExisted = mapper.getProfile(deviceName) != null
+  const hadMapping = profileExisted && mapper.mapCCToKnob(deviceName, cc, channel) != null
+
+  if (mapper.isLearning()) {
+    mapper.handleLearnCC(deviceName, cc, channel)
+    renderStructure()
+    return
+  }
+
+  if (!hadMapping) {
+    mapper.autoAssign(deviceName, cc, channel)
+    renderStructure()
+    return
+  }
+
+  if (wasNewDevice) renderStructure()
+}
+
+const attachInput = (input) => {
+  input.addEventListener('midimessage', (message) => {
+    const [command, control, value] = message.data
+    const isCC = (command & 0xf0) === 0xb0
+    if (!isCC) return
+    const channel = (command & 0x0f) + 1
+    const deviceName = input.name || 'Unknown MIDI Device'
+    handleCC(deviceName, control, channel, value)
+  })
+}
+
+navigator.requestMIDIAccess().then((midiAccess) => {
+  const updateStatus = () => {
+    els.status.textContent = `MIDI ready · ${midiAccess.inputs.size} input${midiAccess.inputs.size === 1 ? '' : 's'} connected`
+  }
+  updateStatus()
+  midiAccess.inputs.forEach(attachInput)
+  midiAccess.addEventListener('statechange', (e) => {
+    if (e.port.type === 'input' && e.port.state === 'connected') attachInput(e.port)
+    updateStatus()
+  })
+}).catch((err) => {
+  els.status.textContent = `MIDI failed: ${err.message}`
+})
+
+renderStructure()
+
+const tick = () => {
+  updateLive()
+  requestAnimationFrame(tick)
+}
+requestAnimationFrame(tick)

--- a/vite.config.js
+++ b/vite.config.js
@@ -31,6 +31,7 @@ export default defineConfig({
         analyze: resolve(import.meta.dirname, 'analyze.html'),
         playlist: resolve(import.meta.dirname, 'playlist.html'),
         'nfc-writer': resolve(import.meta.dirname, 'nfc-writer.html'),
+        midi: resolve(import.meta.dirname, 'midi.html'),
       },
       output: {
         entryFileNames: 'assets/[name].js',


### PR DESCRIPTION
## Summary

A dedicated page at `/midi.html` for managing MIDI controller mappings without bouncing through the editor's per-knob learn flow.

- **Three-column layout** — Devices · CC→Knob mappings · Knob grid
- **Auto-assign** — wiggle a knob on a new device, it appears live and gets bound to the next free `knob_N`
- **Click-to-learn** — click any knob tile, the next CC binds to it (replaces existing mapping cleanly)
- **Inline edit** — change a CC's target knob index by typing into the number input
- **Unmap** — `×` button removes a single CC mapping
- **Live feedback** — value bars and flash highlights show incoming CCs in real time; only CSS is updated per-frame so the inline number input keeps focus while you type

Storage is the same `cranes-midi-profiles` localStorage entry the existing `createMidiMapper` already uses — no new persistence layer.

## Test plan

- [ ] Open `http://localhost:6969/midi.html`
- [ ] Plug in a MIDI controller, wiggle a knob → device appears in left column with a live indicator, mapping appears in middle column
- [ ] Wiggle other knobs → each one auto-assigns to the next `knob_N`
- [ ] Click a knob tile in the right column → it pulses red ("learning…")
- [ ] Move a CC on the controller → it binds to that knob, replacing any prior mapping
- [ ] Type a different number into a CC row's knob input + blur → mapping updates and any previous owner of that index is unmapped
- [ ] Click `×` on a row → that CC is unmapped
- [ ] Reload the page → all mappings persist
- [ ] Open a shader page in another tab while wiggling knobs → values still drive the shader (mapper is shared via localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)