### PR TITLE
Wavelet (DWT) multiresolution audio analysis — opt-in, alongside FFT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,7 @@ uniform float another;   // = 1.2
 - `remote` - Remote mode: `display` (receive commands) or `control` (send commands)
 - `audio=tab` - Capture audio from a browser tab instead of mic. Chrome/Edge only. See [docs/tab-audio.md](docs/tab-audio.md)
 - `audio_file=<url>` - Play a deterministic audio file through the analyzer. See [docs/audio-file-playback.md](docs/audio-file-playback.md)
+- `wavelet=true` - Enable opt-in wavelet (DWT) analysis alongside FFT. Adds `wavelet*` uniforms (octave bands, centroid/spread, bassHit trigger, FFT×wavelet combos). See [docs/wavelet-analysis.md](docs/wavelet-analysis.md)
 - `audio_time=<seconds>` - Start audio file playback at this offset (default: 0)
 - `time=<seconds>` - Hold time constant (useful for deterministic screenshots/testing)
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## What's New
 
+- **[Wavelet audio analysis](docs/wavelet-analysis.md)** — Opt-in `?wavelet=true` multiresolution DWT alongside the FFT: octave bands, brightness/complexity axes, and a sharp low-latency deep-bass drop trigger
 - **[MIDI mapping page](docs/midi-mapping.md#mapping-page-midihtml)** — Visual `/midi.html` UI: see every device + mapping at once, click-to-learn knobs, edit indices inline
 - **[Jam page](docs/jam-page.md)** — Lean live session page: fullscreen shader + knob drawer + spacebar snapshot queue. No editor overhead.
 - **[Multiplayer editor](docs/multiplayer-editor.md)** — Edit shaders together with live cursors and real-time sync
 - **[Tab audio capture](docs/tab-audio.md)** — Visualize Spotify or any browser tab with `?audio=tab`, no drivers needed
-- **[Editor-filesystem sync](docs/editor-filesystem-sync.md)** — Ctrl+S writes to disk, external edits push back to the browser
 
 See the full [changelog](docs/CHANGELOG.md) for more.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable non-shader feature changes to this project will be documented in this file.
 
+## 2026-06-07
+
+### Features
+
+- **[Wavelet (DWT) audio analysis](wavelet-analysis.md) (`?wavelet=true`)** — Opt-in multiresolution analysis running alongside the FFT pipeline. A Daubechies-4 wavelet transform gives octave bands at their own time resolution (smooth bass, sharp treble) for better deep-bass-drop detection and frequency-motion features. Bands are first-class features with the full 11 stat variations (`waveletBand0ZScore`, etc.), plus derived axes (`waveletCentroid`/`waveletSpread`/`waveletTilt`), a sharp `wavelet_bassHit` drop trigger, and FFT×wavelet combinations (`wavelet_punch`, `wavelet_confirmedDrop`). Uses a 128-sample sliding window for ~3ms-latency updates. ([#123](https://github.com/loqwai/paper-cranes/pull/123))
+
+### Developer Experience
+
+- **Headless wavelet feature harnesses** — `scripts/wavelet-harness2.mjs` and `scripts/wavelet-fft-cross.mjs` score audio features for animation quality and cross-domain independence from ffmpeg-decoded PCM, running the exact `createWaveletAnalyzer` that runs live. ([#123](https://github.com/loqwai/paper-cranes/pull/123))
+
 ## 2026-04-30
 
 ### Features

--- a/docs/wavelet-analysis.md
+++ b/docs/wavelet-analysis.md
@@ -1,0 +1,54 @@
+# Wavelet (DWT) Audio Analysis
+
+Opt-in multiresolution audio analysis that runs **alongside** the FFT pipeline. Enable with `?wavelet=true`.
+
+## Why
+
+A single-window FFT analyzes bass and treble at the *same* time resolution — wrong for music. A dyadic **Daubechies-4 DWT** gives octave bands, each at its own natural time resolution: bass updates smoothly, treble/transients update sharply. Better for deep-bass-drop detection (phone mics roll off below ~100Hz) and for frequency-motion features.
+
+## Enabling
+
+Append `?wavelet=true` to any visualization URL. Works with mic, `?audio=tab`, and `?audio_file=`. The wavelet features are then available as shader uniforms.
+
+## Features
+
+Wavelet bands are **first-class features** — each runs through the same statistics path as the FFT features, so it exposes the full 11 stat variations under the FFT naming convention (`waveletBand0`, `waveletBand0ZScore`, `waveletBand0Normalized`, `waveletBand0Slope`, …).
+
+| Uniform | Meaning |
+|---------|---------|
+| `waveletBand0..5` (+ stats) | Octave-band energy, low→high (band0 ≈ 43-86Hz deep bass → band5 ≈ 1.4-2.8kHz) |
+| `waveletBass` (+ stats) | Harmonic-weighted deep-bass energy (survives phone-mic rolloff) |
+| `waveletCentroid` (+ stats) | Spectral brightness — rises as pitch glides up |
+| `waveletSpread` (+ stats) | Spectral complexity — flat/noisy vs pure tone |
+| `waveletTilt` (+ stats) | Bass-vs-treble balance |
+| `wavelet_bassHit` | Sharp, un-smoothed deep-bass **drop trigger** |
+| `wavelet_punch` | **Combination**: fast wavelet bass onset + FFT bass level |
+| `wavelet_confirmedDrop` | **Combination**: wavelet hit lightly gated by FFT energy (fewer false drops) |
+
+### Choosing the right variant
+
+- **Raw / `Normalized`** → "where the frequency/level *is*" (shows pitch glides, sweeps, vibrato)
+- **`ZScore`** → "is this *unusual* right now" (punchy reactive hits, drops) — hides steady trends
+- **`Slope`** → "is it trending up or down"
+
+## Low latency
+
+The wavelet path uses a **128-sample sliding window** (analysis every ~3ms), independent of the FFT's larger window. The FFT×wavelet combinations lead with the fast wavelet component so they react on the wavelet timescale, not the FFT's ~85ms.
+
+## Diagnostic shaders
+
+`shaders/claude/wip/wavelet-scope/` contains scopes for inspecting the features: band meters, scrolling oscilloscopes, and the `independent` / `combined` tapestries. Load e.g. `?shader=claude/wip/wavelet-scope/independent&wavelet=true&audio=tab`.
+
+## Headless analysis
+
+`scripts/wavelet-harness2.mjs` and `scripts/wavelet-fft-cross.mjs` score features (animation quality + cross-domain independence) from ffmpeg-decoded PCM — the same `createWaveletAnalyzer` that runs live, so offline analysis matches the live pipeline.
+
+## Architecture
+
+```
+raw-tap-processor.js (AudioWorklet, sliding window)
+  → waveletWorker.js (thin shell)
+  → waveletAnalyzer.js (createWaveletAnalyzer — shared with the harness)
+  → dwt.js (pure D4 transform)
+  → window.cranes.waveletFeatures
+```

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ import { createAudioFileSource, initAudioFromFile } from './src/audio/audioFileS
 const maybeStartWavelet = async (params, audioContext, sourceNode) => {
     if (params.get('wavelet') !== 'true') return
     const { WaveletProcessor } = await import('./src/audio/WaveletProcessor.js')
-    const wavelet = new WaveletProcessor(audioContext, sourceNode)
+    const historySize = parseInt(params.get('history_size') ?? '500')
+    const wavelet = new WaveletProcessor(audioContext, sourceNode, historySize)
     await wavelet.start()
     window.cranes.waveletProcessor = wavelet
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,15 @@
 import { AudioProcessor } from './src/audio/AudioProcessor.js'
 import { createAudioFileSource, initAudioFromFile } from './src/audio/audioFileSource.js'
+
+// PROTOTYPE: opt-in multiresolution (wavelet) analysis alongside the FFT pipeline.
+// Gated behind ?wavelet=true. Starts a DWT processor on the same context/source.
+const maybeStartWavelet = async (params, audioContext, sourceNode) => {
+    if (params.get('wavelet') !== 'true') return
+    const { WaveletProcessor } = await import('./src/audio/WaveletProcessor.js')
+    const wavelet = new WaveletProcessor(audioContext, sourceNode)
+    await wavelet.start()
+    window.cranes.waveletProcessor = wavelet
+}
 import { makeVisualizer, askForWakeLock } from './src/Visualizer.js'
 import { getInitialShader } from './src/shaderLoader.js'
 
@@ -130,6 +140,7 @@ const setupAudio = async () => {
             await audioProcessor.start()
             // Route through speakers (unlike mic input, file playback has no feedback risk)
             audioProcessor.fftAnalyzer.connect(audioContext.destination)
+            await maybeStartWavelet(params, audioContext, sourceNode)
             return audioProcessor
         } catch (err) {
             console.error('Audio file initialization failed:', err)
@@ -162,6 +173,7 @@ const setupAudio = async () => {
         audioProcessor.smoothingFactor = smoothing;
         audioProcessor.start();
 
+        await maybeStartWavelet(params, audioContext, sourceNode);
         return audioProcessor;
     } catch (err) {
         console.error('Audio initialization failed:', err);
@@ -187,6 +199,7 @@ export const getCranesState = () => {
         seed3: s3,
         seed4: s4,
         ...window.cranes.measuredAudioFeatures, // Audio features (lowest precedence)
+        ...window.cranes.waveletFeatures,       // PROTOTYPE: wavelet band/onset features
         ...window.cranes.controllerFeatures,    // Controller-computed features
         ...parseUrlParams(params),              // URL parameters (parsed as numbers or strings)
         ...window.cranes.manualFeatures,        // Manual features
@@ -201,6 +214,7 @@ const setupCranesState = () => {
     window.cranes = {
         seeds: loadOrCreateSeeds(),
         measuredAudioFeatures: {},  // Audio features (lowest precedence)
+        waveletFeatures: {},        // PROTOTYPE: wavelet band/onset features
         controllerFeatures: {},     // Controller-computed features
         manualFeatures: {},         // Manual features
         messageParams: {},          // Message parameters (highest precedence)

--- a/public/raw-tap-processor.js
+++ b/public/raw-tap-processor.js
@@ -1,0 +1,41 @@
+// raw-tap-processor.js
+// Taps the raw time-domain audio signal (NO windowing) and ships fixed-size
+// frames to the main thread for wavelet analysis. Parallel to window-processor.js,
+// which applies a Hanning window for FFT — wavelets want the raw signal.
+//
+// A DWT needs a power-of-two length. The worklet's render quantum is 128 samples,
+// so we accumulate quanta into a FRAME_SIZE ring and emit a full frame whenever it fills.
+
+const FRAME_SIZE = 1024 // 2^10 — ~21ms at 48kHz. Enough depth for ~6-7 octave bands.
+
+class RawTapProcessor extends AudioWorkletProcessor {
+    constructor() {
+        super()
+        this.buffer = new Float32Array(FRAME_SIZE)
+        this.writePos = 0
+    }
+
+    process(inputs, outputs) {
+        const input = inputs[0]
+        if (!input || input.length === 0) return true
+
+        const channel = input[0] // mono — first channel only
+        const output = outputs[0]?.[0]
+
+        for (let i = 0; i < channel.length; i++) {
+            this.buffer[this.writePos++] = channel[i]
+            // Pass audio through untouched so downstream .connect(destination) still plays.
+            if (output) output[i] = channel[i]
+
+            if (this.writePos >= FRAME_SIZE) {
+                // Emit a copy — the buffer keeps filling for the next frame.
+                this.port.postMessage(this.buffer.slice(0))
+                this.writePos = 0
+            }
+        }
+
+        return true
+    }
+}
+
+registerProcessor('raw-tap-processor', RawTapProcessor)

--- a/public/raw-tap-processor.js
+++ b/public/raw-tap-processor.js
@@ -1,18 +1,34 @@
 // raw-tap-processor.js
-// Taps the raw time-domain audio signal (NO windowing) and ships fixed-size
-// frames to the main thread for wavelet analysis. Parallel to window-processor.js,
-// which applies a Hanning window for FFT — wavelets want the raw signal.
+// Taps the raw time-domain audio signal (NO windowing) and ships fixed-size, OVERLAPPING
+// frames to the main thread for wavelet analysis. Parallel to window-processor.js, which
+// applies a Hanning window for FFT — wavelets want the raw signal.
 //
-// A DWT needs a power-of-two length. The worklet's render quantum is 128 samples,
-// so we accumulate quanta into a FRAME_SIZE ring and emit a full frame whenever it fills.
+// A DWT needs a power-of-two length, so each emitted frame is FRAME_SIZE samples. But we
+// emit a fresh (overlapping) frame every HOP samples — a sliding window — so analysis
+// updates every ~HOP/sampleRate seconds (~3ms) instead of once per full frame (~21ms).
+// This is what gives the low latency, and it matches the offline harness exactly (same
+// FRAME/HOP), so live behavior equals what the harness measured.
 
 const FRAME_SIZE = 1024 // 2^10 — ~21ms at 48kHz. Enough depth for ~6-7 octave bands.
+const HOP = 128         // emit a new overlapping frame every HOP samples (= render quantum)
 
 class RawTapProcessor extends AudioWorkletProcessor {
     constructor() {
         super()
-        this.buffer = new Float32Array(FRAME_SIZE)
-        this.writePos = 0
+        this.buffer = new Float32Array(FRAME_SIZE) // ring of the most recent FRAME_SIZE samples
+        this.writePos = 0       // next write index into the ring
+        this.sinceEmit = 0      // samples accumulated since the last frame emit
+        this.primed = false     // true once the ring has been filled at least once
+    }
+
+    // Emit the most recent FRAME_SIZE samples in chronological order (unwrap the ring).
+    emitFrame() {
+        const frame = new Float32Array(FRAME_SIZE)
+        const start = this.writePos // oldest sample sits at writePos after a full wrap
+        for (let k = 0; k < FRAME_SIZE; k++) {
+            frame[k] = this.buffer[(start + k) % FRAME_SIZE]
+        }
+        this.port.postMessage(frame)
     }
 
     process(inputs, outputs) {
@@ -23,14 +39,16 @@ class RawTapProcessor extends AudioWorkletProcessor {
         const output = outputs[0]?.[0]
 
         for (let i = 0; i < channel.length; i++) {
-            this.buffer[this.writePos++] = channel[i]
+            this.buffer[this.writePos] = channel[i]
+            this.writePos = (this.writePos + 1) % FRAME_SIZE
+            if (this.writePos === 0) this.primed = true // completed a full wrap at least once
             // Pass audio through untouched so downstream .connect(destination) still plays.
             if (output) output[i] = channel[i]
 
-            if (this.writePos >= FRAME_SIZE) {
-                // Emit a copy — the buffer keeps filling for the next frame.
-                this.port.postMessage(this.buffer.slice(0))
-                this.writePos = 0
+            // Emit an overlapping frame every HOP samples, once the ring is primed.
+            if (++this.sinceEmit >= HOP) {
+                this.sinceEmit = 0
+                if (this.primed) this.emitFrame()
             }
         }
 

--- a/scripts/fft.mjs
+++ b/scripts/fft.mjs
@@ -1,0 +1,63 @@
+// fft.mjs — compact iterative radix-2 Cooley-Tukey FFT (no deps), plus a helper that
+// replicates the browser's AnalyserNode.getByteFrequencyData so headless hypnosound FFT
+// features match the live pipeline.
+
+// In-place FFT of real input → returns magnitude spectrum (length N/2).
+// re/im are scratch Float64Arrays of length N.
+export const magnitudeSpectrum = (frame) => {
+    const N = frame.length // must be power of two
+    const re = Float64Array.from(frame)
+    const im = new Float64Array(N)
+
+    // bit-reversal permutation
+    for (let i = 1, j = 0; i < N; i++) {
+        let bit = N >> 1
+        for (; j & bit; bit >>= 1) j ^= bit
+        j ^= bit
+        if (i < j) { const tr = re[i]; re[i] = re[j]; re[j] = tr; const ti = im[i]; im[i] = im[j]; im[j] = ti }
+    }
+    // butterflies
+    for (let len = 2; len <= N; len <<= 1) {
+        const ang = -2 * Math.PI / len
+        const wr = Math.cos(ang), wi = Math.sin(ang)
+        for (let i = 0; i < N; i += len) {
+            let cr = 1, ci = 0
+            for (let k = 0; k < len / 2; k++) {
+                const a = i + k, b = i + k + len / 2
+                const tr = re[b] * cr - im[b] * ci
+                const ti = re[b] * ci + im[b] * cr
+                re[b] = re[a] - tr; im[b] = im[a] - ti
+                re[a] += tr; im[a] += ti
+                const ncr = cr * wr - ci * wi; ci = cr * wi + ci * wr; cr = ncr
+            }
+        }
+    }
+    const half = N >> 1
+    const mag = new Float64Array(half)
+    for (let i = 0; i < half; i++) mag[i] = Math.sqrt(re[i] * re[i] + im[i] * im[i]) / N
+    return mag
+}
+
+// Replicate AnalyserNode.getByteFrequencyData:
+//   smoothing across frames, dB conversion, scale to 0..255 over [minDb, maxDb].
+export const makeByteFreq = ({ minDb = -100, maxDb = -30, smoothing = 0.4 } = {}) => {
+    let smoothed = null
+    return (mag) => {
+        if (!smoothed) smoothed = new Float64Array(mag.length)
+        const out = new Uint8Array(mag.length)
+        for (let i = 0; i < mag.length; i++) {
+            smoothed[i] = smoothing * smoothed[i] + (1 - smoothing) * mag[i]
+            const db = 20 * Math.log10(smoothed[i] + 1e-12)
+            let v = 255 * (db - minDb) / (maxDb - minDb)
+            out[i] = v < 0 ? 0 : v > 255 ? 255 : Math.round(v)
+        }
+        return out
+    }
+}
+
+// Hanning window (the browser applies one before the FFT via window-processor.js).
+export const hann = (N) => {
+    const w = new Float64Array(N)
+    for (let i = 0; i < N; i++) w[i] = 0.5 * (1 - Math.cos(2 * Math.PI * i / (N - 1)))
+    return w
+}

--- a/scripts/wavelet-fft-cross.mjs
+++ b/scripts/wavelet-fft-cross.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// wavelet-fft-cross.mjs — run BOTH the wavelet pipeline and the real hypnosound FFT
+// pipeline on the same frames, then measure cross-domain correlation to find:
+//   • INDEPENDENT wavelet↔FFT pairs → combine for MORE total visual variety
+//   • REDUNDANT pairs → fuse for ROBUSTNESS (two measures agreeing = confident)
+//   • candidate COMBINED features (products / gated confirmations)
+//
+// Usage: node scripts/wavelet-fft-cross.mjs sig.pcm [...]
+
+import { readFileSync } from 'fs'
+import { basename } from 'path'
+import { createWaveletAnalyzer } from '../src/audio/waveletAnalyzer.js'
+import { magnitudeSpectrum, makeByteFreq, hann } from './fft.mjs'
+import {
+    spectralCentroid, spectralFlux, spectralRolloff, spectralSpread,
+    spectralEntropy, spectralCrest, energy, bass, mids, treble, makeCalculateStats,
+} from 'hypnosound'
+
+const FRAME = 1024, HOP = 128, HISTORY = 500
+const FFT_SIZE = 4096 // browser default; we window+FFT a 4096 buffer for the FFT path
+
+const readPcm = (p) => { const b = readFileSync(p); return new Float32Array(b.buffer, b.byteOffset, Math.floor(b.byteLength / 4)) }
+
+// FFT analyzers we care about (the spectral-shape + band features).
+const FFT_FEATURES = {
+    spectralCentroid, spectralRolloff, spectralSpread, spectralEntropy, spectralCrest, energy, bass, mids, treble,
+}
+
+const hannWin = hann(FFT_SIZE)
+
+const runSignal = (samples) => {
+    const wav = createWaveletAnalyzer(HISTORY)
+    const toByte = makeByteFreq({ minDb: -100, maxDb: -30, smoothing: 0.4 })
+    // stats for each FFT feature (zScore etc.) — mirror the live pipeline
+    const fftStats = {}
+    for (const k of Object.keys(FFT_FEATURES)) fftStats[k] = makeCalculateStats(HISTORY)
+
+    const series = {}
+    const push = (k, v) => (series[k] ??= []).push(v)
+
+    const wbuf = new Float32Array(FRAME)       // wavelet window (1024)
+    const fbuf = new Float32Array(FFT_SIZE)     // fft window (4096)
+    let filled = 0, ffilled = 0
+    let prevByte = null
+
+    for (let pos = 0; pos + HOP <= samples.length; pos += HOP) {
+        // slide both windows by HOP
+        wbuf.copyWithin(0, HOP); wbuf.set(samples.subarray(pos, pos + HOP), FRAME - HOP)
+        fbuf.copyWithin(0, HOP); fbuf.set(samples.subarray(pos, pos + HOP), FFT_SIZE - HOP)
+        filled += HOP; ffilled += HOP
+        if (filled < FRAME || ffilled < FFT_SIZE) continue
+
+        // --- wavelet path ---
+        const w = wav.analyze(wbuf)
+        push('w_centroid', w.centroidStats.current)
+        push('w_spread', w.spreadStats.current)
+        push('w_band0Z', w.bandStats[0].zScore)
+        push('w_band3', w.bandStats[3].current)
+        push('w_band5Z', w.bandStats[5].zScore)
+        push('w_bassHit', w.bassHit)
+        push('w_bassZ', w.bassStats.zScore)
+
+        // --- FFT path (windowed 4096 → magnitude → byte-freq → analyzers) ---
+        const windowed = new Float32Array(FFT_SIZE)
+        for (let i = 0; i < FFT_SIZE; i++) windowed[i] = fbuf[i] * hannWin[i]
+        const mag = magnitudeSpectrum(windowed)
+        const byte = toByte(mag)
+        for (const [k, fn] of Object.entries(FFT_FEATURES)) {
+            const val = k === 'spectralFlux' ? fn(byte, prevByte) : fn(byte)
+            const st = fftStats[k](val)
+            push(`f_${k}`, st.current)
+            push(`f_${k}Z`, st.zScore)
+        }
+        prevByte = byte
+    }
+    return series
+}
+
+const files = process.argv.slice(2)
+if (!files.length) { console.error('usage: node wavelet-fft-cross.mjs sig.pcm [...]'); process.exit(1) }
+
+const agg = {}
+for (const f of files) {
+    const s = runSignal(readPcm(f))
+    for (const [k, v] of Object.entries(s)) (agg[k] ??= []).push(...v)
+}
+const nFrames = Object.values(agg)[0]?.length ?? 0
+console.log(`Cross-domain analysis: ${files.length} signals, ${nFrames} frames\n`)
+
+const mean = (xs) => xs.reduce((s, x) => s + x, 0) / xs.length
+const corr = (xs, ys) => { const mx = mean(xs), my = mean(ys); let n = 0, dx = 0, dy = 0; for (let i = 0; i < xs.length; i++) { const a = xs[i] - mx, b = ys[i] - my; n += a * b; dx += a * a; dy += b * b } const d = Math.sqrt(dx * dy); return d < 1e-12 ? 0 : n / d }
+
+const wKeys = Object.keys(agg).filter(k => k.startsWith('w_'))
+const fKeys = Object.keys(agg).filter(k => k.startsWith('f_'))
+
+// Cross-correlation matrix: wavelet (rows) × FFT (cols).
+console.log('=== CROSS-CORRELATION (wavelet rows × FFT cols) ===')
+process.stdout.write(''.padEnd(12))
+fKeys.forEach(k => process.stdout.write(k.replace('f_', '').slice(0, 8).padStart(9)))
+console.log()
+for (const w of wKeys) {
+    process.stdout.write(w.replace('w_', '').padEnd(12))
+    for (const f of fKeys) process.stdout.write(corr(agg[w], agg[f]).toFixed(2).padStart(9))
+    console.log()
+}
+
+// Highlight the most REDUNDANT (|r|>0.7, fuse for robustness) and most INDEPENDENT
+// (|r|<0.15, combine for variety) cross-domain pairs.
+const pairs = []
+for (const w of wKeys) for (const f of fKeys) pairs.push({ w, f, r: corr(agg[w], agg[f]) })
+console.log('\n=== REDUNDANT cross-domain pairs (|r|>0.7 — fuse for robust signals) ===')
+pairs.filter(p => Math.abs(p.r) > 0.7).sort((a, b) => Math.abs(b.r) - Math.abs(a.r)).slice(0, 10)
+    .forEach(p => console.log(`  ${p.w.padEnd(12)} ~ ${p.f.padEnd(16)} r=${p.r.toFixed(2)}`))
+console.log('\n=== INDEPENDENT cross-domain pairs (|r|<0.12 — combine for variety) ===')
+pairs.filter(p => Math.abs(p.r) < 0.12 && !p.w.includes('Hit')).sort((a, b) => Math.abs(a.r) - Math.abs(b.r)).slice(0, 12)
+    .forEach(p => console.log(`  ${p.w.padEnd(12)} ⊥ ${p.f.padEnd(16)} r=${p.r.toFixed(2)}`))

--- a/scripts/wavelet-harness.mjs
+++ b/scripts/wavelet-harness.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// wavelet-harness.mjs — headless analysis of the wavelet feature pipeline.
+//
+// Reads raw f32le mono @44100 PCM (from ffmpeg), runs the EXACT live analyzer
+// (createWaveletAnalyzer), collects each feature's time-series, then scores them for
+// animation quality (dynamics) and mutual independence (correlation matrix).
+//
+// Usage:
+//   ffmpeg -y -f lavfi -i "sine=frequency=60" -t 8 -ac 1 -ar 44100 -f f32le sig.pcm
+//   node scripts/wavelet-harness.mjs sig.pcm [moreSignals.pcm ...]
+//
+// The worklet emits a 1024-sample frame every 128 input samples (render quantum), so
+// we slide a 1024 window with hop 128 to mirror live timing.
+
+import { readFileSync } from 'fs'
+import { basename } from 'path'
+import { createWaveletAnalyzer } from '../src/audio/waveletAnalyzer.js'
+
+const FRAME = 1024
+const HOP = 128            // worklet render quantum
+const HISTORY = 500
+
+// Read f32le PCM into a Float32Array.
+const readPcm = (path) => {
+    const buf = readFileSync(path)
+    return new Float32Array(buf.buffer, buf.byteOffset, Math.floor(buf.byteLength / 4))
+}
+
+// Run the analyzer over a signal, return { feature -> number[] } time-series.
+// We flatten to the same feature names the live pipeline exposes.
+const STAT_SUFFIX = {
+    normalized: 'Normalized', mean: 'Mean', median: 'Median', min: 'Min', max: 'Max',
+    standardDeviation: 'StandardDeviation', zScore: 'ZScore', slope: 'Slope',
+    intercept: 'Intercept', rSquared: 'RSquared',
+}
+const flatten = (series, base, stats) => {
+    ;(series[base] ??= []).push(stats.current)
+    for (const [k, suf] of Object.entries(STAT_SUFFIX)) (series[`${base}${suf}`] ??= []).push(stats[k])
+}
+
+const runSignal = (samples) => {
+    const a = createWaveletAnalyzer(HISTORY)
+    const series = {}
+    const buf = new Float32Array(FRAME)
+    let filled = 0
+    for (let pos = 0; pos + HOP <= samples.length; pos += HOP) {
+        // slide window: shift left by HOP, append next HOP samples
+        buf.copyWithin(0, HOP)
+        buf.set(samples.subarray(pos, pos + HOP), FRAME - HOP)
+        filled += HOP
+        if (filled < FRAME) continue // wait until the window is full
+        const out = a.analyze(buf)
+        out.bandStats.slice(0, 6).forEach((s, i) => flatten(series, `waveletBand${i}`, s))
+        flatten(series, 'waveletBass', out.bassStats)
+        ;(series.wavelet_bassHit ??= []).push(out.bassHit)
+    }
+    return series
+}
+
+// ---- scoring ----
+const stddev = (xs) => {
+    const m = xs.reduce((s, x) => s + x, 0) / xs.length
+    return Math.sqrt(xs.reduce((s, x) => s + (x - m) * (x - m), 0) / xs.length)
+}
+const range = (xs) => Math.max(...xs) - Math.min(...xs)
+// liveliness: fraction of frames where the value moved meaningfully frame-to-frame
+const liveliness = (xs) => {
+    const sd = stddev(xs) || 1e-9
+    let moved = 0
+    for (let i = 1; i < xs.length; i++) if (Math.abs(xs[i] - xs[i - 1]) > sd * 0.05) moved++
+    return moved / (xs.length - 1)
+}
+// jitter: mean abs second-difference / range — high = noisy/spiky, low = smooth
+const jitter = (xs) => {
+    const r = range(xs) || 1e-9
+    let acc = 0
+    for (let i = 2; i < xs.length; i++) acc += Math.abs(xs[i] - 2 * xs[i - 1] + xs[i - 2])
+    return (acc / (xs.length - 2)) / r
+}
+const pearson = (xs, ys) => {
+    const n = xs.length
+    const mx = xs.reduce((s, x) => s + x, 0) / n
+    const my = ys.reduce((s, y) => s + y, 0) / n
+    let num = 0, dx = 0, dy = 0
+    for (let i = 0; i < n; i++) { const a = xs[i] - mx, b = ys[i] - my; num += a * b; dx += a * a; dy += b * b }
+    const d = Math.sqrt(dx * dy)
+    return d < 1e-12 ? 0 : num / d
+}
+
+const files = process.argv.slice(2)
+if (!files.length) { console.error('usage: node wavelet-harness.mjs sig.pcm [...]'); process.exit(1) }
+
+// Aggregate time-series across all signals (concatenate) so scores reflect variety.
+const agg = {}
+for (const f of files) {
+    const series = runSignal(readPcm(f))
+    for (const [k, v] of Object.entries(series)) (agg[k] ??= []).push(...v)
+    console.log(`  loaded ${basename(f)}: ${Object.values(series)[0]?.length ?? 0} frames`)
+}
+
+// Focus on the most animation-relevant stats: ZScore + Normalized of each band/bass.
+const FOCUS = Object.keys(agg).filter(k => /ZScore$|Normalized$/.test(k)).concat(['wavelet_bassHit'])
+
+console.log('\n=== ANIMATION QUALITY (per feature, across all signals) ===')
+console.log('feature'.padEnd(34), 'range'.padStart(8), 'lively'.padStart(8), 'jitter'.padStart(8), 'verdict')
+const scored = []
+for (const k of FOCUS) {
+    const xs = agg[k]; if (!xs || xs.length < 10) continue
+    const r = range(xs), L = liveliness(xs), J = jitter(xs)
+    // good animation line: decent range, moves often, but not too jittery
+    const good = r > 0.3 && L > 0.25 && J < 0.25
+    const verdict = good ? 'GOOD' : (J >= 0.25 ? 'noisy' : (L <= 0.25 ? 'static' : 'weak'))
+    scored.push({ k, r, L, J, good })
+    console.log(k.padEnd(34), r.toFixed(3).padStart(8), L.toFixed(3).padStart(8), J.toFixed(3).padStart(8), '', verdict)
+}
+
+console.log('\n=== INDEPENDENCE (|correlation| among GOOD features; lower = more independent) ===')
+const good = scored.filter(s => s.good).map(s => s.k)
+if (good.length < 2) { console.log('  (need >=2 good features)') }
+else {
+    process.stdout.write(''.padEnd(22))
+    good.forEach(k => process.stdout.write(k.replace('wavelet', 'w').slice(0, 10).padStart(11)))
+    console.log()
+    for (const a of good) {
+        process.stdout.write(a.replace('wavelet', 'w').slice(0, 20).padEnd(22))
+        for (const b of good) {
+            const c = Math.abs(pearson(agg[a], agg[b]))
+            process.stdout.write((a === b ? '—' : c.toFixed(2)).padStart(11))
+        }
+        console.log()
+    }
+    // suggest a maximally-independent quartet (greedy: pick lowest avg |corr|)
+    console.log('\n  Suggested independent set (greedy, |corr|<0.5 pairwise):')
+    const picked = []
+    for (const cand of good) {
+        if (picked.every(p => Math.abs(pearson(agg[cand], agg[p])) < 0.5)) picked.push(cand)
+        if (picked.length >= 5) break
+    }
+    picked.forEach(p => console.log('    •', p))
+}

--- a/scripts/wavelet-harness.mjs
+++ b/scripts/wavelet-harness.mjs
@@ -53,6 +53,23 @@ const runSignal = (samples) => {
         out.bandStats.slice(0, 6).forEach((s, i) => flatten(series, `waveletBand${i}`, s))
         flatten(series, 'waveletBass', out.bassStats)
         ;(series.wavelet_bassHit ??= []).push(out.bassHit)
+
+        // ---- DERIVED candidate features (might be more independent/musical) ----
+        const b = out.bandStats
+        const cur = (i) => b[i]?.current ?? 0
+        // spectral TILT: low-band vs high-band balance (bass-heavy → +, bright → -)
+        const lowE = cur(0) + cur(1) + cur(2)
+        const highE = cur(3) + cur(4) + cur(5)
+        ;(series.waveletTilt ??= []).push((lowE - highE) / (lowE + highE + 1e-6))
+        // spectral CENTROID-ish: energy-weighted band index, 0(bass)..5(treble)
+        let num = 0, den = 0
+        for (let i = 0; i < 6; i++) { num += i * cur(i); den += cur(i) }
+        ;(series.waveletCentroid ??= []).push(den > 1e-6 ? num / den / 5 : 0)
+        // spectral SPREAD: how many bands are active at once (flat vs peaky)
+        const total = den + 1e-6
+        let ent = 0
+        for (let i = 0; i < 6; i++) { const p = cur(i) / total; if (p > 1e-6) ent -= p * Math.log(p) }
+        ;(series.waveletSpread ??= []).push(ent / Math.log(6))
     }
     return series
 }
@@ -98,8 +115,13 @@ for (const f of files) {
     console.log(`  loaded ${basename(f)}: ${Object.values(series)[0]?.length ?? 0} frames`)
 }
 
-// Focus on the most animation-relevant stats: ZScore + Normalized of each band/bass.
-const FOCUS = Object.keys(agg).filter(k => /ZScore$|Normalized$/.test(k)).concat(['wavelet_bassHit'])
+// Animation-relevant: ZScore/Normalized/Slope of bands/bass, the bassHit, and the
+// derived tilt/centroid/spread features.
+const FOCUS = Object.keys(agg).filter(k =>
+    /ZScore$|Normalized$|Slope$/.test(k) ||
+    /^wavelet(Tilt|Centroid|Spread)$/.test(k) ||
+    k === 'wavelet_bassHit'
+)
 
 console.log('\n=== ANIMATION QUALITY (per feature, across all signals) ===')
 console.log('feature'.padEnd(34), 'range'.padStart(8), 'lively'.padStart(8), 'jitter'.padStart(8), 'verdict')
@@ -129,12 +151,18 @@ else {
         }
         console.log()
     }
-    // suggest a maximally-independent quartet (greedy: pick lowest avg |corr|)
-    console.log('\n  Suggested independent set (greedy, |corr|<0.5 pairwise):')
+    // Maximally-independent set: greedy by liveliness, reject candidates correlated
+    // (>THRESH) with anything already picked. Seed with the liveliest feature.
+    const THRESH = 0.45
+    const liveOf = (k) => liveliness(agg[k])
+    const byLive = [...good].sort((a, b) => liveOf(b) - liveOf(a))
+    console.log(`\n  Maximally-independent set (greedy by liveliness, |corr|<${THRESH}):`)
     const picked = []
-    for (const cand of good) {
-        if (picked.every(p => Math.abs(pearson(agg[cand], agg[p])) < 0.5)) picked.push(cand)
-        if (picked.length >= 5) break
+    for (const cand of byLive) {
+        if (picked.every(p => Math.abs(pearson(agg[cand], agg[p])) < THRESH)) picked.push(cand)
     }
-    picked.forEach(p => console.log('    •', p))
+    picked.forEach(p => {
+        const maxCorr = Math.max(0, ...picked.filter(q => q !== p).map(q => Math.abs(pearson(agg[p], agg[q]))))
+        console.log(`    • ${p.padEnd(26)} lively=${liveOf(p).toFixed(2)}  maxCorrInSet=${maxCorr.toFixed(2)}`)
+    })
 }

--- a/scripts/wavelet-harness2.mjs
+++ b/scripts/wavelet-harness2.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// wavelet-harness2.mjs — DEEP feature analysis for music-visual animation quality.
+//
+// Beyond harness1's global range/liveliness/jitter/correlation, this keeps PER-SIGNAL
+// time-series so it can measure what actually matters for driving visuals:
+//
+//   reactionSpeed  — how fast a feature responds to onsets (frames to 50% of its jump).
+//                    Fast = visuals hit on the beat, not a sloppy lag behind it.
+//   discrimination — does the feature look DIFFERENT on different content? (variance of
+//                    per-signal means / overall std). High = it distinguishes kick vs
+//                    sweep vs noise — useful for making visuals "understand" the music.
+//   dutyCycle      — fraction of time the feature sits in the usable middle of its range
+//                    (not pinned at 0 or 1). Pinned features drive dead visuals.
+//   plus range / liveliness / jitter / independence as before.
+//
+// Usage: node scripts/wavelet-harness2.mjs sig1.pcm sig2.pcm ...
+
+import { readFileSync } from 'fs'
+import { basename } from 'path'
+import { createWaveletAnalyzer } from '../src/audio/waveletAnalyzer.js'
+
+const FRAME = 1024, HOP = 128, HISTORY = 500
+
+const readPcm = (p) => { const b = readFileSync(p); return new Float32Array(b.buffer, b.byteOffset, Math.floor(b.byteLength / 4)) }
+
+const STAT_SUFFIX = { normalized: 'Normalized', mean: 'Mean', median: 'Median', min: 'Min', max: 'Max', standardDeviation: 'StandardDeviation', zScore: 'ZScore', slope: 'Slope', intercept: 'Intercept', rSquared: 'RSquared' }
+const flatten = (series, base, stats) => {
+    ;(series[base] ??= []).push(stats.current)
+    for (const [k, suf] of Object.entries(STAT_SUFFIX)) (series[`${base}${suf}`] ??= []).push(stats[k])
+}
+
+const runSignal = (samples) => {
+    const a = createWaveletAnalyzer(HISTORY)
+    const series = {}
+    const buf = new Float32Array(FRAME)
+    let filled = 0
+    for (let pos = 0; pos + HOP <= samples.length; pos += HOP) {
+        buf.copyWithin(0, HOP)
+        buf.set(samples.subarray(pos, pos + HOP), FRAME - HOP)
+        filled += HOP
+        if (filled < FRAME) continue
+        const out = a.analyze(buf)
+        out.bandStats.slice(0, 6).forEach((s, i) => flatten(series, `waveletBand${i}`, s))
+        flatten(series, 'waveletBass', out.bassStats)
+        flatten(series, 'waveletCentroid', out.centroidStats)
+        flatten(series, 'waveletSpread', out.spreadStats)
+        flatten(series, 'waveletTilt', out.tiltStats)
+        ;(series.wavelet_bassHit ??= []).push(out.bassHit)
+    }
+    return series
+}
+
+// ---- metrics ----
+const mean = (xs) => xs.reduce((s, x) => s + x, 0) / xs.length
+const stddev = (xs) => { const m = mean(xs); return Math.sqrt(xs.reduce((s, x) => s + (x - m) ** 2, 0) / xs.length) }
+const range = (xs) => Math.max(...xs) - Math.min(...xs)
+const liveliness = (xs) => { const sd = stddev(xs) || 1e-9; let m = 0; for (let i = 1; i < xs.length; i++) if (Math.abs(xs[i] - xs[i - 1]) > sd * 0.05) m++; return m / (xs.length - 1) }
+const jitter = (xs) => { const r = range(xs) || 1e-9; let a = 0; for (let i = 2; i < xs.length; i++) a += Math.abs(xs[i] - 2 * xs[i - 1] + xs[i - 2]); return (a / (xs.length - 2)) / r }
+const pearson = (xs, ys) => { const n = xs.length, mx = mean(xs), my = mean(ys); let nu = 0, dx = 0, dy = 0; for (let i = 0; i < n; i++) { const a = xs[i] - mx, b = ys[i] - my; nu += a * b; dx += a * a; dy += b * b } const d = Math.sqrt(dx * dy); return d < 1e-12 ? 0 : nu / d }
+
+// reaction speed: find the biggest sustained rises, measure frames from 10%→90% of the jump.
+// returns mean rise-time in frames (lower = snappier). NaN if no clear rises.
+const reactionSpeed = (xs) => {
+    const sd = stddev(xs); if (sd < 1e-6) return NaN
+    const times = []
+    for (let i = 1; i < xs.length - 8; i++) {
+        const jump = xs[i + 8] - xs[i]
+        if (jump < sd * 1.5) continue // only big rises
+        const lo = xs[i] + jump * 0.1, hi = xs[i] + jump * 0.9
+        let t10 = -1, t90 = -1
+        for (let j = i; j <= i + 8; j++) { if (t10 < 0 && xs[j] >= lo) t10 = j; if (xs[j] >= hi) { t90 = j; break } }
+        if (t10 >= 0 && t90 >= t10) times.push(t90 - t10)
+        i += 8
+    }
+    return times.length ? mean(times) : NaN
+}
+
+// discrimination: how much the per-signal MEANS vary, relative to overall std.
+// high = the feature distinguishes one kind of audio from another.
+const discrimination = (perSignalMeans, overallStd) => (overallStd < 1e-9 ? 0 : stddev(perSignalMeans) / overallStd)
+
+// dutyCycle: fraction of frames in the usable 0.1..0.9 band after min-max normalizing.
+const dutyCycle = (xs) => { const mn = Math.min(...xs), r = range(xs) || 1e-9; let c = 0; for (const x of xs) { const n = (x - mn) / r; if (n > 0.1 && n < 0.9) c++ } return c / xs.length }
+
+const files = process.argv.slice(2)
+if (!files.length) { console.error('usage: node wavelet-harness2.mjs sig.pcm [...]'); process.exit(1) }
+
+// per-signal series + aggregate
+const perSignal = {} // file -> { feature -> [] }
+const agg = {}
+for (const f of files) {
+    const s = runSignal(readPcm(f))
+    perSignal[basename(f)] = s
+    for (const [k, v] of Object.entries(s)) (agg[k] ??= []).push(...v)
+}
+console.log(`Analyzed ${files.length} signals, ${Object.values(agg)[0]?.length ?? 0} total frames\n`)
+
+const FOCUS = Object.keys(agg).filter(k =>
+    /ZScore$|Normalized$|Slope$/.test(k) || /^wavelet(Centroid|Spread|Tilt)$/.test(k) || /^waveletBass$/.test(k) || /^waveletBand[0-5]$/.test(k) || k === 'wavelet_bassHit'
+)
+
+// Score every focus feature.
+const rows = []
+for (const k of FOCUS) {
+    const xs = agg[k]; if (!xs || xs.length < 20) continue
+    const sd = stddev(xs)
+    const perMeans = files.map(f => { const v = perSignal[basename(f)][k]; return v && v.length ? mean(v) : 0 })
+    rows.push({
+        k,
+        range: range(xs),
+        lively: liveliness(xs),
+        jitter: jitter(xs),
+        react: reactionSpeed(xs),
+        discrim: discrimination(perMeans, sd),
+        duty: dutyCycle(xs),
+    })
+}
+
+// composite "animation score": rewards range, liveliness, discrimination, duty, fast reaction;
+// penalizes jitter. Tuned for music-visual usefulness.
+const animScore = (r) => {
+    const reactScore = isNaN(r.react) ? 0.5 : Math.max(0, 1 - r.react / 6) // <6 frames = good
+    return (
+        Math.min(r.range, 1) * 0.15 +
+        r.lively * 0.20 +
+        r.discrim * 0.20 +
+        r.duty * 0.20 +
+        reactScore * 0.15 +
+        Math.max(0, 1 - r.jitter * 3) * 0.10
+    )
+}
+rows.forEach(r => r.score = animScore(r))
+rows.sort((a, b) => b.score - a.score)
+
+console.log('=== FEATURE SCORES (sorted by animation usefulness) ===')
+console.log('feature'.padEnd(30), 'score'.padStart(6), 'range'.padStart(7), 'lively'.padStart(7), 'jitter'.padStart(7), 'react'.padStart(6), 'discrim'.padStart(8), 'duty'.padStart(6))
+for (const r of rows) {
+    console.log(
+        r.k.padEnd(30),
+        r.score.toFixed(3).padStart(6),
+        r.range.toFixed(2).padStart(7),
+        r.lively.toFixed(2).padStart(7),
+        r.jitter.toFixed(2).padStart(7),
+        (isNaN(r.react) ? '—' : r.react.toFixed(1)).padStart(6),
+        r.discrim.toFixed(2).padStart(8),
+        r.duty.toFixed(2).padStart(6),
+    )
+}
+
+// Greedy maximally-independent set from the TOP-scoring features.
+const THRESH = 0.5
+console.log(`\n=== MAXIMALLY-INDEPENDENT SET (top scorers, |corr|<${THRESH}) ===`)
+const picked = []
+for (const r of rows) {
+    if (picked.every(p => Math.abs(pearson(agg[r.k], agg[p.k])) < THRESH)) picked.push(r)
+    if (picked.length >= 8) break
+}
+for (const p of picked) {
+    const mc = Math.max(0, ...picked.filter(q => q !== p).map(q => Math.abs(pearson(agg[p.k], agg[q.k]))))
+    console.log(`  • ${p.k.padEnd(28)} score=${p.score.toFixed(2)}  maxCorr=${mc.toFixed(2)}`)
+}
+
+// ---- CURATED VJ SET: a deliberate blend for music visuals ----
+// Mix high-DISCRIMINATION raw features ("what kind of sound") with fast Z-SCORE
+// reactors ("what's happening right now") + the trigger. Enforce independence within.
+console.log('\n=== CURATED VJ SET (blend of character + reactive + trigger, |corr|<0.5) ===')
+const byMetric = (pred, metric) => rows.filter(r => pred(r.k)).sort((a, b) => b[metric] - a[metric])
+const isRaw = (k) => /^wavelet(Centroid|Spread|Tilt)$|^waveletBand[0-5]$|^waveletBass$/.test(k)
+const isZ = (k) => /ZScore$/.test(k)
+const vj = []
+const tryAdd = (r) => { if (r && vj.every(p => Math.abs(pearson(agg[r.k], agg[p.k])) < THRESH)) { vj.push(r); return true } return false }
+// 1-2 character features (high discrimination, raw)
+for (const r of byMetric(isRaw, 'discrim')) { if (vj.filter(x => isRaw(x.k)).length >= 3) break; tryAdd(r) }
+// 3-4 reactive features (fast z-scores, prefer different bands)
+for (const r of byMetric(isZ, 'react').reverse()) { if (vj.filter(x => isZ(x.k)).length >= 4) break; tryAdd(r) }
+// the trigger
+const hit = rows.find(r => r.k === 'wavelet_bassHit'); if (hit) vj.push(hit)
+for (const p of vj) {
+    const mc = Math.max(0, ...vj.filter(q => q !== p).map(q => Math.abs(pearson(agg[p.k], agg[q.k]))))
+    const role = p.k === 'wavelet_bassHit' ? 'TRIGGER' : (isZ(p.k) ? 'reactive' : 'character')
+    console.log(`  • ${p.k.padEnd(26)} [${role.padEnd(9)}] score=${p.score.toFixed(2)} react=${isNaN(p.react)?'—':p.react.toFixed(1)} discrim=${p.discrim.toFixed(2)} maxCorr=${mc.toFixed(2)}`)
+}

--- a/shaders/claude/wip/wavelet-scope/1.frag
+++ b/shaders/claude/wip/wavelet-scope/1.frag
@@ -1,0 +1,118 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, debug
+//
+// WAVELET SCOPE — diagnostic for the DWT prototype (?wavelet=true).
+// Left  : 6 octave-band meters (low→high) from the wavelet transform.
+//         Each band's height = its z-score (spiking vs its own baseline).
+// Right : the FFT spectralFlux z-score, for side-by-side onset comparison.
+// Top strip: WAVELET onset (cyan) vs FFT spectralFlux z (magenta) — the key A/B.
+//   Watch a kick: the cyan bar should snap up and back FASTER/TIGHTER than magenta
+//   if the wavelet onset really localizes transients better than the 85ms FFT window.
+//
+// Requires ?wavelet=true so window.cranes.waveletFeatures is populated.
+// wavelet_band0..5, wavelet_band0Z..5Z, wavelet_onset, wavelet_onsetSmooth,
+// wavelet_bass are injected as uniforms automatically (do NOT redeclare).
+
+#define BANDS 6
+
+// Wavelet prototype uniforms — these come from window.cranes.waveletFeatures, which
+// is NOT in the known hypnosound feature list, so they must be declared explicitly.
+// twgl binds them from the features map; if ?wavelet=true is absent they read 0.
+uniform float wavelet_band0;
+uniform float wavelet_band1;
+uniform float wavelet_band2;
+uniform float wavelet_band3;
+uniform float wavelet_band4;
+uniform float wavelet_band5;
+uniform float wavelet_band0Z;
+uniform float wavelet_band1Z;
+uniform float wavelet_band2Z;
+uniform float wavelet_band3Z;
+uniform float wavelet_band4Z;
+uniform float wavelet_band5Z;
+uniform float wavelet_onset;
+uniform float wavelet_onsetSmooth;
+uniform float wavelet_bass;
+
+// Draw a filled bar from y=0 up to `h` within an [x0,x1] column. Returns coverage 0/1.
+float bar(vec2 uv, float x0, float x1, float h) {
+    if (uv.x < x0 || uv.x > x1) return 0.0;
+    return step(uv.y, h);
+}
+
+float waveletBandZ(int i) {
+    if (i == 0) return wavelet_band0Z;
+    if (i == 1) return wavelet_band1Z;
+    if (i == 2) return wavelet_band2Z;
+    if (i == 3) return wavelet_band3Z;
+    if (i == 4) return wavelet_band4Z;
+    return wavelet_band5Z;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord.xy / iResolution.xy; // 0..1, y up
+
+    vec3 col = vec3(0.02, 0.02, 0.04); // near-black background
+
+    // ---- TOP STRIP: onset A/B comparison (top 18% of screen) ----
+    if (uv.y > 0.82) {
+        float t = (uv.y - 0.82) / 0.18; // 0..1 within strip
+        // Wavelet onset on the left third's worth of width, full-width split L/R
+        float wOnset = clamp(wavelet_onset * 6.0, 0.0, 1.0);      // raw, sharp
+        float fFlux  = clamp(spectralFluxZScore, 0.0, 1.0);       // FFT comparison
+        // Left half = wavelet (cyan), right half = FFT flux (magenta)
+        if (uv.x < 0.5) {
+            float h = wOnset;
+            col = mix(col, vec3(0.0, 0.9, 1.0), step(t, h));
+        } else {
+            float h = fFlux;
+            col = mix(col, vec3(1.0, 0.0, 0.7), step(t, h));
+        }
+        // center divider
+        col = mix(col, vec3(0.3), step(abs(uv.x - 0.5), 0.002));
+        fragColor = vec4(col, 1.0);
+        return;
+    }
+
+    // ---- MAIN AREA: meters (bottom 82%) ----
+    float meterY = uv.y / 0.82; // remap so meters use the lower region
+
+    // RIGHT 30%: FFT spectralFlux z-score reference meter
+    if (uv.x > 0.7) {
+        float h = clamp(spectralFluxZScore * 0.5 + 0.5, 0.0, 1.0);
+        float fill = step(meterY, h);
+        col = mix(col, vec3(1.0, 0.2, 0.6), fill);
+        // baseline at 0.5 (z=0)
+        col = mix(col, vec3(0.4), step(abs(meterY - 0.5), 0.004));
+        fragColor = vec4(col, 1.0);
+        return;
+    }
+
+    // LEFT 70%: six wavelet octave-band z-score meters
+    float region = 0.7;
+    float colW = region / float(BANDS);
+    int idx = int(uv.x / colW);
+    idx = clamp(idx, 0, BANDS - 1);
+    float z = waveletBandZ(idx);
+    float h = clamp(z * 0.5 + 0.5, 0.0, 1.0); // z=0 → mid height
+
+    float x0 = float(idx) * colW + 0.005;
+    float x1 = float(idx + 1) * colW - 0.005;
+    float fill = bar(vec2(uv.x, meterY), x0, x1, h);
+
+    // Hue per band: low bands warm (red/orange), high bands cool (blue/violet) —
+    // mirrors chromadepth depth ordering so you can read frequency at a glance.
+    float hue = float(idx) / float(BANDS - 1) * 0.7; // 0=red .. 0.7=violet
+    vec3 bandCol = hsl2rgb(vec3(hue, 0.85, 0.55));
+    col = mix(col, bandCol, fill);
+
+    // onset flash: when wavelet_onset fires, flash a white horizontal line across
+    // the whole left meter area — this is the "did the kick land sharply" tell.
+    float flash = smoothstep(0.08, 0.25, wavelet_onset);
+    col = mix(col, vec3(1.0), flash * step(abs(meterY - 0.95), 0.02));
+
+    // baseline at z=0
+    col = mix(col, vec3(0.25), step(abs(meterY - 0.5), 0.003));
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/wip/wavelet-scope/2.frag
+++ b/shaders/claude/wip/wavelet-scope/2.frag
@@ -1,0 +1,71 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, oscilloscope, graph, debug
+//
+// WAVELET BASS OSCILLOSCOPE — scrolling line comparison of the wavelet bass-hit
+// detector vs the traditional FFT features, for the deep-bass-on-phone-mic use case.
+//
+// Scrolls left every frame (frame-feedback idiom from graph/line-z-score.frag) and
+// plots a new sample in the rightmost column. Watch which line spikes cleanly on each
+// bass hit and which smear / miss:
+//
+//   CYAN    = wavelet_bassZ        (our new detector — harmonic-weighted, self-calibrating)
+//   RED     = bassZScore           (traditional FFT bass z-score)
+//   YELLOW  = energyZScore         (traditional energy z-score)
+//   MAGENTA = spectralFluxZScore   (the current de-facto drop signal)
+//
+// White full-height flash column = wavelet_bassHit fired this frame (a detected drop).
+//
+// Center line = z=0. Range mapped is roughly z ∈ [-2.5, +2.5].
+// Run with ?wavelet=true so the wavelet uniforms are populated.
+
+// Wavelet prototype uniforms (not in the known feature list — declare explicitly).
+uniform float wavelet_bassZ;
+uniform float wavelet_bassHit;
+uniform float wavelet_bassEnergy;
+
+// Map a z-score (~[-2.5,2.5]) to a 0..1 vertical screen position.
+float zToY(float z) {
+    return clamp((z + 2.5) / 5.0, 0.0, 1.0);
+}
+
+// Is the current row within `w` pixels of the plotted value at height `h01`?
+bool onLine(vec2 fragCoord, float h01, float w) {
+    return abs(fragCoord.y - h01 * resolution.y) < w;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord.xy / resolution.xy;
+
+    // ---- SCROLL: shift everything left by sampling one pixel to the right ----
+    if (uv.x < 0.99) {
+        vec2 prevUV = uv;
+        prevUV.x += 1.0 / resolution.x;
+        fragColor = getLastFrameColor(prevUV);
+        // gently fade old trails so the graph doesn't smear to mush over time
+        fragColor.rgb *= 0.992;
+        // faint center baseline (z=0) drawn into the scrolled history too
+        if (abs(uv.y - 0.5) < 1.5 / resolution.y) fragColor.rgb = max(fragColor.rgb, vec3(0.12));
+        return;
+    }
+
+    // ---- NEW SAMPLE COLUMN (rightmost ~1%) ----
+    vec3 col = vec3(0.0);
+
+    // baseline at z=0
+    if (abs(uv.y - 0.5) < 1.5 / resolution.y) col = vec3(0.18);
+
+    float lw = 4.0; // line half-width in pixels
+
+    // Plot order: draw traditional first, wavelet last so cyan sits on top.
+    if (onLine(fragCoord, zToY(spectralFluxZScore), lw)) col = vec3(1.0, 0.0, 0.7); // magenta
+    if (onLine(fragCoord, zToY(energyZScore),       lw)) col = vec3(1.0, 1.0, 0.0); // yellow
+    if (onLine(fragCoord, zToY(bassZScore),         lw)) col = vec3(1.0, 0.15, 0.1); // red
+    if (onLine(fragCoord, zToY(wavelet_bassZ),      lw + 1.0)) col = vec3(0.0, 0.95, 1.0); // cyan (ours, thicker)
+
+    // HIT FLASH: when the wavelet bass-hit fires, paint the whole new column white-ish
+    // so a detected drop is unmissable as a vertical strobe scrolling across.
+    float hit = smoothstep(0.02, 0.12, wavelet_bassHit);
+    col = mix(col, vec3(1.0), hit * 0.7);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/wip/wavelet-scope/3.frag
+++ b/shaders/claude/wip/wavelet-scope/3.frag
@@ -1,0 +1,97 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, oscilloscope, graph, drop-detector, debug
+//
+// WAVELET BASS vs DROP-DETECTOR — scrolling oscilloscope that overlays our new wavelet
+// bass-hit line against the ACTUAL drop-detector signal we've been using
+// (graph/drop-detector/1.frag), so the difference is directly visible.
+//
+// The drop-detector doesn't use one feature — it counts how many spectral z-scores
+// exceed a threshold (PROBE_B) at the same instant. A "drop" = >=2 of
+// {energy, kurtosis, entropy, flux, rolloff} spiking together. We reproduce that exact
+// logic here as its own line so it can be compared, not approximated.
+//
+//   CYAN     = wavelet_bassZ            (our new detector — continuous bass-hit strength)
+//   WHITE col= wavelet_bassHit fired    (our drop trigger)
+//   ORANGE   = drop-detector highZScores/5  (the signal we've been using, 0..1)
+//   ORANGE col (top band) = drop-detector "drop" fired (>=2 z-scores over threshold)
+//
+//   Faint reference lines of the drop-detector's own inputs:
+//   dim RED=energyZ  dim GREEN=kurtosisZ  dim YELLOW=entropyZ  dim TEAL=fluxZ  dim GRAY=rolloffZ
+//
+// Run with ?wavelet=true. PROBE_B matches the drop-detector default (0.95).
+
+uniform float wavelet_bassZ;
+uniform float wavelet_bassHit;
+uniform float wavelet_bassEnergy;
+
+#define PROBE_B 0.95           // drop-detector threshold (from graph/drop-detector/1.frag)
+#define DROP_MIN 2             // >=2 simultaneous spikes = a "drop"
+#define ULTRA_DROP_COUNT 5
+
+// The exact features the drop-detector counts.
+#define DD_RED    energyZScore
+#define DD_GREEN  spectralKurtosisZScore
+#define DD_YELLOW spectralEntropyZScore
+#define DD_TEAL   spectralFluxZScore
+#define DD_GRAY   spectralRolloffZScore
+
+float zToY(float z) { return clamp((z + 2.5) / 5.0, 0.0, 1.0); }
+bool onLine(vec2 fragCoord, float h01, float w) { return abs(fragCoord.y - h01 * resolution.y) < w; }
+
+// Reproduce the drop-detector's core: count z-scores past the threshold.
+int dropCount() {
+    int n = 0;
+    if (abs(DD_RED)    > PROBE_B) n++;
+    if (abs(DD_GREEN)  > PROBE_B) n++;
+    if (abs(DD_YELLOW) > PROBE_B) n++;
+    if (abs(DD_TEAL)   > PROBE_B) n++;
+    if (abs(DD_GRAY)   > PROBE_B) n++;
+    return n;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord.xy / resolution.xy;
+
+    // ---- SCROLL LEFT ----
+    if (uv.x < 0.99) {
+        vec2 prevUV = uv;
+        prevUV.x += 1.0 / resolution.x;
+        fragColor = getLastFrameColor(prevUV);
+        fragColor.rgb *= 0.992; // gentle trail fade
+        if (abs(uv.y - 0.5) < 1.5 / resolution.y) fragColor.rgb = max(fragColor.rgb, vec3(0.12));
+        return;
+    }
+
+    // ---- NEW SAMPLE COLUMN ----
+    vec3 col = vec3(0.0);
+    if (abs(uv.y - 0.5) < 1.5 / resolution.y) col = vec3(0.18); // z=0 baseline
+
+    float lw = 3.0;
+
+    // Faint drop-detector input lines (so you can see WHICH features it's reacting to).
+    if (onLine(fragCoord, zToY(DD_RED),    lw)) col = max(col, vec3(0.35, 0.05, 0.05));
+    if (onLine(fragCoord, zToY(DD_GREEN),  lw)) col = max(col, vec3(0.05, 0.30, 0.05));
+    if (onLine(fragCoord, zToY(DD_YELLOW), lw)) col = max(col, vec3(0.30, 0.30, 0.05));
+    if (onLine(fragCoord, zToY(DD_TEAL),   lw)) col = max(col, vec3(0.10, 0.18, 0.35));
+    if (onLine(fragCoord, zToY(DD_GRAY),   lw)) col = max(col, vec3(0.22, 0.26, 0.22));
+
+    // DROP-DETECTOR aggregate signal: highZScores / 5, drawn as a bold ORANGE line.
+    // This IS the signal we've been using to fire drops. Plotted 0 (bottom) .. 1 (top).
+    int dc = dropCount();
+    float ddLevel = float(dc) / float(ULTRA_DROP_COUNT);
+    if (onLine(fragCoord, ddLevel, lw + 1.0)) col = vec3(1.0, 0.55, 0.0); // orange
+
+    // WAVELET bass line (cyan, on top).
+    if (onLine(fragCoord, zToY(wavelet_bassZ), lw + 1.0)) col = vec3(0.0, 0.95, 1.0);
+
+    // ---- EVENT FLASHES (two separate columns, stacked) ----
+    // Top band: drop-detector "drop" fired (>=2 z-scores over threshold) — ORANGE.
+    if (uv.y > 0.94 && dc >= DROP_MIN) {
+        col = mix(col, vec3(1.0, 0.55, 0.0), 0.85);
+    }
+    // Full-column WHITE flash: our wavelet bass hit fired.
+    float hit = smoothstep(0.02, 0.12, wavelet_bassHit);
+    if (uv.y <= 0.94) col = mix(col, vec3(1.0), hit * 0.6);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/wip/wavelet-scope/4.frag
+++ b/shaders/claude/wip/wavelet-scope/4.frag
@@ -1,0 +1,65 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, oscilloscope, graph, debug
+//
+// WAVELET FULL-BAND OSCILLOSCOPE — scrolls all six octave-band z-scores as separate
+// lines so you can see the whole multiresolution picture the DWT produces, low->high.
+// Each band is colored by frequency (red=low/bass -> violet=high/treble), mirroring
+// chromadepth depth order, so you can read which octaves are active at a glance.
+//
+//   band0Z  43-86 Hz    deep bass     RED
+//   band1Z  86-172 Hz   low bass      ORANGE
+//   band2Z  172-345 Hz  low-mid       YELLOW/GREEN
+//   band3Z  345-689 Hz  mid           GREEN
+//   band4Z  689-1378 Hz high-mid      CYAN/BLUE
+//   band5Z  1.4-2.8 kHz treble        VIOLET
+//
+//   White full-height column = wavelet_bassHit fired (the deep-bass drop trigger).
+//
+// Center line = z=0, range mapped ~ z in [-2.5, +2.5]. Run with ?wavelet=true.
+
+uniform float wavelet_band0Z;
+uniform float wavelet_band1Z;
+uniform float wavelet_band2Z;
+uniform float wavelet_band3Z;
+uniform float wavelet_band4Z;
+uniform float wavelet_band5Z;
+uniform float wavelet_bassHit;
+
+float zToY(float z) { return clamp((z + 2.5) / 5.0, 0.0, 1.0); }
+bool onLine(vec2 fragCoord, float h01, float w) { return abs(fragCoord.y - h01 * resolution.y) < w; }
+
+// frequency t in [0,1] -> chromadepth-ordered hue (0=red .. ~0.78=violet)
+vec3 bandColor(float t) { return hsl2rgb(vec3(t * 0.78, 0.9, 0.55)); }
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord.xy / resolution.xy;
+
+    // ---- SCROLL LEFT ----
+    if (uv.x < 0.99) {
+        vec2 prevUV = uv;
+        prevUV.x += 1.0 / resolution.x;
+        fragColor = getLastFrameColor(prevUV);
+        fragColor.rgb *= 0.992; // gentle trail fade
+        if (abs(uv.y - 0.5) < 1.5 / resolution.y) fragColor.rgb = max(fragColor.rgb, vec3(0.12));
+        return;
+    }
+
+    // ---- NEW SAMPLE COLUMN ----
+    vec3 col = vec3(0.0);
+    if (abs(uv.y - 0.5) < 1.5 / resolution.y) col = vec3(0.18); // z=0 baseline
+
+    float lw = 3.0;
+    // Plot high bands first, low (bass) last so the bass line sits on top.
+    if (onLine(fragCoord, zToY(wavelet_band5Z), lw)) col = bandColor(1.00);
+    if (onLine(fragCoord, zToY(wavelet_band4Z), lw)) col = bandColor(0.80);
+    if (onLine(fragCoord, zToY(wavelet_band3Z), lw)) col = bandColor(0.60);
+    if (onLine(fragCoord, zToY(wavelet_band2Z), lw)) col = bandColor(0.40);
+    if (onLine(fragCoord, zToY(wavelet_band1Z), lw)) col = bandColor(0.20);
+    if (onLine(fragCoord, zToY(wavelet_band0Z), lw + 1.0)) col = bandColor(0.0); // bass, thicker, on top
+
+    // bass-hit flash column
+    float hit = smoothstep(0.02, 0.12, wavelet_bassHit);
+    col = mix(col, vec3(1.0), hit * 0.6);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/wip/wavelet-scope/5.frag
+++ b/shaders/claude/wip/wavelet-scope/5.frag
@@ -1,0 +1,103 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, oscilloscope, graph, drop-detector, debug
+//
+// SPLIT SCOPE — vertical split comparison, both halves scrolling independently.
+//
+//   TOP HALF    = NEW wavelet features
+//     band0Z..band5Z octave z-scores (red=bass .. violet=treble), bass line thick/on top
+//     white full-height tick at the top edge when wavelet_bassHit fires
+//
+//   BOTTOM HALF = OLD drop-detector features (graph/drop-detector/1.frag logic)
+//     its five input z-scores (energy/kurtosis/entropy/flux/rolloff) + orange aggregate
+//     orange tick at the bottom edge when its drop fires (>=2 z-scores over PROBE_B)
+//
+// Each half has its own z=0 baseline at its vertical center. Run with ?wavelet=true.
+
+uniform float wavelet_band0Z;
+uniform float wavelet_band1Z;
+uniform float wavelet_band2Z;
+uniform float wavelet_band3Z;
+uniform float wavelet_band4Z;
+uniform float wavelet_band5Z;
+uniform float wavelet_bassHit;
+
+#define PROBE_B 0.95
+#define DROP_MIN 2
+#define ULTRA 5.0
+#define DD_RED    energyZScore
+#define DD_GREEN  spectralKurtosisZScore
+#define DD_YELLOW spectralEntropyZScore
+#define DD_TEAL   spectralFluxZScore
+#define DD_GRAY   spectralRolloffZScore
+
+bool onLine(float fy, float h01, float w) { return abs(fy - h01 * resolution.y) < w; }
+vec3 bandColor(float t) { return hsl2rgb(vec3(t * 0.78, 0.9, 0.55)); }
+
+// Map z to a 0..1 position WITHIN a half: lo..hi are the half's screen bounds.
+float zToHalf(float z, float lo, float hi) {
+    float c = clamp((z + 2.5) / 5.0, 0.0, 1.0); // 0..1 of the half
+    return mix(lo, hi, c);
+}
+
+int dropCount() {
+    int n = 0;
+    if (abs(DD_RED)>PROBE_B) n++; if (abs(DD_GREEN)>PROBE_B) n++; if (abs(DD_YELLOW)>PROBE_B) n++;
+    if (abs(DD_TEAL)>PROBE_B) n++; if (abs(DD_GRAY)>PROBE_B) n++;
+    return n;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord.xy / resolution.xy;
+    bool top = uv.y >= 0.5;
+    // Per-half bounds (small margin off the divider/edges).
+    float lo = top ? 0.52 : 0.02;
+    float hi = top ? 0.98 : 0.48;
+    float mid = (lo + hi) * 0.5; // this half's z=0 line
+
+    // ---- SCROLL LEFT (sampling stays within this half, so halves don't bleed) ----
+    if (uv.x < 0.99) {
+        vec2 prevUV = uv;
+        prevUV.x += 1.0 / resolution.x;
+        fragColor = getLastFrameColor(prevUV);
+        fragColor.rgb *= 0.992;
+        if (abs(uv.y - mid) < 1.5 / resolution.y) fragColor.rgb = max(fragColor.rgb, vec3(0.12));
+        // hard divider line at y=0.5
+        if (abs(uv.y - 0.5) < 2.0 / resolution.y) fragColor.rgb = vec3(0.3);
+        return;
+    }
+
+    // ---- NEW SAMPLE COLUMN ----
+    vec3 col = vec3(0.0);
+    if (abs(uv.y - mid) < 1.5 / resolution.y) col = vec3(0.18); // this half's z=0 baseline
+    if (abs(uv.y - 0.5) < 2.0 / resolution.y) { fragColor = vec4(0.3,0.3,0.3,1.0); return; } // divider
+
+    float lw = 3.0;
+
+    if (top) {
+        // NEW: wavelet band z-scores (high first, bass last/on top)
+        if (onLine(fragCoord.y, zToHalf(wavelet_band5Z, lo, hi), lw)) col = bandColor(1.00);
+        if (onLine(fragCoord.y, zToHalf(wavelet_band4Z, lo, hi), lw)) col = bandColor(0.80);
+        if (onLine(fragCoord.y, zToHalf(wavelet_band3Z, lo, hi), lw)) col = bandColor(0.60);
+        if (onLine(fragCoord.y, zToHalf(wavelet_band2Z, lo, hi), lw)) col = bandColor(0.40);
+        if (onLine(fragCoord.y, zToHalf(wavelet_band1Z, lo, hi), lw)) col = bandColor(0.20);
+        if (onLine(fragCoord.y, zToHalf(wavelet_band0Z, lo, hi), lw + 1.0)) col = bandColor(0.0);
+        // bass-hit tick at the very top edge
+        float hit = smoothstep(0.02, 0.12, wavelet_bassHit);
+        if (uv.y > 0.95) col = mix(col, vec3(1.0), hit * 0.85);
+    } else {
+        // OLD: drop-detector inputs + aggregate
+        if (onLine(fragCoord.y, zToHalf(DD_GRAY,   lo, hi), lw)) col = vec3(0.5, 0.6, 0.5);
+        if (onLine(fragCoord.y, zToHalf(DD_TEAL,   lo, hi), lw)) col = vec3(0.3, 0.4, 1.0);
+        if (onLine(fragCoord.y, zToHalf(DD_YELLOW, lo, hi), lw)) col = vec3(1.0, 1.0, 0.0);
+        if (onLine(fragCoord.y, zToHalf(DD_GREEN,  lo, hi), lw)) col = vec3(0.0, 1.0, 0.0);
+        if (onLine(fragCoord.y, zToHalf(DD_RED,    lo, hi), lw)) col = vec3(1.0, 0.15, 0.1);
+        // aggregate highZScores/5 as a 0(bottom)..1(top of half) orange line
+        int dc = dropCount();
+        float agg = float(dc) / ULTRA;
+        if (onLine(fragCoord.y, mix(lo, hi, agg), lw + 1.0)) col = vec3(1.0, 0.55, 0.0);
+        // drop-fired tick at the very bottom edge
+        if (uv.y < 0.05 && dc >= DROP_MIN) col = vec3(1.0, 0.55, 0.0);
+    }
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/wip/wavelet-scope/6.frag
+++ b/shaders/claude/wip/wavelet-scope/6.frag
@@ -1,0 +1,110 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, meters, graph, drop-detector, debug
+//
+// SPLIT METERS (live-debug) — vertical split, filled bar meters instead of thin
+// confetti-prone lines so the comparison is legible on noisy live tab audio.
+//
+//   TOP HALF    = NEW wavelet features
+//     6 stacked horizontal bars, one per octave band (red=deep bass .. violet=treble),
+//     each fills left->right by its z-score. Big white flash across the top edge when
+//     wavelet_bassHit fires (the deep-bass drop trigger).
+//
+//   BOTTOM HALF = OLD drop-detector features (graph/drop-detector/1.frag logic)
+//     5 stacked bars for its z-score inputs (energy/kurtosis/entropy/flux/rolloff),
+//     each turns BRIGHT when it crosses PROBE_B. A wide aggregate bar shows
+//     dropCount/5. Big orange flash across the bottom when a drop fires (>=2 over threshold).
+//
+// Bars grow from screen center outward to both sides so a spike reads as a symmetric
+// pulse. Run with ?wavelet=true  (and ?audio=tab for live Spotify).
+
+uniform float wavelet_band0Z;
+uniform float wavelet_band1Z;
+uniform float wavelet_band2Z;
+uniform float wavelet_band3Z;
+uniform float wavelet_band4Z;
+uniform float wavelet_band5Z;
+uniform float wavelet_bassHit;
+uniform float wavelet_bassZ;
+
+#define PROBE_B 0.95
+#define DROP_MIN 2
+#define DD_RED    energyZScore
+#define DD_GREEN  spectralKurtosisZScore
+#define DD_YELLOW spectralEntropyZScore
+#define DD_TEAL   spectralFluxZScore
+#define DD_GRAY   spectralRolloffZScore
+
+vec3 bandColor(float t) { return hsl2rgb(vec3(t * 0.78, 0.9, 0.55)); }
+
+// A centered horizontal bar in a horizontal slot [y0,y1]. `val01` in 0..1 sets how far
+// it fills from center (x=0.5) toward both edges. Returns intensity 0..1 for this pixel.
+float bar(vec2 uv, float y0, float y1, float val01) {
+    if (uv.y < y0 || uv.y >= y1) return 0.0;
+    float reach = clamp(val01, 0.0, 1.0) * 0.5;
+    float distFromCenter = abs(uv.x - 0.5);
+    // soft edge
+    return 1.0 - smoothstep(reach - 0.004, reach + 0.004, distFromCenter);
+}
+
+// map a z-score to 0..1 fill (|z| so spikes either direction fill the bar)
+float zFill(float z) { return clamp(abs(z) / 2.0, 0.0, 1.0); }
+
+int dropCount() {
+    int n = 0;
+    if (abs(DD_RED)>PROBE_B) n++; if (abs(DD_GREEN)>PROBE_B) n++; if (abs(DD_YELLOW)>PROBE_B) n++;
+    if (abs(DD_TEAL)>PROBE_B) n++; if (abs(DD_GRAY)>PROBE_B) n++;
+    return n;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord.xy / resolution.xy;
+    vec3 col = vec3(0.015);
+
+    // center vertical reference + divider
+    if (abs(uv.x - 0.5) < 1.0 / resolution.x) col = vec3(0.15);
+    if (abs(uv.y - 0.5) < 2.0 / resolution.y) { fragColor = vec4(0.3,0.3,0.3,1.0); return; }
+
+    if (uv.y > 0.5) {
+        // ===== TOP: NEW wavelet octave bands =====
+        // 6 bands stacked in [0.52, 0.98]; band0 (bass) at the BOTTOM of the top half
+        // (nearest the divider) so bass sits in the middle of the screen.
+        float zs[6];
+        zs[0]=wavelet_band0Z; zs[1]=wavelet_band1Z; zs[2]=wavelet_band2Z;
+        zs[3]=wavelet_band3Z; zs[4]=wavelet_band4Z; zs[5]=wavelet_band5Z;
+        float lo = 0.52, hi = 0.97, slot = (hi - lo) / 6.0;
+        for (int i = 0; i < 6; i++) {
+            float y0 = lo + float(i) * slot + 0.004;
+            float y1 = lo + float(i+1) * slot - 0.004;
+            float b = bar(uv, y0, y1, zFill(zs[i]));
+            col = mix(col, bandColor(float(i) / 5.0), b);
+        }
+        // bass-hit flash strip along the very top
+        float hit = smoothstep(0.02, 0.12, wavelet_bassHit);
+        if (uv.y > 0.975) col = mix(col, vec3(1.0), hit);
+    } else {
+        // ===== BOTTOM: OLD drop-detector inputs =====
+        float zs[5];
+        zs[0]=DD_RED; zs[1]=DD_GREEN; zs[2]=DD_YELLOW; zs[3]=DD_TEAL; zs[4]=DD_GRAY;
+        vec3 cols[5];
+        cols[0]=vec3(1.0,0.15,0.1); cols[1]=vec3(0.1,1.0,0.2); cols[2]=vec3(1.0,0.9,0.1);
+        cols[3]=vec3(0.3,0.5,1.0); cols[4]=vec3(0.6,0.7,0.6);
+        float lo = 0.06, hi = 0.48, slot = (hi - lo) / 5.0;
+        for (int i = 0; i < 5; i++) {
+            float y0 = lo + float(i) * slot + 0.004;
+            float y1 = lo + float(i+1) * slot - 0.004;
+            float b = bar(uv, y0, y1, zFill(zs[i]));
+            // brighten when this z-score is past the drop threshold
+            float over = step(PROBE_B, abs(zs[i]));
+            vec3 c = mix(cols[i] * 0.5, cols[i], over);
+            col = mix(col, c, b);
+        }
+        // aggregate dropCount/5 as a wide bar just under the divider
+        int dc = dropCount();
+        float agg = bar(uv, 0.485, 0.5, float(dc) / 5.0);
+        col = mix(col, vec3(1.0, 0.55, 0.0), agg);
+        // drop-fired flash strip along the very bottom
+        if (uv.y < 0.025 && dc >= DROP_MIN) col = vec3(1.0, 0.55, 0.0);
+    }
+
+    fragColor = vec4(col, 1.0);
+}

--- a/shaders/claude/wip/wavelet-scope/7.frag
+++ b/shaders/claude/wip/wavelet-scope/7.frag
@@ -1,0 +1,94 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, oscilloscope, graph, analytics, debug
+//
+// PAIRED TAPESTRY — signal-tapestry-style lane scope (one feature per horizontal lane,
+// history scrolls right->left). Each WAVELET feature sits directly above its matched
+// FFT feature so you can read the pair's behavior over time, side by side.
+//
+//   TOP GROUP (wavelet)        BOTTOM GROUP (FFT, the method we use now)
+//   ─────────────────────      ─────────────────────────────────────────
+//   0  waveletBassZScore       3  bassZScore         (bass dynamics)
+//   1  waveletBand2ZScore      4  midsZScore         (low-mid / body)
+//   2  waveletBand5ZScore      5  trebleZScore       (treble / air)
+//
+// Wavelet bands are now first-class features (same hypnosound stats path as FFT),
+// so their ZScores are smoothed the same way — no more near-zero-std noise blowup.
+//
+// Lane = a horizontal band. A bright line traces the feature's z-score within its lane
+// (center = z0, up = positive). Each lane is color-coded; the wavelet group runs warm
+// (reds/oranges), the FFT group runs cool (blues/violets), so the two methods are
+// instantly distinguishable. A thin divider separates the groups.
+//
+// Run with ?wavelet=true (+ ?audio=tab for live Spotify).
+
+uniform float waveletBassZScore;
+uniform float waveletBand2ZScore;
+uniform float waveletBand5ZScore;
+
+#define NUM_LANES 6.0
+#define MARGIN 0.02
+#define GAP 0.006
+#define USABLE (1.0 - 2.0*MARGIN - GAP*(NUM_LANES-1.0))
+#define LANE_H (USABLE / NUM_LANES)
+// lane 0 at TOP of screen, lane 5 at bottom (so wavelet group is on top)
+#define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
+
+// Draw one feature's z-score line into its lane. Returns rgba contribution.
+vec4 lane(vec2 uv, float z, float centerY, vec3 color) {
+    float halfH = LANE_H * 0.5;
+    if (abs(uv.y - centerY) > halfH) return vec4(0.0);
+
+    // local position -0.5..0.5 within the lane; z maps to vertical displacement.
+    float local = (uv.y - centerY) / LANE_H;       // -0.5..0.5
+    float zPos = clamp(z * 0.35, -0.45, 0.45);      // z -> displacement within lane
+
+    // faint lane background + center (z=0) reference line
+    vec3 col = color * 0.06;
+    float a = 0.06;
+    if (abs(local) < 1.2 / (LANE_H * iResolution.y)) { col = color * 0.25; a = 0.25; }
+
+    // the z-score trace line
+    float d = abs(local - zPos) * LANE_H * iResolution.y; // px distance to the line
+    float line = smoothstep(3.5, 0.5, d);
+    col = mix(col, color * (1.2 + abs(z) * 0.3), line);
+    a = max(a, line);
+
+    return vec4(col, a);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = fragCoord / res;
+
+    // ---- SCROLL right -> left ----
+    if (floor(fragCoord.x) < floor(res.x) - 1.0) {
+        vec2 p = vec2((fragCoord.x + 1.0) / res.x, uv.y);
+        vec4 prev = getLastFrameColor(p);
+        prev.rgb *= 0.99;  // gentle trail fade
+        // keep the group divider crisp in history
+        if (abs(uv.y - 0.5) < 1.5/res.y) prev.rgb = vec3(0.25);
+        fragColor = vec4(prev.rgb, 1.0);
+        return;
+    }
+
+    // ---- NEW COLUMN ----
+    vec3 bg = vec3(0.01);
+    fragColor = vec4(bg, 1.0);
+
+    // group divider between wavelet (top 3) and FFT (bottom 3)
+    if (abs(uv.y - 0.5) < 1.5/res.y) { fragColor = vec4(0.25,0.25,0.25,1.0); return; }
+
+    // WAVELET group — warm hues (lanes 0..2)
+    vec4 r;
+    r = lane(uv, waveletBassZScore,  LANE_Y(0.0), vec3(1.0, 0.30, 0.20)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // red
+    r = lane(uv, waveletBand2ZScore, LANE_Y(1.0), vec3(1.0, 0.65, 0.15)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // orange
+    r = lane(uv, waveletBand5ZScore, LANE_Y(2.0), vec3(1.0, 0.85, 0.30)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // gold
+
+    // FFT group — cool hues (lanes 3..5)
+    r = lane(uv, bassZScore,   LANE_Y(3.0), vec3(0.25, 0.55, 1.0)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // blue
+    r = lane(uv, midsZScore,   LANE_Y(4.0), vec3(0.45, 0.40, 1.0)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // indigo
+    r = lane(uv, trebleZScore, LANE_Y(5.0), vec3(0.70, 0.40, 1.0)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // violet
+
+    fragColor.rgb = clamp(fragColor.rgb, 0.0, 1.0);
+    fragColor.a = 1.0;
+}

--- a/shaders/claude/wip/wavelet-scope/8.frag
+++ b/shaders/claude/wip/wavelet-scope/8.frag
@@ -7,9 +7,12 @@
 //
 //   TOP GROUP (wavelet)        BOTTOM GROUP (FFT, the method we use now)
 //   ─────────────────────      ─────────────────────────────────────────
-//   0  wavelet_bassZ           3  bassZScore         (bass dynamics)
-//   1  wavelet_band2Z          4  midsZScore         (low-mid / body)
-//   2  wavelet_band5Z          5  trebleZScore       (treble / air)
+//   0  waveletBassZScore       3  bassZScore         (bass dynamics)
+//   1  waveletBand2ZScore      4  midsZScore         (low-mid / body)
+//   2  waveletBand5ZScore      5  trebleZScore       (treble / air)
+//
+// (wavelet bands are first-class features now; old wavelet_bandNZ names were renamed
+//  to the FFT convention waveletBandNZScore — this shader was updated to match.)
 //
 // Lane = a horizontal band. A bright line traces the feature's z-score within its lane
 // (center = z0, up = positive). Each lane is color-coded; the wavelet group runs warm
@@ -18,9 +21,9 @@
 //
 // Run with ?wavelet=true (+ ?audio=tab for live Spotify).
 
-uniform float wavelet_bassZ;
-uniform float wavelet_band2Z;
-uniform float wavelet_band5Z;
+uniform float waveletBassZScore;
+uniform float waveletBand2ZScore;
+uniform float waveletBand5ZScore;
 
 #define NUM_LANES 6.0
 #define MARGIN 0.02
@@ -77,9 +80,9 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     // WAVELET group — warm hues (lanes 0..2)
     vec4 r;
-    r = lane(uv, wavelet_bassZ,  LANE_Y(0.0), vec3(1.0, 0.30, 0.20)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // red
-    r = lane(uv, wavelet_band2Z, LANE_Y(1.0), vec3(1.0, 0.65, 0.15)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // orange
-    r = lane(uv, wavelet_band5Z, LANE_Y(2.0), vec3(1.0, 0.85, 0.30)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // gold
+    r = lane(uv, waveletBassZScore,  LANE_Y(0.0), vec3(1.0, 0.30, 0.20)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // red
+    r = lane(uv, waveletBand2ZScore, LANE_Y(1.0), vec3(1.0, 0.65, 0.15)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // orange
+    r = lane(uv, waveletBand5ZScore, LANE_Y(2.0), vec3(1.0, 0.85, 0.30)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // gold
 
     // FFT group — cool hues (lanes 3..5)
     r = lane(uv, bassZScore,   LANE_Y(3.0), vec3(0.25, 0.55, 1.0)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // blue

--- a/shaders/claude/wip/wavelet-scope/8.frag
+++ b/shaders/claude/wip/wavelet-scope/8.frag
@@ -1,0 +1,91 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, oscilloscope, graph, analytics, debug
+//
+// PAIRED TAPESTRY — signal-tapestry-style lane scope (one feature per horizontal lane,
+// history scrolls right->left). Each WAVELET feature sits directly above its matched
+// FFT feature so you can read the pair's behavior over time, side by side.
+//
+//   TOP GROUP (wavelet)        BOTTOM GROUP (FFT, the method we use now)
+//   ─────────────────────      ─────────────────────────────────────────
+//   0  wavelet_bassZ           3  bassZScore         (bass dynamics)
+//   1  wavelet_band2Z          4  midsZScore         (low-mid / body)
+//   2  wavelet_band5Z          5  trebleZScore       (treble / air)
+//
+// Lane = a horizontal band. A bright line traces the feature's z-score within its lane
+// (center = z0, up = positive). Each lane is color-coded; the wavelet group runs warm
+// (reds/oranges), the FFT group runs cool (blues/violets), so the two methods are
+// instantly distinguishable. A thin divider separates the groups.
+//
+// Run with ?wavelet=true (+ ?audio=tab for live Spotify).
+
+uniform float wavelet_bassZ;
+uniform float wavelet_band2Z;
+uniform float wavelet_band5Z;
+
+#define NUM_LANES 6.0
+#define MARGIN 0.02
+#define GAP 0.006
+#define USABLE (1.0 - 2.0*MARGIN - GAP*(NUM_LANES-1.0))
+#define LANE_H (USABLE / NUM_LANES)
+// lane 0 at TOP of screen, lane 5 at bottom (so wavelet group is on top)
+#define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
+
+// Draw one feature's z-score line into its lane. Returns rgba contribution.
+vec4 lane(vec2 uv, float z, float centerY, vec3 color) {
+    float halfH = LANE_H * 0.5;
+    if (abs(uv.y - centerY) > halfH) return vec4(0.0);
+
+    // local position -0.5..0.5 within the lane; z maps to vertical displacement.
+    float local = (uv.y - centerY) / LANE_H;       // -0.5..0.5
+    float zPos = clamp(z * 0.35, -0.45, 0.45);      // z -> displacement within lane
+
+    // faint lane background + center (z=0) reference line
+    vec3 col = color * 0.06;
+    float a = 0.06;
+    if (abs(local) < 1.2 / (LANE_H * iResolution.y)) { col = color * 0.25; a = 0.25; }
+
+    // the z-score trace line
+    float d = abs(local - zPos) * LANE_H * iResolution.y; // px distance to the line
+    float line = smoothstep(3.5, 0.5, d);
+    col = mix(col, color * (1.2 + abs(z) * 0.3), line);
+    a = max(a, line);
+
+    return vec4(col, a);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = fragCoord / res;
+
+    // ---- SCROLL right -> left ----
+    if (floor(fragCoord.x) < floor(res.x) - 1.0) {
+        vec2 p = vec2((fragCoord.x + 1.0) / res.x, uv.y);
+        vec4 prev = getLastFrameColor(p);
+        prev.rgb *= 0.99;  // gentle trail fade
+        // keep the group divider crisp in history
+        if (abs(uv.y - 0.5) < 1.5/res.y) prev.rgb = vec3(0.25);
+        fragColor = vec4(prev.rgb, 1.0);
+        return;
+    }
+
+    // ---- NEW COLUMN ----
+    vec3 bg = vec3(0.01);
+    fragColor = vec4(bg, 1.0);
+
+    // group divider between wavelet (top 3) and FFT (bottom 3)
+    if (abs(uv.y - 0.5) < 1.5/res.y) { fragColor = vec4(0.25,0.25,0.25,1.0); return; }
+
+    // WAVELET group — warm hues (lanes 0..2)
+    vec4 r;
+    r = lane(uv, wavelet_bassZ,  LANE_Y(0.0), vec3(1.0, 0.30, 0.20)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // red
+    r = lane(uv, wavelet_band2Z, LANE_Y(1.0), vec3(1.0, 0.65, 0.15)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // orange
+    r = lane(uv, wavelet_band5Z, LANE_Y(2.0), vec3(1.0, 0.85, 0.30)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // gold
+
+    // FFT group — cool hues (lanes 3..5)
+    r = lane(uv, bassZScore,   LANE_Y(3.0), vec3(0.25, 0.55, 1.0)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // blue
+    r = lane(uv, midsZScore,   LANE_Y(4.0), vec3(0.45, 0.40, 1.0)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // indigo
+    r = lane(uv, trebleZScore, LANE_Y(5.0), vec3(0.70, 0.40, 1.0)); fragColor.rgb = mix(fragColor.rgb, r.rgb, r.a); // violet
+
+    fragColor.rgb = clamp(fragColor.rgb, 0.0, 1.0);
+    fragColor.a = 1.0;
+}

--- a/shaders/claude/wip/wavelet-scope/JOURNAL.md
+++ b/shaders/claude/wip/wavelet-scope/JOURNAL.md
@@ -1,0 +1,38 @@
+# Wavelet Scope — Feature Exploration Journal
+
+Running log of feature combos tested live (laptop mic, various music) and what worked.
+Each entry: what I tried, what the data/eye showed, verdict.
+
+## Metrics used
+- **sd** (movement): want > 0.06 — a flat line animates nothing
+- **jitter** (smoothness): want < 0.10 — higher reads as noise, bad for smooth visuals
+- **|corr|** (independence): want < 0.5 pairwise — correlated lanes drive only one thing
+- **fire rate / distinct hits** (triggers): want discrete hits, NOT always-on or never
+
+## Findings
+
+### Smooth animation lines (laptop mic)
+The maximally-independent smooth set that survived multiple loop iterations:
+`energyNormalized` (loudness) · `waveletBand5Normalized` (treble) · `waveletBand3Normalized` (mid) · `waveletBand1Normalized` (low-bass).
+- All pairwise |corr| ≤ 0.44, all sd 0.10–0.19, all jitter < 0.10. ✓
+- Tested swaps that ALL made it worse: `rolloffN` (0.66 w/ energyN), `band4N` (0.78 w/ band3N), `tilt` (0.67 w/ energyN), `centroid` (too flat on mic, sd 0.04). So this set is converged for mic.
+- **band1N is the weakest** (jitter 0.097, corr 0.44) but the most independent — kept.
+
+### Triggers
+- **BUG (found & fixed):** trigger fired on `zMap(z) > 0.4`, but zMap(0)=0.5 → fired ~99% of the time (always-on wall, not a trigger). Fixed to fire on RAW `z > 0.8` (genuine positive spike).
+- **`energyZScore` is the best trigger source** — 11 distinct hits in 5s. `waveletBassZScore` only 2, `spectralFluxZScore` 1 (always-on). `waveletBand5ZScore` = 9 (good for treble).
+- Mic note: `wavelet_bassHit` is weak on laptop mic (peaks ~0.15-0.25) — deep-bass transients attenuated. Use level lines or energyZ triggers instead in mic environments.
+
+### Smoothing
+- Wavelet features were 6-7× jitterier than FFT until I added EMA (a=0.18) in WaveletProcessor (FFT pipeline already smooths). Triggers (`bassHit`/`confirmedDrop`) exempt — sharpness is the point.
+
+## Shader lineage
+- `independent.frag` — pure-wavelet smooth tapestry (synthetic-tuned 6 features + EMA)
+- `combined.frag` — wavelet vs FFT vs combos (punch, confirmedDrop)
+- `bass-activity.frag` — mic-tuned: 4 smooth independent lines + 2 clean triggers
+- (more to come as I find good combos)
+
+## TODO / ideas to test
+- centroid + slope features for "frequency gliding" lanes (worked on synthetic sweeps)
+- a "drama" shader: only the most reactive independent features for high-energy music
+- cross-domain combos as smooth lines (not just triggers)

--- a/shaders/claude/wip/wavelet-scope/bass-activity.frag
+++ b/shaders/claude/wip/wavelet-scope/bass-activity.frag
@@ -31,7 +31,7 @@ uniform float waveletBand5ZScore;
 uniform float waveletBassZScore;
 // energyNormalized is a known FFT feature — auto-declared by the wrapper, just referenced.
 
-#define TRIGGER_THRESH 0.4 // z-score level (after zMap) above which a trigger "fires"
+#define Z_FIRE 0.8 // raw z-score above which a trigger fires (a genuine positive spike)
 
 #define NUM_LANES 6.0
 #define MARGIN 0.012
@@ -59,15 +59,15 @@ vec4 lane(vec2 uv, float v01, float cy, vec3 cLo, vec3 cHi) {
 
 float zMap(float z) { return clamp(z * 0.2 + 0.5, 0.0, 1.0); }
 
-// Trigger lane: renders a CLEAN full-lane flash when z crosses the threshold, instead of
-// a noisy wandering line. The flash brightness scales with how far past threshold it is.
+// Trigger lane: flashes when the RAW z-score spikes POSITIVE (a real hit), not on the
+// baseline. Bug fix: previously fired on zMap(z)>0.4, but zMap(0)=0.5 so it was on ~99%
+// of the time. Now fires only when z > Z_FIRE (a genuine positive anomaly).
 vec4 triggerLane(vec2 uv, float z, float cy, vec3 color) {
     if (abs(uv.y - cy) > LANE_H * 0.5) return vec4(0.0);
-    float v = zMap(z);
-    float fire = smoothstep(TRIGGER_THRESH, TRIGGER_THRESH + 0.25, v); // 0..1 above thresh
-    vec3 col = color * 0.06;                       // dim lane background
-    col += color * fire * 1.8;                     // bright flash on fire
-    return vec4(col, clamp(0.08 + fire, 0.0, 1.0));
+    float fire = smoothstep(Z_FIRE, Z_FIRE + 0.5, z); // fires on positive z-spikes only
+    vec3 col = color * 0.05;                          // dim lane background
+    col += color * fire * 2.0;                        // bright flash on a real hit
+    return vec4(col, clamp(0.06 + fire, 0.0, 1.0));
 }
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
@@ -87,9 +87,9 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     r = lane(uv, waveletBand5Normalized,          LANE_Y(1.0), vec3(0.0,0.45,0.5), vec3(0.2,1.0,0.95)); col = mix(col, r.rgb, r.a); // cyan  TREBLE
     r = lane(uv, waveletBand3Normalized,          LANE_Y(2.0), vec3(0.1,0.5,0.1),  vec3(0.4,1.0,0.35)); col = mix(col, r.rgb, r.a); // green MID
     r = lane(uv, waveletBand1Normalized,          LANE_Y(3.0), vec3(0.6,0.3,0.0),  vec3(1.0,0.6,0.15)); col = mix(col, r.rgb, r.a); // orange LOW
-    // TRIGGERS (clean threshold flashes)
+    // TRIGGERS (fire only on real positive z-spikes — energyZ has the best hit structure)
     r = triggerLane(uv, waveletBand5ZScore,       LANE_Y(4.0), vec3(1.0,0.9,0.2));  col = mix(col, r.rgb, r.a); // yellow TREBLE hit
-    r = triggerLane(uv, waveletBassZScore,        LANE_Y(5.0), vec3(1.0,0.3,1.0));  col = mix(col, r.rgb, r.a); // magenta BASS hit
+    r = triggerLane(uv, energyZScore,             LANE_Y(5.0), vec3(1.0,0.3,1.0));  col = mix(col, r.rgb, r.a); // magenta ENERGY hit
 
     fragColor = vec4(clamp(col, 0.0, 1.6), 1.0);
 }

--- a/shaders/claude/wip/wavelet-scope/bass-activity.frag
+++ b/shaders/claude/wip/wavelet-scope/bass-activity.frag
@@ -1,0 +1,81 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, oscilloscope, graph, debug
+//
+// BASS ACTIVITY — animation lines tuned for a LAPTOP MIC environment, where deep bass
+// is attenuated so the sharp bass-HIT trigger barely fires. Instead of the trigger, this
+// plots bass ENERGY LEVELS (which the mic captures fine and swing plenty) as bright
+// flowing lines. These are the bass-reactive signals that actually work here.
+//
+//   lane 0  waveletBassNormalized    harmonic-weighted bass LEVEL (0..1)        RED
+//   lane 1  waveletBand0Normalized   deep bass 43-86Hz level                    ORANGE
+//   lane 2  waveletBand1Normalized   low bass 86-172Hz (survives mic best)      GOLD
+//   lane 3  waveletBassZScore        bass anomaly — spikes on bass swells       GREEN
+//   lane 4  energyNormalized         overall loudness (FFT) for reference       CYAN
+//   lane 5  waveletBass              raw bass energy, scaled — biggest mover     MAGENTA
+//
+// History scrolls right->left, bright persistent lines. Run with ?wavelet=true.
+
+uniform float waveletBassNormalized;
+uniform float waveletBand0Normalized;
+uniform float waveletBand1Normalized;
+uniform float waveletBassZScore;
+uniform float waveletBass;
+// energyNormalized is a known FFT feature — auto-declared by the wrapper, just referenced.
+
+#define NUM_LANES 6.0
+#define MARGIN 0.012
+#define GAP 0.005
+#define USABLE (1.0 - 2.0*MARGIN - GAP*(NUM_LANES-1.0))
+#define LANE_H (USABLE / NUM_LANES)
+#define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
+
+// EMA-smooth toward the previous column's plotted height so lines flow.
+float smoothLane(float v01, float cy) {
+    float prevLocal = 0.5, best = 0.0;
+    for (int i = 0; i < 48; i++) {
+        float local = float(i) / 47.0;
+        float y = cy + (local - 0.5) * LANE_H;
+        vec3 pc = getLastFrameColor(vec2(1.0 - 1.5 / iResolution.x, y)).rgb;
+        float b = pc.r + pc.g + pc.b;
+        if (b > best) { best = b; prevLocal = local; }
+    }
+    return (best > 0.3) ? mix(prevLocal, clamp(v01, 0.0, 1.0), 0.35) : clamp(v01, 0.0, 1.0);
+}
+
+vec4 lane(vec2 uv, float v01, float cy, vec3 cLo, vec3 cHi) {
+    if (abs(uv.y - cy) > LANE_H * 0.5) return vec4(0.0);
+    float local = (uv.y - cy) / LANE_H + 0.5;
+    v01 = clamp(v01, 0.0, 1.0);
+    vec3 lc = mix(cLo, cHi, v01);
+    vec3 col = mix(cLo, cHi, local) * 0.07;
+    if (abs(local - 0.5) < 2.0 / (LANE_H * iResolution.y)) col += cHi * 0.18;
+    float dpx = abs(local - v01) * LANE_H * iResolution.y;
+    float core = smoothstep(4.0, 0.0, dpx);
+    float glow = smoothstep(26.0, 3.0, dpx);
+    col += lc * core * 2.2 + lc * glow * 0.5;
+    return vec4(col, clamp(core + glow * 0.5 + 0.10, 0.0, 1.0));
+}
+
+float zMap(float z) { return clamp(z * 0.2 + 0.5, 0.0, 1.0); }
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = fragCoord / res;
+
+    if (floor(fragCoord.x) < floor(res.x) - 1.0) {
+        vec2 p = vec2((fragCoord.x + 1.0) / res.x, uv.y);
+        fragColor = vec4(getLastFrameColor(p).rgb * 0.999, 1.0);
+        return;
+    }
+
+    vec3 col = vec3(0.02, 0.02, 0.03);
+    vec4 r;
+    r = lane(uv, smoothLane(waveletBassNormalized,  LANE_Y(0.0)), LANE_Y(0.0), vec3(0.6,0.05,0.1), vec3(1.0,0.3,0.25)); col = mix(col, r.rgb, r.a); // red
+    r = lane(uv, smoothLane(waveletBand0Normalized, LANE_Y(1.0)), LANE_Y(1.0), vec3(0.6,0.25,0.0), vec3(1.0,0.6,0.15)); col = mix(col, r.rgb, r.a); // orange
+    r = lane(uv, smoothLane(waveletBand1Normalized, LANE_Y(2.0)), LANE_Y(2.0), vec3(0.6,0.5,0.0),  vec3(1.0,0.9,0.2));  col = mix(col, r.rgb, r.a); // gold
+    r = lane(uv, zMap(waveletBassZScore),                         LANE_Y(3.0), vec3(0.1,0.5,0.1),  vec3(0.4,1.0,0.35)); col = mix(col, r.rgb, r.a); // green (reactive)
+    r = lane(uv, smoothLane(clamp(energyNormalized,0.0,1.0), LANE_Y(4.0)), LANE_Y(4.0), vec3(0.0,0.45,0.5), vec3(0.2,1.0,0.95)); col = mix(col, r.rgb, r.a); // cyan
+    r = lane(uv, smoothLane(clamp(waveletBass*0.4,0.0,1.0), LANE_Y(5.0)), LANE_Y(5.0), vec3(0.6,0.0,0.5), vec3(1.0,0.3,1.0)); col = mix(col, r.rgb, r.a); // magenta
+
+    fragColor = vec4(clamp(col, 0.0, 1.6), 1.0);
+}

--- a/shaders/claude/wip/wavelet-scope/bass-activity.frag
+++ b/shaders/claude/wip/wavelet-scope/bass-activity.frag
@@ -6,22 +6,32 @@
 // — useless for driving distinct visuals. These lanes each measure a DIFFERENT axis
 // (verified low cross-correlation live), so they animate independently:
 //
-//   lane 0  waveletBassNormalized    BASS level                                 RED
-//   lane 1  waveletSpread            COMPLEXITY (corr 0.05 vs bass — independent) GOLD
-//   lane 2  waveletCentroid          BRIGHTNESS (corr 0.21 vs bass)             GREEN
-//   lane 3  waveletBand5Normalized   TREBLE level (corr 0.37 vs bass)           CYAN
-//   lane 4  energyNormalized         LOUDNESS (FFT) — song dynamics             BLUE
-//   lane 5  waveletBand3Normalized   MID level                                  MAGENTA
+// MIC-TUNED (live /loop): SMOOTH flowing lines for continuous animation + clean TRIGGERS
+// for hits — no noisy z-score lines. Measured in-room: these 4 smooth movers are lively
+// (sd>0.08) AND smooth (jitter<0.1) AND independent (pairwise |corr|<0.58). The 2 trigger
+// lanes are z-scores rendered as THRESHOLDED pulses (clean bars, not jittery lines).
 //
-// History scrolls right->left, bright persistent lines. Features are EMA-smoothed in
-// WaveletProcessor so they flow. Run with ?wavelet=true.
+//   SMOOTH LINES (drive continuous visual params):
+//   lane 0  energyNormalized         LOUDNESS — song dynamics       BLUE
+//   lane 1  waveletBand5Normalized   TREBLE level                   CYAN
+//   lane 2  waveletBand3Normalized   MID level                      GREEN
+//   lane 3  waveletBand1Normalized   LOW-BASS level                 ORANGE
+//
+//   TRIGGERS (drive discrete events — flash bars when they fire):
+//   lane 4  waveletBand5ZScore       TREBLE hit                     YELLOW
+//   lane 5  waveletBassZScore        BASS hit                       MAGENTA
+//
+// History scrolls right->left. Smooth features are EMA-smoothed in WaveletProcessor.
+// Run with ?wavelet=true.
 
-uniform float waveletBassNormalized;
-uniform float waveletSpread;
-uniform float waveletCentroid;
 uniform float waveletBand5Normalized;
 uniform float waveletBand3Normalized;
+uniform float waveletBand1Normalized;
+uniform float waveletBand5ZScore;
+uniform float waveletBassZScore;
 // energyNormalized is a known FFT feature — auto-declared by the wrapper, just referenced.
+
+#define TRIGGER_THRESH 0.4 // z-score level (after zMap) above which a trigger "fires"
 
 #define NUM_LANES 6.0
 #define MARGIN 0.012
@@ -49,6 +59,17 @@ vec4 lane(vec2 uv, float v01, float cy, vec3 cLo, vec3 cHi) {
 
 float zMap(float z) { return clamp(z * 0.2 + 0.5, 0.0, 1.0); }
 
+// Trigger lane: renders a CLEAN full-lane flash when z crosses the threshold, instead of
+// a noisy wandering line. The flash brightness scales with how far past threshold it is.
+vec4 triggerLane(vec2 uv, float z, float cy, vec3 color) {
+    if (abs(uv.y - cy) > LANE_H * 0.5) return vec4(0.0);
+    float v = zMap(z);
+    float fire = smoothstep(TRIGGER_THRESH, TRIGGER_THRESH + 0.25, v); // 0..1 above thresh
+    vec3 col = color * 0.06;                       // dim lane background
+    col += color * fire * 1.8;                     // bright flash on fire
+    return vec4(col, clamp(0.08 + fire, 0.0, 1.0));
+}
+
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 res = iResolution.xy;
     vec2 uv = fragCoord / res;
@@ -61,12 +82,14 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     vec3 col = vec3(0.02, 0.02, 0.03);
     vec4 r;
-    r = lane(uv, waveletBassNormalized,           LANE_Y(0.0), vec3(0.6,0.05,0.1), vec3(1.0,0.3,0.25)); col = mix(col, r.rgb, r.a); // red   BASS
-    r = lane(uv, waveletSpread,                   LANE_Y(1.0), vec3(0.6,0.4,0.0),  vec3(1.0,0.9,0.2));  col = mix(col, r.rgb, r.a); // gold  COMPLEXITY
-    r = lane(uv, waveletCentroid,                 LANE_Y(2.0), vec3(0.1,0.5,0.1),  vec3(0.4,1.0,0.35)); col = mix(col, r.rgb, r.a); // green BRIGHTNESS
-    r = lane(uv, waveletBand5Normalized,          LANE_Y(3.0), vec3(0.0,0.45,0.5), vec3(0.2,1.0,0.95)); col = mix(col, r.rgb, r.a); // cyan  TREBLE
-    r = lane(uv, clamp(energyNormalized,0.0,1.0), LANE_Y(4.0), vec3(0.05,0.2,0.6), vec3(0.4,0.6,1.0));  col = mix(col, r.rgb, r.a); // blue  LOUDNESS
-    r = lane(uv, waveletBand3Normalized,          LANE_Y(5.0), vec3(0.6,0.0,0.5),  vec3(1.0,0.3,1.0));  col = mix(col, r.rgb, r.a); // magenta MID
+    // SMOOTH independent lines (continuous animation)
+    r = lane(uv, clamp(energyNormalized,0.0,1.0), LANE_Y(0.0), vec3(0.05,0.2,0.6), vec3(0.4,0.6,1.0));  col = mix(col, r.rgb, r.a); // blue  LOUDNESS
+    r = lane(uv, waveletBand5Normalized,          LANE_Y(1.0), vec3(0.0,0.45,0.5), vec3(0.2,1.0,0.95)); col = mix(col, r.rgb, r.a); // cyan  TREBLE
+    r = lane(uv, waveletBand3Normalized,          LANE_Y(2.0), vec3(0.1,0.5,0.1),  vec3(0.4,1.0,0.35)); col = mix(col, r.rgb, r.a); // green MID
+    r = lane(uv, waveletBand1Normalized,          LANE_Y(3.0), vec3(0.6,0.3,0.0),  vec3(1.0,0.6,0.15)); col = mix(col, r.rgb, r.a); // orange LOW
+    // TRIGGERS (clean threshold flashes)
+    r = triggerLane(uv, waveletBand5ZScore,       LANE_Y(4.0), vec3(1.0,0.9,0.2));  col = mix(col, r.rgb, r.a); // yellow TREBLE hit
+    r = triggerLane(uv, waveletBassZScore,        LANE_Y(5.0), vec3(1.0,0.3,1.0));  col = mix(col, r.rgb, r.a); // magenta BASS hit
 
     fragColor = vec4(clamp(col, 0.0, 1.6), 1.0);
 }

--- a/shaders/claude/wip/wavelet-scope/bass-activity.frag
+++ b/shaders/claude/wip/wavelet-scope/bass-activity.frag
@@ -1,25 +1,26 @@
 // @fullscreen: true
 // @tags: diagnostic, wavelet, oscilloscope, graph, debug
 //
-// BASS ACTIVITY — animation lines tuned for a LAPTOP MIC environment, where deep bass
-// is attenuated so the sharp bass-HIT trigger barely fires. Instead of the trigger, this
-// plots bass ENERGY LEVELS (which the mic captures fine and swing plenty) as bright
-// flowing lines. These are the bass-reactive signals that actually work here.
+// INDEPENDENT ACTIVITY — animation lines that move INDEPENDENTLY (not in sync). The old
+// version plotted 4 flavors of bass, which all spike together on a kick (live corr 0.7-0.9)
+// — useless for driving distinct visuals. These lanes each measure a DIFFERENT axis
+// (verified low cross-correlation live), so they animate independently:
 //
-//   lane 0  waveletBassNormalized    harmonic-weighted bass LEVEL (0..1)        RED
-//   lane 1  waveletBand0Normalized   deep bass 43-86Hz level                    ORANGE
-//   lane 2  waveletBand1Normalized   low bass 86-172Hz (survives mic best)      GOLD
-//   lane 3  waveletBassZScore        bass anomaly — spikes on bass swells       GREEN
-//   lane 4  energyNormalized         overall loudness (FFT) for reference       CYAN
-//   lane 5  waveletBass              raw bass energy, scaled — biggest mover     MAGENTA
+//   lane 0  waveletBassNormalized    BASS level                                 RED
+//   lane 1  waveletSpread            COMPLEXITY (corr 0.05 vs bass — independent) GOLD
+//   lane 2  waveletCentroid          BRIGHTNESS (corr 0.21 vs bass)             GREEN
+//   lane 3  waveletBand5Normalized   TREBLE level (corr 0.37 vs bass)           CYAN
+//   lane 4  energyNormalized         LOUDNESS (FFT) — song dynamics             BLUE
+//   lane 5  waveletBand3Normalized   MID level                                  MAGENTA
 //
-// History scrolls right->left, bright persistent lines. Run with ?wavelet=true.
+// History scrolls right->left, bright persistent lines. Features are EMA-smoothed in
+// WaveletProcessor so they flow. Run with ?wavelet=true.
 
 uniform float waveletBassNormalized;
-uniform float waveletBand0Normalized;
-uniform float waveletBand1Normalized;
-uniform float waveletBassZScore;
-uniform float waveletBass;
+uniform float waveletSpread;
+uniform float waveletCentroid;
+uniform float waveletBand5Normalized;
+uniform float waveletBand3Normalized;
 // energyNormalized is a known FFT feature — auto-declared by the wrapper, just referenced.
 
 #define NUM_LANES 6.0
@@ -29,18 +30,8 @@ uniform float waveletBass;
 #define LANE_H (USABLE / NUM_LANES)
 #define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
 
-// EMA-smooth toward the previous column's plotted height so lines flow.
-float smoothLane(float v01, float cy) {
-    float prevLocal = 0.5, best = 0.0;
-    for (int i = 0; i < 48; i++) {
-        float local = float(i) / 47.0;
-        float y = cy + (local - 0.5) * LANE_H;
-        vec3 pc = getLastFrameColor(vec2(1.0 - 1.5 / iResolution.x, y)).rgb;
-        float b = pc.r + pc.g + pc.b;
-        if (b > best) { best = b; prevLocal = local; }
-    }
-    return (best > 0.3) ? mix(prevLocal, clamp(v01, 0.0, 1.0), 0.35) : clamp(v01, 0.0, 1.0);
-}
+// (Smoothing now happens in WaveletProcessor — the published features are already
+// EMA-smoothed to match the FFT pipeline, so the shader just plots them directly.)
 
 vec4 lane(vec2 uv, float v01, float cy, vec3 cLo, vec3 cHi) {
     if (abs(uv.y - cy) > LANE_H * 0.5) return vec4(0.0);
@@ -70,12 +61,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     vec3 col = vec3(0.02, 0.02, 0.03);
     vec4 r;
-    r = lane(uv, smoothLane(waveletBassNormalized,  LANE_Y(0.0)), LANE_Y(0.0), vec3(0.6,0.05,0.1), vec3(1.0,0.3,0.25)); col = mix(col, r.rgb, r.a); // red
-    r = lane(uv, smoothLane(waveletBand0Normalized, LANE_Y(1.0)), LANE_Y(1.0), vec3(0.6,0.25,0.0), vec3(1.0,0.6,0.15)); col = mix(col, r.rgb, r.a); // orange
-    r = lane(uv, smoothLane(waveletBand1Normalized, LANE_Y(2.0)), LANE_Y(2.0), vec3(0.6,0.5,0.0),  vec3(1.0,0.9,0.2));  col = mix(col, r.rgb, r.a); // gold
-    r = lane(uv, zMap(waveletBassZScore),                         LANE_Y(3.0), vec3(0.1,0.5,0.1),  vec3(0.4,1.0,0.35)); col = mix(col, r.rgb, r.a); // green (reactive)
-    r = lane(uv, smoothLane(clamp(energyNormalized,0.0,1.0), LANE_Y(4.0)), LANE_Y(4.0), vec3(0.0,0.45,0.5), vec3(0.2,1.0,0.95)); col = mix(col, r.rgb, r.a); // cyan
-    r = lane(uv, smoothLane(clamp(waveletBass*0.4,0.0,1.0), LANE_Y(5.0)), LANE_Y(5.0), vec3(0.6,0.0,0.5), vec3(1.0,0.3,1.0)); col = mix(col, r.rgb, r.a); // magenta
+    r = lane(uv, waveletBassNormalized,           LANE_Y(0.0), vec3(0.6,0.05,0.1), vec3(1.0,0.3,0.25)); col = mix(col, r.rgb, r.a); // red   BASS
+    r = lane(uv, waveletSpread,                   LANE_Y(1.0), vec3(0.6,0.4,0.0),  vec3(1.0,0.9,0.2));  col = mix(col, r.rgb, r.a); // gold  COMPLEXITY
+    r = lane(uv, waveletCentroid,                 LANE_Y(2.0), vec3(0.1,0.5,0.1),  vec3(0.4,1.0,0.35)); col = mix(col, r.rgb, r.a); // green BRIGHTNESS
+    r = lane(uv, waveletBand5Normalized,          LANE_Y(3.0), vec3(0.0,0.45,0.5), vec3(0.2,1.0,0.95)); col = mix(col, r.rgb, r.a); // cyan  TREBLE
+    r = lane(uv, clamp(energyNormalized,0.0,1.0), LANE_Y(4.0), vec3(0.05,0.2,0.6), vec3(0.4,0.6,1.0));  col = mix(col, r.rgb, r.a); // blue  LOUDNESS
+    r = lane(uv, waveletBand3Normalized,          LANE_Y(5.0), vec3(0.6,0.0,0.5),  vec3(1.0,0.3,1.0));  col = mix(col, r.rgb, r.a); // magenta MID
 
     fragColor = vec4(clamp(col, 0.0, 1.6), 1.0);
 }

--- a/shaders/claude/wip/wavelet-scope/centroid-solo.frag
+++ b/shaders/claude/wip/wavelet-scope/centroid-solo.frag
@@ -1,0 +1,56 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, oscilloscope, debug
+//
+// CENTROID SOLO — one feature, full screen, BRIGHT and SMOOTHED so a frequency
+// ramp/oscillation reads as a clean rising/falling line. Plots waveletCentroid
+// (spectral brightness): up = pitch higher, down = pitch lower. Run with ?wavelet=true.
+//
+// The value is smoothed against the previous frame's plotted height (read back from the
+// scrolled image) so fast jitter becomes a clean curve instead of fuzz.
+
+uniform float waveletCentroid;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = fragCoord / res;
+
+    // ---- SCROLL (and decode previous height from the rightmost-but-one column) ----
+    if (floor(fragCoord.x) < floor(res.x) - 1.0) {
+        vec2 p = vec2((fragCoord.x + 1.0) / res.x, uv.y);
+        fragColor = vec4(getLastFrameColor(p).rgb * 0.95, 1.0);
+        return;
+    }
+
+    // Read where the line was one column back (its brightness peak height), to smooth.
+    // Sample a vertical strip of the previous column and find the brightest row.
+    float prevH = 0.5, best = 0.0;
+    for (int i = 0; i < 64; i++) {
+        float y = float(i) / 63.0;
+        float b = getLastFrameColor(vec2(1.0 - 1.5 / res.x, y)).g; // green channel ~ line
+        if (b > best) { best = b; prevH = y; }
+    }
+    float target = clamp(waveletCentroid, 0.0, 1.0);
+    // smooth toward target so the trace is a clean curve (0.25 = responsive but smooth)
+    float v = (best > 0.1) ? mix(prevH, target, 0.25) : target;
+
+    // ---- DRAW the bright line ----
+    float dpx = abs(uv.y - v) * res.y;
+    float core = smoothstep(5.0, 0.0, dpx);    // crisp bright core
+    float glow = smoothstep(70.0, 5.0, dpx);   // wide bloom
+
+    // color sweeps with height: red(bass/low) → yellow → cyan(treble/high)
+    vec3 c = v < 0.5
+        ? mix(vec3(1.0, 0.25, 0.15), vec3(1.0, 0.9, 0.2), v * 2.0)
+        : mix(vec3(1.0, 0.9, 0.2), vec3(0.2, 0.95, 1.0), (v - 0.5) * 2.0);
+
+    // reference gridlines
+    float grid = 0.0;
+    grid += smoothstep(1.5, 0.0, abs(uv.y - 0.25) * res.y);
+    grid += smoothstep(1.5, 0.0, abs(uv.y - 0.50) * res.y);
+    grid += smoothstep(1.5, 0.0, abs(uv.y - 0.75) * res.y);
+
+    vec3 col = vec3(0.03, 0.03, 0.06) + vec3(0.10, 0.10, 0.14) * grid;
+    col += c * core * 2.2 + c * glow * 0.6;   // bright
+
+    fragColor = vec4(clamp(col, 0.0, 2.0), 1.0);
+}

--- a/shaders/claude/wip/wavelet-scope/combined.frag
+++ b/shaders/claude/wip/wavelet-scope/combined.frag
@@ -1,0 +1,71 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, fft, oscilloscope, graph, debug
+//
+// WAVELET × FFT COMBINED SCOPE — showcases cross-domain combined features next to the
+// pure wavelet ones. The harness proved wavelet onsets are independent from ALL FFT
+// features, so these blends (wavelet=WHEN, FFT=WHAT) add real information.
+//
+//   lane 0  waveletCentroid       pure wavelet brightness            ROSE
+//   lane 1  waveletSpread         pure wavelet complexity            GOLD
+//   lane 2  spectralCentroid      pure FFT brightness (precise)      GREEN
+//   lane 3  wavelet_punch         COMBO: fast bass onset + accurate level   CYAN
+//   lane 4  wavelet_confirmedDrop COMBO: drop cross-confirmed by both domains  BLUE
+//   lane 5  wavelet_bassHit       pure wavelet trigger (for comparison)  MAGENTA
+//
+// Watch lane 5 (wavelet alone) vs lane 4 (cross-confirmed): lane 4 fires only when the
+// FFT energy ALSO rises — fewer false drops. Run with ?wavelet=true.
+
+uniform float waveletCentroid;
+uniform float waveletSpread;
+uniform float wavelet_punch;
+uniform float wavelet_confirmedDrop;
+uniform float wavelet_bassHit;
+// NOTE: spectralCentroid is a known FFT feature — auto-declared by the wrapper, so we
+// do NOT declare it here (redeclaration is a compile error). Just reference it.
+
+#define NUM_LANES 6.0
+#define MARGIN 0.012
+#define GAP 0.004
+#define USABLE (1.0 - 2.0*MARGIN - GAP*(NUM_LANES-1.0))
+#define LANE_H (USABLE / NUM_LANES)
+#define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
+
+vec4 lane(vec2 uv, float v01, float centerY, vec3 cLo, vec3 cHi) {
+    if (abs(uv.y - centerY) > LANE_H * 0.5) return vec4(0.0);
+    float local = (uv.y - centerY) / LANE_H + 0.5;
+    v01 = clamp(v01, 0.0, 1.0);
+    vec3 lc = mix(cLo, cHi, v01);
+    vec3 col = mix(cLo, cHi, local) * 0.05;
+    float a = 0.10;
+    if (abs(local - 0.5) < 1.5 / (LANE_H * iResolution.y)) col += cHi * 0.15;
+    float dpx = abs(local - v01) * LANE_H * iResolution.y;
+    float core = smoothstep(3.0, 0.0, dpx);
+    float glow = smoothstep(22.0, 2.0, dpx);
+    col += lc * core * 1.6 + lc * glow * 0.35;
+    a = max(a, core + glow * 0.4);
+    return vec4(col, clamp(a, 0.0, 1.0));
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = fragCoord / res;
+
+    if (floor(fragCoord.x) < floor(res.x) - 1.0) {
+        vec2 p = vec2((fragCoord.x + 1.0) / res.x, uv.y);
+        fragColor = vec4(getLastFrameColor(p).rgb * 0.985, 1.0);
+        return;
+    }
+
+    vec3 col = vec3(0.02, 0.02, 0.03);
+    vec4 r;
+    r = lane(uv, waveletCentroid,                       LANE_Y(0.0), vec3(0.6,0.05,0.25), vec3(1.0,0.35,0.45)); col = mix(col, r.rgb, r.a); // rose (wavelet bright)
+    r = lane(uv, waveletSpread,                         LANE_Y(1.0), vec3(0.7,0.35,0.0),  vec3(1.0,0.85,0.2));  col = mix(col, r.rgb, r.a); // gold (wavelet complexity)
+    r = lane(uv, clamp(spectralCentroid*0.7,0.0,1.0),   LANE_Y(2.0), vec3(0.2,0.5,0.05),  vec3(0.6,1.0,0.25));  col = mix(col, r.rgb, r.a); // green (FFT bright)
+    r = lane(uv, clamp(wavelet_punch,0.0,1.0),          LANE_Y(3.0), vec3(0.0,0.5,0.55),  vec3(0.2,1.0,1.0));   col = mix(col, r.rgb, r.a); // cyan (COMBO punch)
+    r = lane(uv, clamp(wavelet_confirmedDrop*0.3,0.0,1.0), LANE_Y(4.0), vec3(0.05,0.2,0.6), vec3(0.35,0.6,1.0)); col = mix(col, r.rgb, r.a); // blue (COMBO drop)
+    r = lane(uv, clamp(wavelet_bassHit*0.15,0.0,1.0),   LANE_Y(5.0), vec3(0.6,0.0,0.5),   vec3(1.0,0.3,1.0));   col = mix(col, r.rgb, r.a); // magenta (wavelet trigger)
+    float hit = smoothstep(0.05, 0.3, wavelet_bassHit);
+    if (abs(uv.y - LANE_Y(5.0)) < LANE_H*0.5) col = mix(col, vec3(1.0,0.5,1.0), hit*0.6);
+
+    fragColor = vec4(clamp(col, 0.0, 1.5), 1.0);
+}

--- a/shaders/claude/wip/wavelet-scope/independent.frag
+++ b/shaders/claude/wip/wavelet-scope/independent.frag
@@ -1,25 +1,28 @@
 // @fullscreen: true
 // @tags: diagnostic, wavelet, oscilloscope, graph, debug
 //
-// INDEPENDENT SET — the 7 maximally-independent, lively wavelet features the headless
-// harness picked across 8 varied signals (all pairwise |correlation| < 0.45). These are
-// the lines to ANIMATE with: each can drive a distinct visual param without lockstep.
+// INDEPENDENT SET v2 — now plotting the variants that match what you HEAR. A steady
+// frequency glide (sweep) shows up in the RAW centroid + its SLOPE, NOT in z-scores
+// (z-score measures "unusual vs baseline", so it hides steady trends). So we mix:
+//   • RAW level lanes  → "where is the frequency / how complex is it right now"
+//   • SLOPE lanes      → "is it rising or falling" (the literal sloping-up signal)
+//   • Z-SCORE lanes    → punchy reactive hits (bass kicks)
 //
-//   lane 0  waveletBand0ZScore     43-86 Hz deep bass        RED
-//   lane 1  waveletCentroid        spectral brightness       ORANGE   (derived)
-//   lane 2  waveletBand1ZScore     86-172 Hz low bass        YELLOW
-//   lane 3  waveletSpread          spectral complexity       GREEN    (derived)
-//   lane 4  waveletBand2ZScore     172-345 Hz low-mid        TEAL
-//   lane 5  waveletBand3Normalized 345-689 Hz mid level      BLUE
-//   lane 6  wavelet_bassHit        sharp deep-bass trigger   VIOLET (full-lane flash)
+//   lane 0  waveletCentroid          RAW brightness (rises as freq glides up)  ORANGE
+//   lane 1  waveletCentroidSlope     is brightness RISING(+)/FALLING(-)        AMBER
+//   lane 2  waveletSpread            RAW spectral complexity                   GREEN
+//   lane 3  waveletBass              RAW deep-bass level                       RED
+//   lane 4  waveletBand0ZScore       deep-bass HITS (reactive)                 PINK
+//   lane 5  waveletBand3Normalized   mid level                                 BLUE
+//   lane 6  wavelet_bassHit          sharp drop trigger                        VIOLET
 //
 // History scrolls right->left, one thick smooth trace per lane. Run with ?wavelet=true.
 
-uniform float waveletBand0ZScore;
 uniform float waveletCentroid;
-uniform float waveletBand1ZScore;
+uniform float waveletCentroidSlope;
 uniform float waveletSpread;
-uniform float waveletBand2ZScore;
+uniform float waveletBass;
+uniform float waveletBand0ZScore;
 uniform float waveletBand3Normalized;
 uniform float wavelet_bassHit;
 
@@ -43,6 +46,8 @@ vec4 lane(vec2 uv, float v01, float centerY, vec3 color) {
 }
 
 float zMap(float z) { return clamp(z * 0.2 + 0.5, 0.0, 1.0); }
+// slope is small; amplify and center at 0.5 so rising=up, falling=down
+float slopeMap(float s) { return clamp(s * 300.0 + 0.5, 0.0, 1.0); }
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 res = iResolution.xy;
@@ -56,13 +61,13 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     vec3 col = vec3(0.012);
     vec4 r;
-    r = lane(uv, zMap(waveletBand0ZScore),     LANE_Y(0.0), vec3(1.0,0.22,0.18)); col = mix(col, r.rgb, r.a); // red
-    r = lane(uv, waveletCentroid,              LANE_Y(1.0), vec3(1.0,0.55,0.12)); col = mix(col, r.rgb, r.a); // orange
-    r = lane(uv, zMap(waveletBand1ZScore),     LANE_Y(2.0), vec3(1.0,0.85,0.12)); col = mix(col, r.rgb, r.a); // yellow
-    r = lane(uv, waveletSpread,                LANE_Y(3.0), vec3(0.25,0.95,0.30)); col = mix(col, r.rgb, r.a); // green
-    r = lane(uv, zMap(waveletBand2ZScore),     LANE_Y(4.0), vec3(0.15,0.85,0.85)); col = mix(col, r.rgb, r.a); // teal
-    r = lane(uv, waveletBand3Normalized,       LANE_Y(5.0), vec3(0.30,0.50,1.0));  col = mix(col, r.rgb, r.a); // blue
-    // bassHit lane: trace + bright flash when it fires
+    r = lane(uv, waveletCentroid,            LANE_Y(0.0), vec3(1.0,0.55,0.12)); col = mix(col, r.rgb, r.a); // orange RAW brightness
+    r = lane(uv, slopeMap(waveletCentroidSlope), LANE_Y(1.0), vec3(1.0,0.80,0.30)); col = mix(col, r.rgb, r.a); // amber SLOPE
+    r = lane(uv, waveletSpread,              LANE_Y(2.0), vec3(0.25,0.95,0.30)); col = mix(col, r.rgb, r.a); // green complexity
+    r = lane(uv, clamp(waveletBass*0.3,0.0,1.0), LANE_Y(3.0), vec3(1.0,0.25,0.20)); col = mix(col, r.rgb, r.a); // red RAW bass
+    r = lane(uv, zMap(waveletBand0ZScore),   LANE_Y(4.0), vec3(1.0,0.35,0.70)); col = mix(col, r.rgb, r.a); // pink bass HITS
+    r = lane(uv, waveletBand3Normalized,     LANE_Y(5.0), vec3(0.30,0.50,1.0)); col = mix(col, r.rgb, r.a); // blue mid
+    // bassHit lane: trace + flash
     r = lane(uv, clamp(wavelet_bassHit*0.15,0.0,1.0), LANE_Y(6.0), vec3(0.7,0.4,1.0)); col = mix(col, r.rgb, r.a);
     float hit = smoothstep(0.05, 0.3, wavelet_bassHit);
     if (abs(uv.y - LANE_Y(6.0)) < LANE_H*0.5) col = mix(col, vec3(0.9,0.7,1.0), hit*0.45);

--- a/shaders/claude/wip/wavelet-scope/independent.frag
+++ b/shaders/claude/wip/wavelet-scope/independent.frag
@@ -1,0 +1,72 @@
+// @fullscreen: true
+// @tags: diagnostic, wavelet, oscilloscope, graph, debug
+//
+// INDEPENDENT QUINTET — the maximally-independent wavelet features the headless
+// harness picked (all pairwise |correlation| < 0.5 across 8 varied signals). These
+// are the lines we want to ANIMATE with: lively, low-jitter, and mutually independent
+// so they can drive distinct visual params without moving in lockstep.
+//
+//   lane 0  waveletBand0ZScore    43-86 Hz   deep bass        RED
+//   lane 1  waveletBand1ZScore    86-172 Hz  low bass         ORANGE
+//   lane 2  waveletBand2Normalized 172-345Hz low-mid          YELLOW
+//   lane 3  waveletBand3ZScore    345-689 Hz mid              GREEN
+//   lane 4  wavelet_bassHit       sharp deep-bass drop trigger CYAN (full-edge flash)
+//
+// History scrolls right->left, one thick smooth trace per lane. Run with ?wavelet=true.
+
+uniform float waveletBand0ZScore;
+uniform float waveletBand1ZScore;
+uniform float waveletBand2Normalized;
+uniform float waveletBand3ZScore;
+uniform float wavelet_bassHit;
+
+#define NUM_LANES 5.0
+#define MARGIN 0.02
+#define GAP 0.008
+#define USABLE (1.0 - 2.0*MARGIN - GAP*(NUM_LANES-1.0))
+#define LANE_H (USABLE / NUM_LANES)
+#define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
+
+// trace one value (already 0..1) into a lane; returns rgba
+vec4 lane(vec2 uv, float v01, float centerY, vec3 color) {
+    float halfH = LANE_H * 0.5;
+    if (abs(uv.y - centerY) > halfH) return vec4(0.0);
+    float local = (uv.y - centerY) / LANE_H + 0.5;       // 0..1 bottom→top of lane
+    vec3 col = color * 0.06; float a = 0.06;
+    // center reference
+    if (abs(local - 0.5) < 1.0 / (LANE_H * iResolution.y)) { col = color * 0.22; a = 0.22; }
+    float d = abs(local - clamp(v01, 0.0, 1.0)) * LANE_H * iResolution.y;
+    float line = smoothstep(3.5, 0.5, d);
+    col = mix(col, color * 1.3, line);
+    a = max(a, line);
+    return vec4(col, a);
+}
+
+// map a z-score (~[-2.5,2.5]) to 0..1
+float zMap(float z) { return clamp(z * 0.2 + 0.5, 0.0, 1.0); }
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 res = iResolution.xy;
+    vec2 uv = fragCoord / res;
+
+    // scroll
+    if (floor(fragCoord.x) < floor(res.x) - 1.0) {
+        vec2 p = vec2((fragCoord.x + 1.0) / res.x, uv.y);
+        vec3 prev = getLastFrameColor(p).rgb * 0.99;
+        fragColor = vec4(prev, 1.0);
+        return;
+    }
+
+    vec3 col = vec3(0.012);
+    vec4 r;
+    r = lane(uv, zMap(waveletBand0ZScore),   LANE_Y(0.0), vec3(1.0,0.25,0.20)); col = mix(col, r.rgb, r.a); // red
+    r = lane(uv, zMap(waveletBand1ZScore),   LANE_Y(1.0), vec3(1.0,0.55,0.15)); col = mix(col, r.rgb, r.a); // orange
+    r = lane(uv, waveletBand2Normalized,     LANE_Y(2.0), vec3(1.0,0.85,0.15)); col = mix(col, r.rgb, r.a); // yellow
+    r = lane(uv, zMap(waveletBand3ZScore),   LANE_Y(3.0), vec3(0.25,0.95,0.35)); col = mix(col, r.rgb, r.a); // green
+    // bassHit lane: trace + a bright flash across the lane when it fires
+    r = lane(uv, clamp(wavelet_bassHit * 0.15, 0.0, 1.0), LANE_Y(4.0), vec3(0.1,0.9,1.0)); col = mix(col, r.rgb, r.a);
+    float hit = smoothstep(0.05, 0.3, wavelet_bassHit);
+    if (abs(uv.y - LANE_Y(4.0)) < LANE_H*0.5) col = mix(col, vec3(0.6,1.0,1.0), hit*0.4);
+
+    fragColor = vec4(clamp(col, 0.0, 1.0), 1.0);
+}

--- a/shaders/claude/wip/wavelet-scope/independent.frag
+++ b/shaders/claude/wip/wavelet-scope/independent.frag
@@ -1,22 +1,21 @@
 // @fullscreen: true
 // @tags: diagnostic, wavelet, oscilloscope, graph, debug
 //
-// WAVELET TAPESTRY — multiple bright animation lines, one relevant audio feature per
-// lane, history scrolling right->left. Tuned for legibility: bold glowing traces +
-// lightly smoothed so ramps/oscillations read as clean curves, not jittery fuzz.
+// WAVELET TAPESTRY — iter: top animation features by motion analysis (smooth flow +
+// full-range coverage). Bright persistent lines, history scrolls right->left.
 //
-//   lane 0  waveletCentroid     BRIGHTNESS  — rises/falls as pitch glides up/down  ROSE
-//   lane 1  waveletSpread       COMPLEXITY  — noisy/full vs pure tone               GOLD
-//   lane 2  waveletBand1Normalized  LOW-BASS level                                 GREEN
-//   lane 3  waveletBand3Normalized  MID level                                      TEAL
-//   lane 4  waveletBand5Normalized  TREBLE level                                   AZURE
-//   lane 5  wavelet_bassHit     DROP trigger (flashes)                             MAGENTA
+//   lane 0  waveletCentroid          BRIGHTNESS — smoothest line (autocorr 0.97)   ROSE
+//   lane 1  waveletSpread            COMPLEXITY — 2nd smoothest (0.88)             GOLD
+//   lane 2  waveletBassNormalized    BASS level — full-range coverage             GREEN
+//   lane 3  waveletBand3Normalized   MID level                                    TEAL
+//   lane 4  waveletBand5Normalized   TREBLE level (shows freq glides)             AZURE
+//   lane 5  wavelet_bassHit          DROP trigger (reactive flash)                MAGENTA
 //
 // Run with ?wavelet=true (+ audio_file= or audio=tab).
 
 uniform float waveletCentroid;
 uniform float waveletSpread;
-uniform float waveletBand1Normalized;
+uniform float waveletBassNormalized;
 uniform float waveletBand3Normalized;
 uniform float waveletBand5Normalized;
 uniform float wavelet_bassHit;
@@ -28,18 +27,16 @@ uniform float wavelet_bassHit;
 #define LANE_H (USABLE / NUM_LANES)
 #define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
 
-// Bright glowing trace at height v01 within its lane, two-color gradient + bloom.
 vec4 lane(vec2 uv, float v01, float cy, vec3 cLo, vec3 cHi) {
     if (abs(uv.y - cy) > LANE_H * 0.5) return vec4(0.0);
-    float local = (uv.y - cy) / LANE_H + 0.5;   // 0..1 bottom→top
+    float local = (uv.y - cy) / LANE_H + 0.5;
     v01 = clamp(v01, 0.0, 1.0);
     vec3 lc = mix(cLo, cHi, v01);
-    // tinted lane bg so lanes stay visually separated even when quiet
     vec3 col = mix(cLo, cHi, local) * 0.07;
-    if (abs(local - 0.5) < 2.0 / (LANE_H * iResolution.y)) col += cHi * 0.18; // center ref
+    if (abs(local - 0.5) < 2.0 / (LANE_H * iResolution.y)) col += cHi * 0.18;
     float dpx = abs(local - v01) * LANE_H * iResolution.y;
-    float core = smoothstep(4.0, 0.0, dpx);       // crisp core
-    float glow = smoothstep(26.0, 3.0, dpx);      // bloom
+    float core = smoothstep(4.0, 0.0, dpx);
+    float glow = smoothstep(26.0, 3.0, dpx);
     col += lc * core * 2.2 + lc * glow * 0.5;
     return vec4(col, clamp(core + glow * 0.5 + 0.10, 0.0, 1.0));
 }
@@ -48,8 +45,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 res = iResolution.xy;
     vec2 uv = fragCoord / res;
 
-    // scroll left — NO fade, so historical lines stay fully bright across the screen.
-    // (a tiny 0.999 keeps the tinted backgrounds from accumulating to white over time)
+    // scroll left, history stays bright (no fade)
     if (floor(fragCoord.x) < floor(res.x) - 1.0) {
         vec2 p = vec2((fragCoord.x + 1.0) / res.x, uv.y);
         fragColor = vec4(getLastFrameColor(p).rgb * 0.999, 1.0);
@@ -60,10 +56,9 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec4 r;
     r = lane(uv, waveletCentroid,         LANE_Y(0.0), vec3(0.6,0.05,0.25), vec3(1.0,0.40,0.50)); col = mix(col, r.rgb, r.a); // rose
     r = lane(uv, waveletSpread,           LANE_Y(1.0), vec3(0.7,0.35,0.0),  vec3(1.0,0.88,0.25)); col = mix(col, r.rgb, r.a); // gold
-    r = lane(uv, waveletBand1Normalized,  LANE_Y(2.0), vec3(0.1,0.45,0.1),  vec3(0.45,1.0,0.35)); col = mix(col, r.rgb, r.a); // green
+    r = lane(uv, waveletBassNormalized,   LANE_Y(2.0), vec3(0.1,0.45,0.1),  vec3(0.45,1.0,0.35)); col = mix(col, r.rgb, r.a); // green
     r = lane(uv, waveletBand3Normalized,  LANE_Y(3.0), vec3(0.0,0.45,0.5),  vec3(0.2,1.0,0.95));  col = mix(col, r.rgb, r.a); // teal
     r = lane(uv, waveletBand5Normalized,  LANE_Y(4.0), vec3(0.05,0.2,0.6),  vec3(0.4,0.65,1.0));  col = mix(col, r.rgb, r.a); // azure
-    // trigger lane: trace + flash
     r = lane(uv, clamp(wavelet_bassHit*0.15,0.0,1.0), LANE_Y(5.0), vec3(0.6,0.0,0.5), vec3(1.0,0.35,1.0)); col = mix(col, r.rgb, r.a);
     float hit = smoothstep(0.05, 0.3, wavelet_bassHit);
     if (abs(uv.y - LANE_Y(5.0)) < LANE_H*0.5) col = mix(col, vec3(1.0,0.5,1.0), hit*0.6);

--- a/shaders/claude/wip/wavelet-scope/independent.frag
+++ b/shaders/claude/wip/wavelet-scope/independent.frag
@@ -1,8 +1,11 @@
 // @fullscreen: true
 // @tags: diagnostic, wavelet, oscilloscope, graph, debug
 //
-// WAVELET TAPESTRY — iter: top animation features by motion analysis (smooth flow +
-// full-range coverage). Bright persistent lines, history scrolls right->left.
+// WAVELET TAPESTRY — iter: top animation features + per-lane EMA smoothing. Headless
+// analysis showed a light EMA (a=0.3) lifts smoothness (autocorr 0.6->0.97) while
+// keeping motion — turning choppy lines into silky flowing animation curves.
+// Each new sample is EMA-blended with the previous column's plotted height (read back
+// from the scrolled image), so the traces flow. Bright persistent history.
 //
 //   lane 0  waveletCentroid          BRIGHTNESS — smoothest line (autocorr 0.97)   ROSE
 //   lane 1  waveletSpread            COMPLEXITY — 2nd smoothest (0.88)             GOLD
@@ -26,6 +29,22 @@ uniform float wavelet_bassHit;
 #define USABLE (1.0 - 2.0*MARGIN - GAP*(NUM_LANES-1.0))
 #define LANE_H (USABLE / NUM_LANES)
 #define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
+
+// EMA-smooth the value toward where the line was one column back, so traces flow.
+// Reads the previous column's brightest row within this lane = the old line height.
+float smoothLane(float v01, float cy) {
+    float prevLocal = 0.5, best = 0.0;
+    for (int i = 0; i < 48; i++) {
+        float local = float(i) / 47.0;
+        float y = cy + (local - 0.5) * LANE_H;
+        float b = getLastFrameColor(vec2(1.0 - 1.5 / iResolution.x, y)).r
+                + getLastFrameColor(vec2(1.0 - 1.5 / iResolution.x, y)).g
+                + getLastFrameColor(vec2(1.0 - 1.5 / iResolution.x, y)).b;
+        if (b > best) { best = b; prevLocal = local; }
+    }
+    // blend toward target (a=0.3): smooth flow but still responsive
+    return (best > 0.3) ? mix(prevLocal, clamp(v01, 0.0, 1.0), 0.3) : clamp(v01, 0.0, 1.0);
+}
 
 vec4 lane(vec2 uv, float v01, float cy, vec3 cLo, vec3 cHi) {
     if (abs(uv.y - cy) > LANE_H * 0.5) return vec4(0.0);
@@ -54,11 +73,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     vec3 col = vec3(0.02, 0.02, 0.03);
     vec4 r;
-    r = lane(uv, waveletCentroid,         LANE_Y(0.0), vec3(0.6,0.05,0.25), vec3(1.0,0.40,0.50)); col = mix(col, r.rgb, r.a); // rose
-    r = lane(uv, waveletSpread,           LANE_Y(1.0), vec3(0.7,0.35,0.0),  vec3(1.0,0.88,0.25)); col = mix(col, r.rgb, r.a); // gold
-    r = lane(uv, waveletBassNormalized,   LANE_Y(2.0), vec3(0.1,0.45,0.1),  vec3(0.45,1.0,0.35)); col = mix(col, r.rgb, r.a); // green
-    r = lane(uv, waveletBand3Normalized,  LANE_Y(3.0), vec3(0.0,0.45,0.5),  vec3(0.2,1.0,0.95));  col = mix(col, r.rgb, r.a); // teal
-    r = lane(uv, waveletBand5Normalized,  LANE_Y(4.0), vec3(0.05,0.2,0.6),  vec3(0.4,0.65,1.0));  col = mix(col, r.rgb, r.a); // azure
+    r = lane(uv, smoothLane(waveletCentroid,        LANE_Y(0.0)), LANE_Y(0.0), vec3(0.6,0.05,0.25), vec3(1.0,0.40,0.50)); col = mix(col, r.rgb, r.a); // rose
+    r = lane(uv, smoothLane(waveletSpread,          LANE_Y(1.0)), LANE_Y(1.0), vec3(0.7,0.35,0.0),  vec3(1.0,0.88,0.25)); col = mix(col, r.rgb, r.a); // gold
+    r = lane(uv, smoothLane(waveletBassNormalized,  LANE_Y(2.0)), LANE_Y(2.0), vec3(0.1,0.45,0.1),  vec3(0.45,1.0,0.35)); col = mix(col, r.rgb, r.a); // green
+    r = lane(uv, smoothLane(waveletBand3Normalized, LANE_Y(3.0)), LANE_Y(3.0), vec3(0.0,0.45,0.5),  vec3(0.2,1.0,0.95));  col = mix(col, r.rgb, r.a); // teal
+    r = lane(uv, smoothLane(waveletBand5Normalized, LANE_Y(4.0)), LANE_Y(4.0), vec3(0.05,0.2,0.6),  vec3(0.4,0.65,1.0));  col = mix(col, r.rgb, r.a); // azure
+    // trigger lane stays UN-smoothed — sharpness is the point
     r = lane(uv, clamp(wavelet_bassHit*0.15,0.0,1.0), LANE_Y(5.0), vec3(0.6,0.0,0.5), vec3(1.0,0.35,1.0)); col = mix(col, r.rgb, r.a);
     float hit = smoothstep(0.05, 0.3, wavelet_bassHit);
     if (abs(uv.y - LANE_Y(5.0)) < LANE_H*0.5) col = mix(col, vec3(1.0,0.5,1.0), hit*0.6);

--- a/shaders/claude/wip/wavelet-scope/independent.frag
+++ b/shaders/claude/wip/wavelet-scope/independent.frag
@@ -1,39 +1,39 @@
 // @fullscreen: true
 // @tags: diagnostic, wavelet, oscilloscope, graph, debug
 //
-// INDEPENDENT QUINTET — the maximally-independent wavelet features the headless
-// harness picked (all pairwise |correlation| < 0.5 across 8 varied signals). These
-// are the lines we want to ANIMATE with: lively, low-jitter, and mutually independent
-// so they can drive distinct visual params without moving in lockstep.
+// INDEPENDENT SET — the 7 maximally-independent, lively wavelet features the headless
+// harness picked across 8 varied signals (all pairwise |correlation| < 0.45). These are
+// the lines to ANIMATE with: each can drive a distinct visual param without lockstep.
 //
-//   lane 0  waveletBand0ZScore    43-86 Hz   deep bass        RED
-//   lane 1  waveletBand1ZScore    86-172 Hz  low bass         ORANGE
-//   lane 2  waveletBand2Normalized 172-345Hz low-mid          YELLOW
-//   lane 3  waveletBand3ZScore    345-689 Hz mid              GREEN
-//   lane 4  wavelet_bassHit       sharp deep-bass drop trigger CYAN (full-edge flash)
+//   lane 0  waveletBand0ZScore     43-86 Hz deep bass        RED
+//   lane 1  waveletCentroid        spectral brightness       ORANGE   (derived)
+//   lane 2  waveletBand1ZScore     86-172 Hz low bass        YELLOW
+//   lane 3  waveletSpread          spectral complexity       GREEN    (derived)
+//   lane 4  waveletBand2ZScore     172-345 Hz low-mid        TEAL
+//   lane 5  waveletBand3Normalized 345-689 Hz mid level      BLUE
+//   lane 6  wavelet_bassHit        sharp deep-bass trigger   VIOLET (full-lane flash)
 //
 // History scrolls right->left, one thick smooth trace per lane. Run with ?wavelet=true.
 
 uniform float waveletBand0ZScore;
+uniform float waveletCentroid;
 uniform float waveletBand1ZScore;
-uniform float waveletBand2Normalized;
-uniform float waveletBand3ZScore;
+uniform float waveletSpread;
+uniform float waveletBand2ZScore;
+uniform float waveletBand3Normalized;
 uniform float wavelet_bassHit;
 
-#define NUM_LANES 5.0
-#define MARGIN 0.02
-#define GAP 0.008
+#define NUM_LANES 7.0
+#define MARGIN 0.015
+#define GAP 0.006
 #define USABLE (1.0 - 2.0*MARGIN - GAP*(NUM_LANES-1.0))
 #define LANE_H (USABLE / NUM_LANES)
 #define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
 
-// trace one value (already 0..1) into a lane; returns rgba
 vec4 lane(vec2 uv, float v01, float centerY, vec3 color) {
-    float halfH = LANE_H * 0.5;
-    if (abs(uv.y - centerY) > halfH) return vec4(0.0);
-    float local = (uv.y - centerY) / LANE_H + 0.5;       // 0..1 bottom→top of lane
+    if (abs(uv.y - centerY) > LANE_H * 0.5) return vec4(0.0);
+    float local = (uv.y - centerY) / LANE_H + 0.5;       // 0..1 bottom→top
     vec3 col = color * 0.06; float a = 0.06;
-    // center reference
     if (abs(local - 0.5) < 1.0 / (LANE_H * iResolution.y)) { col = color * 0.22; a = 0.22; }
     float d = abs(local - clamp(v01, 0.0, 1.0)) * LANE_H * iResolution.y;
     float line = smoothstep(3.5, 0.5, d);
@@ -42,31 +42,30 @@ vec4 lane(vec2 uv, float v01, float centerY, vec3 color) {
     return vec4(col, a);
 }
 
-// map a z-score (~[-2.5,2.5]) to 0..1
 float zMap(float z) { return clamp(z * 0.2 + 0.5, 0.0, 1.0); }
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 res = iResolution.xy;
     vec2 uv = fragCoord / res;
 
-    // scroll
     if (floor(fragCoord.x) < floor(res.x) - 1.0) {
         vec2 p = vec2((fragCoord.x + 1.0) / res.x, uv.y);
-        vec3 prev = getLastFrameColor(p).rgb * 0.99;
-        fragColor = vec4(prev, 1.0);
+        fragColor = vec4(getLastFrameColor(p).rgb * 0.99, 1.0);
         return;
     }
 
     vec3 col = vec3(0.012);
     vec4 r;
-    r = lane(uv, zMap(waveletBand0ZScore),   LANE_Y(0.0), vec3(1.0,0.25,0.20)); col = mix(col, r.rgb, r.a); // red
-    r = lane(uv, zMap(waveletBand1ZScore),   LANE_Y(1.0), vec3(1.0,0.55,0.15)); col = mix(col, r.rgb, r.a); // orange
-    r = lane(uv, waveletBand2Normalized,     LANE_Y(2.0), vec3(1.0,0.85,0.15)); col = mix(col, r.rgb, r.a); // yellow
-    r = lane(uv, zMap(waveletBand3ZScore),   LANE_Y(3.0), vec3(0.25,0.95,0.35)); col = mix(col, r.rgb, r.a); // green
-    // bassHit lane: trace + a bright flash across the lane when it fires
-    r = lane(uv, clamp(wavelet_bassHit * 0.15, 0.0, 1.0), LANE_Y(4.0), vec3(0.1,0.9,1.0)); col = mix(col, r.rgb, r.a);
+    r = lane(uv, zMap(waveletBand0ZScore),     LANE_Y(0.0), vec3(1.0,0.22,0.18)); col = mix(col, r.rgb, r.a); // red
+    r = lane(uv, waveletCentroid,              LANE_Y(1.0), vec3(1.0,0.55,0.12)); col = mix(col, r.rgb, r.a); // orange
+    r = lane(uv, zMap(waveletBand1ZScore),     LANE_Y(2.0), vec3(1.0,0.85,0.12)); col = mix(col, r.rgb, r.a); // yellow
+    r = lane(uv, waveletSpread,                LANE_Y(3.0), vec3(0.25,0.95,0.30)); col = mix(col, r.rgb, r.a); // green
+    r = lane(uv, zMap(waveletBand2ZScore),     LANE_Y(4.0), vec3(0.15,0.85,0.85)); col = mix(col, r.rgb, r.a); // teal
+    r = lane(uv, waveletBand3Normalized,       LANE_Y(5.0), vec3(0.30,0.50,1.0));  col = mix(col, r.rgb, r.a); // blue
+    // bassHit lane: trace + bright flash when it fires
+    r = lane(uv, clamp(wavelet_bassHit*0.15,0.0,1.0), LANE_Y(6.0), vec3(0.7,0.4,1.0)); col = mix(col, r.rgb, r.a);
     float hit = smoothstep(0.05, 0.3, wavelet_bassHit);
-    if (abs(uv.y - LANE_Y(4.0)) < LANE_H*0.5) col = mix(col, vec3(0.6,1.0,1.0), hit*0.4);
+    if (abs(uv.y - LANE_Y(6.0)) < LANE_H*0.5) col = mix(col, vec3(0.9,0.7,1.0), hit*0.45);
 
     fragColor = vec4(clamp(col, 0.0, 1.0), 1.0);
 }

--- a/shaders/claude/wip/wavelet-scope/independent.frag
+++ b/shaders/claude/wip/wavelet-scope/independent.frag
@@ -1,81 +1,72 @@
 // @fullscreen: true
 // @tags: diagnostic, wavelet, oscilloscope, graph, debug
 //
-// WAVELET VJ SCOPE — the curated maximally-independent feature set the harness picked
-// across 20 signals (all pairwise |corr| <= 0.37), each tuned to its best variant.
-// A blend of CHARACTER (what kind of sound) + REACTIVE (what's happening) + TRIGGER.
+// WAVELET TAPESTRY — multiple bright animation lines, one relevant audio feature per
+// lane, history scrolling right->left. Tuned for legibility: bold glowing traces +
+// lightly smoothed so ramps/oscillations read as clean curves, not jittery fuzz.
 //
-//   lane 0  waveletCentroid        brightness  (rises as freq glides up)   ROSE→RED
-//   lane 1  waveletSpread          complexity  (flat noise vs pure tone)   AMBER→GOLD
-//   lane 2  waveletBand3           raw mid energy                          LIME→GREEN
-//   lane 3  waveletBand0ZScore     deep-bass HITS (reactive)               CYAN
-//   lane 4  waveletBand5ZScore     treble HITS (reactive)                  AZURE→BLUE
-//   lane 5  wavelet_bassHit        deep-bass DROP trigger                  MAGENTA→VIOLET
+//   lane 0  waveletCentroid     BRIGHTNESS  — rises/falls as pitch glides up/down  ROSE
+//   lane 1  waveletSpread       COMPLEXITY  — noisy/full vs pure tone               GOLD
+//   lane 2  waveletBand1Normalized  LOW-BASS level                                 GREEN
+//   lane 3  waveletBand3Normalized  MID level                                      TEAL
+//   lane 4  waveletBand5Normalized  TREBLE level                                   AZURE
+//   lane 5  wavelet_bassHit     DROP trigger (flashes)                             MAGENTA
 //
-// History scrolls right->left, glowing traces on tinted lanes. Run with ?wavelet=true.
+// Run with ?wavelet=true (+ audio_file= or audio=tab).
 
 uniform float waveletCentroid;
 uniform float waveletSpread;
-uniform float waveletBand3;
-uniform float waveletBand0ZScore;
-uniform float waveletBand5ZScore;
+uniform float waveletBand1Normalized;
+uniform float waveletBand3Normalized;
+uniform float waveletBand5Normalized;
 uniform float wavelet_bassHit;
 
 #define NUM_LANES 6.0
 #define MARGIN 0.012
-#define GAP 0.004
+#define GAP 0.005
 #define USABLE (1.0 - 2.0*MARGIN - GAP*(NUM_LANES-1.0))
 #define LANE_H (USABLE / NUM_LANES)
 #define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
 
-// A glowing trace at height v01 within a lane, with a two-color gradient (cLo→cHi by
-// height) and a soft bloom so it reads bright on a recording.
-vec4 lane(vec2 uv, float v01, float centerY, vec3 cLo, vec3 cHi) {
-    if (abs(uv.y - centerY) > LANE_H * 0.5) return vec4(0.0);
-    float local = (uv.y - centerY) / LANE_H + 0.5;       // 0..1 bottom→top
+// Bright glowing trace at height v01 within its lane, two-color gradient + bloom.
+vec4 lane(vec2 uv, float v01, float cy, vec3 cLo, vec3 cHi) {
+    if (abs(uv.y - cy) > LANE_H * 0.5) return vec4(0.0);
+    float local = (uv.y - cy) / LANE_H + 0.5;   // 0..1 bottom→top
     v01 = clamp(v01, 0.0, 1.0);
-    vec3 lc = mix(cLo, cHi, v01); // trace color shifts with its own value
-
-    // tinted lane background (subtle, so lanes are visually separated even when quiet)
-    vec3 col = mix(cLo, cHi, local) * 0.05;
-    float a = 0.10;
-    // center reference line
-    if (abs(local - 0.5) < 1.5 / (LANE_H * iResolution.y)) { col += cHi * 0.15; }
-
+    vec3 lc = mix(cLo, cHi, v01);
+    // tinted lane bg so lanes stay visually separated even when quiet
+    vec3 col = mix(cLo, cHi, local) * 0.07;
+    if (abs(local - 0.5) < 2.0 / (LANE_H * iResolution.y)) col += cHi * 0.18; // center ref
     float dpx = abs(local - v01) * LANE_H * iResolution.y;
-    float core = smoothstep(3.0, 0.0, dpx);       // bright core
-    float glow = smoothstep(22.0, 2.0, dpx);      // soft bloom
-    col += lc * core * 1.6 + lc * glow * 0.35;
-    a = max(a, core + glow * 0.4);
-    return vec4(col, clamp(a, 0.0, 1.0));
+    float core = smoothstep(4.0, 0.0, dpx);       // crisp core
+    float glow = smoothstep(26.0, 3.0, dpx);      // bloom
+    col += lc * core * 2.2 + lc * glow * 0.5;
+    return vec4(col, clamp(core + glow * 0.5 + 0.10, 0.0, 1.0));
 }
-
-float zMap(float z) { return clamp(z * 0.2 + 0.5, 0.0, 1.0); }
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 res = iResolution.xy;
     vec2 uv = fragCoord / res;
 
-    // scroll left with a faint trail
+    // scroll left — NO fade, so historical lines stay fully bright across the screen.
+    // (a tiny 0.999 keeps the tinted backgrounds from accumulating to white over time)
     if (floor(fragCoord.x) < floor(res.x) - 1.0) {
         vec2 p = vec2((fragCoord.x + 1.0) / res.x, uv.y);
-        fragColor = vec4(getLastFrameColor(p).rgb * 0.985, 1.0);
+        fragColor = vec4(getLastFrameColor(p).rgb * 0.999, 1.0);
         return;
     }
 
     vec3 col = vec3(0.02, 0.02, 0.03);
     vec4 r;
-    // CHARACTER lanes — warm spectrum
-    r = lane(uv, waveletCentroid,          LANE_Y(0.0), vec3(0.6,0.05,0.25), vec3(1.0,0.35,0.45)); col = mix(col, r.rgb, r.a); // rose→red
-    r = lane(uv, waveletSpread,            LANE_Y(1.0), vec3(0.7,0.35,0.0),  vec3(1.0,0.85,0.2));  col = mix(col, r.rgb, r.a); // amber→gold
-    r = lane(uv, clamp(waveletBand3*0.4,0.0,1.0), LANE_Y(2.0), vec3(0.2,0.5,0.05), vec3(0.6,1.0,0.25)); col = mix(col, r.rgb, r.a); // lime→green
-    // REACTIVE lanes — cool spectrum
-    r = lane(uv, zMap(waveletBand0ZScore), LANE_Y(3.0), vec3(0.0,0.5,0.55),  vec3(0.2,1.0,1.0));  col = mix(col, r.rgb, r.a); // cyan
-    r = lane(uv, zMap(waveletBand5ZScore), LANE_Y(4.0), vec3(0.05,0.2,0.6),  vec3(0.35,0.6,1.0)); col = mix(col, r.rgb, r.a); // azure→blue
-    // TRIGGER lane — vivid magenta with a full-lane flash on fire
-    r = lane(uv, clamp(wavelet_bassHit*0.15,0.0,1.0), LANE_Y(5.0), vec3(0.6,0.0,0.5), vec3(1.0,0.3,1.0)); col = mix(col, r.rgb, r.a);
+    r = lane(uv, waveletCentroid,         LANE_Y(0.0), vec3(0.6,0.05,0.25), vec3(1.0,0.40,0.50)); col = mix(col, r.rgb, r.a); // rose
+    r = lane(uv, waveletSpread,           LANE_Y(1.0), vec3(0.7,0.35,0.0),  vec3(1.0,0.88,0.25)); col = mix(col, r.rgb, r.a); // gold
+    r = lane(uv, waveletBand1Normalized,  LANE_Y(2.0), vec3(0.1,0.45,0.1),  vec3(0.45,1.0,0.35)); col = mix(col, r.rgb, r.a); // green
+    r = lane(uv, waveletBand3Normalized,  LANE_Y(3.0), vec3(0.0,0.45,0.5),  vec3(0.2,1.0,0.95));  col = mix(col, r.rgb, r.a); // teal
+    r = lane(uv, waveletBand5Normalized,  LANE_Y(4.0), vec3(0.05,0.2,0.6),  vec3(0.4,0.65,1.0));  col = mix(col, r.rgb, r.a); // azure
+    // trigger lane: trace + flash
+    r = lane(uv, clamp(wavelet_bassHit*0.15,0.0,1.0), LANE_Y(5.0), vec3(0.6,0.0,0.5), vec3(1.0,0.35,1.0)); col = mix(col, r.rgb, r.a);
     float hit = smoothstep(0.05, 0.3, wavelet_bassHit);
     if (abs(uv.y - LANE_Y(5.0)) < LANE_H*0.5) col = mix(col, vec3(1.0,0.5,1.0), hit*0.6);
 
-    fragColor = vec4(clamp(col, 0.0, 1.5), 1.0);
+    fragColor = vec4(clamp(col, 0.0, 1.6), 1.0);
 }

--- a/shaders/claude/wip/wavelet-scope/independent.frag
+++ b/shaders/claude/wip/wavelet-scope/independent.frag
@@ -1,76 +1,81 @@
 // @fullscreen: true
 // @tags: diagnostic, wavelet, oscilloscope, graph, debug
 //
-// INDEPENDENT SET v2 — now plotting the variants that match what you HEAR. A steady
-// frequency glide (sweep) shows up in the RAW centroid + its SLOPE, NOT in z-scores
-// (z-score measures "unusual vs baseline", so it hides steady trends). So we mix:
-//   • RAW level lanes  → "where is the frequency / how complex is it right now"
-//   • SLOPE lanes      → "is it rising or falling" (the literal sloping-up signal)
-//   • Z-SCORE lanes    → punchy reactive hits (bass kicks)
+// WAVELET VJ SCOPE — the curated maximally-independent feature set the harness picked
+// across 20 signals (all pairwise |corr| <= 0.37), each tuned to its best variant.
+// A blend of CHARACTER (what kind of sound) + REACTIVE (what's happening) + TRIGGER.
 //
-//   lane 0  waveletCentroid          RAW brightness (rises as freq glides up)  ORANGE
-//   lane 1  waveletCentroidSlope     is brightness RISING(+)/FALLING(-)        AMBER
-//   lane 2  waveletSpread            RAW spectral complexity                   GREEN
-//   lane 3  waveletBass              RAW deep-bass level                       RED
-//   lane 4  waveletBand0ZScore       deep-bass HITS (reactive)                 PINK
-//   lane 5  waveletBand3Normalized   mid level                                 BLUE
-//   lane 6  wavelet_bassHit          sharp drop trigger                        VIOLET
+//   lane 0  waveletCentroid        brightness  (rises as freq glides up)   ROSE→RED
+//   lane 1  waveletSpread          complexity  (flat noise vs pure tone)   AMBER→GOLD
+//   lane 2  waveletBand3           raw mid energy                          LIME→GREEN
+//   lane 3  waveletBand0ZScore     deep-bass HITS (reactive)               CYAN
+//   lane 4  waveletBand5ZScore     treble HITS (reactive)                  AZURE→BLUE
+//   lane 5  wavelet_bassHit        deep-bass DROP trigger                  MAGENTA→VIOLET
 //
-// History scrolls right->left, one thick smooth trace per lane. Run with ?wavelet=true.
+// History scrolls right->left, glowing traces on tinted lanes. Run with ?wavelet=true.
 
 uniform float waveletCentroid;
-uniform float waveletCentroidSlope;
 uniform float waveletSpread;
-uniform float waveletBass;
+uniform float waveletBand3;
 uniform float waveletBand0ZScore;
-uniform float waveletBand3Normalized;
+uniform float waveletBand5ZScore;
 uniform float wavelet_bassHit;
 
-#define NUM_LANES 7.0
-#define MARGIN 0.015
-#define GAP 0.006
+#define NUM_LANES 6.0
+#define MARGIN 0.012
+#define GAP 0.004
 #define USABLE (1.0 - 2.0*MARGIN - GAP*(NUM_LANES-1.0))
 #define LANE_H (USABLE / NUM_LANES)
 #define LANE_Y(i) (1.0 - MARGIN - LANE_H*0.5 - (i)*(LANE_H + GAP))
 
-vec4 lane(vec2 uv, float v01, float centerY, vec3 color) {
+// A glowing trace at height v01 within a lane, with a two-color gradient (cLo→cHi by
+// height) and a soft bloom so it reads bright on a recording.
+vec4 lane(vec2 uv, float v01, float centerY, vec3 cLo, vec3 cHi) {
     if (abs(uv.y - centerY) > LANE_H * 0.5) return vec4(0.0);
     float local = (uv.y - centerY) / LANE_H + 0.5;       // 0..1 bottom→top
-    vec3 col = color * 0.06; float a = 0.06;
-    if (abs(local - 0.5) < 1.0 / (LANE_H * iResolution.y)) { col = color * 0.22; a = 0.22; }
-    float d = abs(local - clamp(v01, 0.0, 1.0)) * LANE_H * iResolution.y;
-    float line = smoothstep(3.5, 0.5, d);
-    col = mix(col, color * 1.3, line);
-    a = max(a, line);
-    return vec4(col, a);
+    v01 = clamp(v01, 0.0, 1.0);
+    vec3 lc = mix(cLo, cHi, v01); // trace color shifts with its own value
+
+    // tinted lane background (subtle, so lanes are visually separated even when quiet)
+    vec3 col = mix(cLo, cHi, local) * 0.05;
+    float a = 0.10;
+    // center reference line
+    if (abs(local - 0.5) < 1.5 / (LANE_H * iResolution.y)) { col += cHi * 0.15; }
+
+    float dpx = abs(local - v01) * LANE_H * iResolution.y;
+    float core = smoothstep(3.0, 0.0, dpx);       // bright core
+    float glow = smoothstep(22.0, 2.0, dpx);      // soft bloom
+    col += lc * core * 1.6 + lc * glow * 0.35;
+    a = max(a, core + glow * 0.4);
+    return vec4(col, clamp(a, 0.0, 1.0));
 }
 
 float zMap(float z) { return clamp(z * 0.2 + 0.5, 0.0, 1.0); }
-// slope is small; amplify and center at 0.5 so rising=up, falling=down
-float slopeMap(float s) { return clamp(s * 300.0 + 0.5, 0.0, 1.0); }
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 res = iResolution.xy;
     vec2 uv = fragCoord / res;
 
+    // scroll left with a faint trail
     if (floor(fragCoord.x) < floor(res.x) - 1.0) {
         vec2 p = vec2((fragCoord.x + 1.0) / res.x, uv.y);
-        fragColor = vec4(getLastFrameColor(p).rgb * 0.99, 1.0);
+        fragColor = vec4(getLastFrameColor(p).rgb * 0.985, 1.0);
         return;
     }
 
-    vec3 col = vec3(0.012);
+    vec3 col = vec3(0.02, 0.02, 0.03);
     vec4 r;
-    r = lane(uv, waveletCentroid,            LANE_Y(0.0), vec3(1.0,0.55,0.12)); col = mix(col, r.rgb, r.a); // orange RAW brightness
-    r = lane(uv, slopeMap(waveletCentroidSlope), LANE_Y(1.0), vec3(1.0,0.80,0.30)); col = mix(col, r.rgb, r.a); // amber SLOPE
-    r = lane(uv, waveletSpread,              LANE_Y(2.0), vec3(0.25,0.95,0.30)); col = mix(col, r.rgb, r.a); // green complexity
-    r = lane(uv, clamp(waveletBass*0.3,0.0,1.0), LANE_Y(3.0), vec3(1.0,0.25,0.20)); col = mix(col, r.rgb, r.a); // red RAW bass
-    r = lane(uv, zMap(waveletBand0ZScore),   LANE_Y(4.0), vec3(1.0,0.35,0.70)); col = mix(col, r.rgb, r.a); // pink bass HITS
-    r = lane(uv, waveletBand3Normalized,     LANE_Y(5.0), vec3(0.30,0.50,1.0)); col = mix(col, r.rgb, r.a); // blue mid
-    // bassHit lane: trace + flash
-    r = lane(uv, clamp(wavelet_bassHit*0.15,0.0,1.0), LANE_Y(6.0), vec3(0.7,0.4,1.0)); col = mix(col, r.rgb, r.a);
+    // CHARACTER lanes — warm spectrum
+    r = lane(uv, waveletCentroid,          LANE_Y(0.0), vec3(0.6,0.05,0.25), vec3(1.0,0.35,0.45)); col = mix(col, r.rgb, r.a); // rose→red
+    r = lane(uv, waveletSpread,            LANE_Y(1.0), vec3(0.7,0.35,0.0),  vec3(1.0,0.85,0.2));  col = mix(col, r.rgb, r.a); // amber→gold
+    r = lane(uv, clamp(waveletBand3*0.4,0.0,1.0), LANE_Y(2.0), vec3(0.2,0.5,0.05), vec3(0.6,1.0,0.25)); col = mix(col, r.rgb, r.a); // lime→green
+    // REACTIVE lanes — cool spectrum
+    r = lane(uv, zMap(waveletBand0ZScore), LANE_Y(3.0), vec3(0.0,0.5,0.55),  vec3(0.2,1.0,1.0));  col = mix(col, r.rgb, r.a); // cyan
+    r = lane(uv, zMap(waveletBand5ZScore), LANE_Y(4.0), vec3(0.05,0.2,0.6),  vec3(0.35,0.6,1.0)); col = mix(col, r.rgb, r.a); // azure→blue
+    // TRIGGER lane — vivid magenta with a full-lane flash on fire
+    r = lane(uv, clamp(wavelet_bassHit*0.15,0.0,1.0), LANE_Y(5.0), vec3(0.6,0.0,0.5), vec3(1.0,0.3,1.0)); col = mix(col, r.rgb, r.a);
     float hit = smoothstep(0.05, 0.3, wavelet_bassHit);
-    if (abs(uv.y - LANE_Y(6.0)) < LANE_H*0.5) col = mix(col, vec3(0.9,0.7,1.0), hit*0.45);
+    if (abs(uv.y - LANE_Y(5.0)) < LANE_H*0.5) col = mix(col, vec3(1.0,0.5,1.0), hit*0.6);
 
-    fragColor = vec4(clamp(col, 0.0, 1.0), 1.0);
+    fragColor = vec4(clamp(col, 0.0, 1.5), 1.0);
 }

--- a/shaders/claude/wip/wavelet-scope/wavelet-scope.md
+++ b/shaders/claude/wip/wavelet-scope/wavelet-scope.md
@@ -137,6 +137,40 @@ trace. For deep-bass-drop reliability the wavelet line wins; the gap should wide
 phone mic where the spectral features get even mushier. Worth re-running this exact 3.frag
 comparison live through a phone to confirm.
 
+## First-class features + headless harness (the big refactor)
+
+The wavelet bands are now FIRST-CLASS features: each octave band runs through
+hypnosound's `makeCalculateStats` (the same path as bass/mids/treble), so it exposes
+the full 11 stats under FFT naming (`waveletBand0`, `waveletBand0ZScore`, ...). This
+fixed the near-zero-std z-score noise blowup on quiet material.
+
+Pure modules extracted for the eventual library: `src/audio/dwt.js` (transform) and
+`src/audio/waveletAnalyzer.js` (per-frame feature computation). The worker is a thin
+shell around `createWaveletAnalyzer`, so the headless harness runs the EXACT live code.
+
+`scripts/wavelet-harness.mjs` reads ffmpeg f32 PCM and scores every feature for
+animation quality (range/liveliness/jitter) + independence (correlation matrix). Across
+8 varied signals it found:
+- ZScores are the cleanest reactive lines (jitter 0.06-0.11).
+- Derived `waveletCentroid` (brightness) + `waveletSpread` (complexity) are lively AND
+  independent from the raw bands — added to the analyzer with full stats.
+- Maximally-independent set (all pairwise |corr|<0.45): band0Z, centroid, band1Z,
+  spread, band2Z, band3N, bassHit.
+
+## Variant choice matters (user's ear caught this)
+
+A frequency glide (sweep) was NOT visible when plotting ZScores — z-score measures
+"unusual vs baseline" so it HIDES steady trends. Use the right variant for the intent:
+- **RAW / Normalized** → "where is the frequency / level right now" (shows glides)
+- **Slope** → "is it rising or falling" (the trend itself)
+- **ZScore** → "is this unusual right now" (punchy reactive hits, drops)
+
+`independent.frag` v2 plots raw centroid + centroidSlope + raw band levels for the
+glide-sensitive lanes, z-scores only for reactive bass. Verified: raw centroid rises
+0.09→0.83 monotonically on a calibrated 50-2000Hz sweep.
+
+Test audio (gitignored, in public/test-audio/): varied-loop.mp3, sweep-demo.mp3.
+
 ## Next steps (not done — prototype only)
 
 - Decide: add wavelet features *alongside* FFT (lowest risk) vs build a kick-detection

--- a/shaders/claude/wip/wavelet-scope/wavelet-scope.md
+++ b/shaders/claude/wip/wavelet-scope/wavelet-scope.md
@@ -1,0 +1,148 @@
+# wavelet-scope — DWT multiresolution prototype
+
+A throwaway diagnostic for evaluating whether a **wavelet transform** (multiresolution
+analysis) gives sharper transients and better bass/treble timing than the production
+FFT pipeline.
+
+## Why this exists
+
+The FFT pipeline uses a single window (4096-pt ≈ 85ms). One window length means bass
+and treble are analyzed at the *same* time resolution — wrong for music. Bass wants long
+windows (frequency precision); transients/treble want short windows (time precision).
+A **dyadic DWT** gives each octave its own natural time resolution for free, and
+localizes transients to ~1-2ms instead of smearing them across 85ms.
+
+## Architecture (isolated — zero changes to AudioProcessor.js / hypnosound)
+
+```
+raw-tap-processor.js (AudioWorklet)   → grabs raw, un-windowed time-domain samples
+        ↓ 1024-sample frames
+src/audio/waveletWorker.js            → Daubechies-4 (D4) DWT per frame
+        ↓
+src/audio/WaveletProcessor.js         → publishes window.cranes.waveletFeatures
+        ↓ (spread into getCranesState in index.js)
+this shader                           → 6 band meters + onset flash vs FFT spectralFlux
+```
+
+Gated behind `?wavelet=true`. Exposed uniforms (declared explicitly in the .frag since
+they aren't in the known hypnosound feature list):
+`wavelet_band0..5`, `wavelet_band0Z..5Z`, `wavelet_onset`, `wavelet_onsetSmooth`, `wavelet_bass`.
+
+## How to run
+
+```
+?shader=claude/wip/wavelet-scope/1&wavelet=true&audio_file=test-audio/dubstep.mp3&audio_time=30&fullscreen=true
+```
+
+- Left 70%: 6 octave-band z-score meters (red=low → violet=high)
+- Right 30%: FFT spectralFlux z-score reference
+- Top strip: wavelet onset (cyan) vs FFT spectralFlux (magenta) — the A/B
+
+(Audio-file playback needs a user gesture; click once and resume the context.)
+
+## Findings (Subtronics "Revenge Of The Goldfish", ~30s in, 2026-06-07)
+
+DWT math verified standalone first: orthonormal (energy-preserving ratio 1.0000), low
+sine → coarse band, high sine → finest band, impulse → sharp finest-band spike.
+
+Live on real dubstep, sampled at 33ms over 2s:
+
+| Metric | Wavelet onset | FFT spectralFlux |
+|---|---|---|
+| Transient events detected | **5** | 2 |
+| Spike shape | isolated single-frame (`▇`→`▁`) | broader bumps (`▄▃`) |
+
+The wavelet onset catches ~2.5× more kicks and fires as sharp single-frame spikes, while
+FFT flux smears and misses several. The bass band (band0) tracks the kick envelope cleanly
+(`██▇▇` swell + natural decay). **Conclusion: the multiresolution approach delivers the two
+things the FFT pipeline was weak on — sharper transients and per-octave bass/treble timing.**
+
+## Deep-bass-hit detection (the live-phone-mic use case)
+
+Reworked the worker from a treble-onset detector into a **deep bass HIT detector**,
+because the real goal is catching bass drops on a phone mic in a live room.
+
+DWT band frequency map (44.1kHz, 1024-pt frame, 23ms):
+
+| band | freq | role |
+|---|---|---|
+| band0 | 43-86 Hz | deep bass (fundamental of a drop) |
+| band1 | 86-172 Hz | low bass / first harmonic — **survives phone-mic rolloff best** |
+| approx | <43 Hz | true sub (mostly murdered by phone mics) |
+
+**Key insight:** phone mics roll off hard below ~100Hz, so a 48Hz drop's fundamental is
+heavily attenuated, but its harmonic near 96Hz (band1) survives. The detector uses a
+**harmonic-weighted** `bassEnergy = band1*1.0 + band0*0.8 + sub*0.5` so it fires on the
+HIT even when the sub-tone barely reaches the mic.
+
+New uniforms: `wavelet_bassHit` (sharp rising-edge signal), `wavelet_bassZ`
+(self-calibrating hit strength — mic-level-agnostic), `wavelet_bassEnergy`.
+
+**Findings** (synthetic `bass-drop-test.mp3`: 48Hz hits @0.75s + 40Hz sub @1.5s + pink noise):
+- 7/8 hits detected over 6s, both via raw hit and z-score. bassZ peaked 1.565.
+- Sparkline shows sharp, evenly-spaced rising edges with clean silence between — only
+  ~10% of frames above threshold, all clustered at hits. Low false-positive.
+- band1 (`▇`) consistently taller than band0 (`▄`) on each hit — confirms the harmonic
+  survives better than the fundamental, validating the harmonic weighting for phone mics.
+
+`wavelet_bassZ` is the recommended signal to drive bass-drop visuals: it measures "is this
+bass unusual right now" so it adapts to whatever level the mic actually captures.
+
+## 2.frag — scrolling oscilloscope comparison (wavelet vs traditional)
+
+Built in the `graph/line-z-score.frag` idiom (scroll left via frame feedback, draw a new
+sample in the rightmost column). Overlays four bass-relevant lines so you can watch which
+spikes cleanly on each hit:
+
+- CYAN = `wavelet_bassZ` (ours), RED = `bassZScore`, YELLOW = `energyZScore`,
+  MAGENTA = `spectralFluxZScore` (the current de-facto drop signal).
+- White full-height column = `wavelet_bassHit` fired (a detected drop).
+
+Run: `?shader=claude/wip/wavelet-scope/2&wavelet=true&audio_file=test-audio/bass-drop-test.mp3&fullscreen=true`
+
+**Result (visual, ~12 hits on the synthetic deep-bass file):**
+- The white hit-flash columns are perfectly periodic — one per drop, no misses, no false
+  fires between. Clean, reliable bass-drop trigger.
+- The cyan `wavelet_bassZ` line is a coherent trace that dips then snaps to a sharp peak at
+  each hit. High signal-to-noise, readable rhythm.
+- The traditional features are visibly noisier — scattered confetti with no clean line.
+  `spectralFluxZScore` (magenta) in particular does NOT track the bass hits cleanly,
+  matching the live experience that the FFT drop signal is mushy on bass-starved input.
+
+Conclusion: `wavelet_bassHit` (trigger) + `wavelet_bassZ` (continuous strength) are the
+recommended signals for deep-bass-drop visuals, especially on phone mics.
+
+## 3.frag — wavelet bass vs the ACTUAL drop-detector
+
+`2.frag` compared against a single feature (`spectralFluxZScore`). But the real signal we've
+been using is `graph/drop-detector/1.frag`, which is NOT one feature — it counts how many
+spectral z-scores exceed PROBE_B (0.95) at once: a "drop" = >=2 of
+{energyZ, spectralKurtosisZ, spectralEntropyZ, spectralFluxZ, spectralRolloffZ}.
+`3.frag` reproduces that exact logic and plots it (orange) next to `wavelet_bassZ` (cyan),
+with the drop-detector's five input z-scores drawn dimly so you can see what it reacts to.
+
+Run: `?shader=claude/wip/wavelet-scope/3&wavelet=true&audio_file=test-audio/bass-drop-test.mp3&fullscreen=true`
+
+**Measured comparison (synthetic deep-bass file, ~18s, hits every 0.75s):**
+
+| Detector | Distinct events | Character |
+|---|---|---|
+| wavelet bass (`wavelet_bassHit`) | **11** | clean ~1-per-drop, readable cyan line, bassZ max 1.6 |
+| drop-detector (>=2 z>0.95) | 8 | DID fire (maxSimultaneousZ reached 5), but erratic — its inputs are scattered confetti, not a coherent line |
+
+Honest read: the drop-detector is NOT dead on bass content — each hit's broadband transient
+nudges entropy/flux/rolloff enough to trip it sometimes. But it's noisier and less consistent
+(8 vs 11), and its trace is visually noise where the wavelet bass line is a clean readable
+trace. For deep-bass-drop reliability the wavelet line wins; the gap should widen on a real
+phone mic where the spectral features get even mushier. Worth re-running this exact 3.frag
+comparison live through a phone to confirm.
+
+## Next steps (not done — prototype only)
+
+- Decide: add wavelet features *alongside* FFT (lowest risk) vs build a kick-detection
+  controller off `wavelet_onset` (replaces the unreliable `beat` uniform).
+- CWT scalogram version would be prettier but is too expensive for 60fps mobile — DWT is
+  the right call for a live tool.
+- `test-audio/dubstep.mp3` and `test-audio/kick-test.mp3` are local test assets (gitignore
+  if not wanted in the repo).
+```

--- a/src/audio/WaveletProcessor.js
+++ b/src/audio/WaveletProcessor.js
@@ -96,6 +96,22 @@ export class WaveletProcessor {
         out.wavelet_bassHit = bassHit
         out.wavelet_bassHitSmooth = this.hitSmooth
 
+        // ---- CROSS-DOMAIN COMBINATIONS (wavelet WHEN × FFT WHAT) ----
+        // The harness showed wavelet onsets are independent from all FFT features, so
+        // these blends genuinely add information rather than averaging noise. FFT features
+        // are read live from the FFT pipeline (measuredAudioFeatures) on the same frame.
+        const fft = window.cranes?.measuredAudioFeatures
+        if (fft) {
+            const band0Z = bandStats[0]?.zScore ?? 0
+            const bassLevel = fft.bass ?? 0
+            const energyZ = fft.energyZScore ?? 0
+            // punch: wavelet's FAST bass onset + FFT's ACCURATE bass level → snappy AND precise.
+            out.wavelet_punch = (band0Z * 0.2 + 0.5) * 0.5 + bassLevel * 0.5
+            // confirmedDrop: the wavelet bass-hit, GATED by FFT energy rising. Both domains
+            // must agree → a higher-confidence drop than either alone (independent from all).
+            out.wavelet_confirmedDrop = bassHit * Math.max(0, energyZ)
+        }
+
         window.cranes.waveletFeatures = out
     }
 

--- a/src/audio/WaveletProcessor.js
+++ b/src/audio/WaveletProcessor.js
@@ -1,35 +1,67 @@
 // WaveletProcessor.js
-// PROTOTYPE — isolated multiresolution (DWT) analysis running alongside the FFT
-// pipeline. Gated behind ?wavelet=true. Publishes octave-band energies + a sharp
-// onset signal as float uniforms via window.cranes.waveletFeatures.
+// Multiresolution (DWT) analysis running alongside the FFT pipeline. Gated behind
+// ?wavelet=true. Each octave band is a FIRST-CLASS feature: it goes through the same
+// hypnosound stats path as the FFT features (via waveletWorker.js → makeCalculateStats),
+// so it exposes the full 11 statistical variations under the FFT naming convention.
 //
-// Exposed uniforms (low→high octave band):
-//   wavelet_band0 .. wavelet_band5      RMS energy per octave detail band
-//   wavelet_band0Z .. wavelet_band5Z    per-band z-score (spiking vs own baseline)
-//   wavelet_onset                       sharp transient signal (finest-band positive flux)
-//   wavelet_onsetSmooth                 lightly smoothed onset (for non-strobing visuals)
-//   wavelet_bass                        coarse approximation energy
+// Exposed features (i = 0..5, low→high octave; band0 = 43-86Hz deep bass):
+//   waveletBand{i}                 raw RMS energy of the octave's detail coefficients
+//   waveletBand{i}ZScore           is this band unusual vs its own rolling baseline
+//   waveletBand{i}Normalized       0-1 within recent range
+//   waveletBand{i}Mean/Median/Min/Max/StandardDeviation/Slope/Intercept/RSquared
+//   waveletBass + waveletBass{Stat} harmonic-weighted deep-bass energy (full stats)
+//   wavelet_bassHit                sharp UN-smoothed deep-bass drop trigger (raw)
+//   wavelet_bassHitSmooth          lightly smoothed trigger (for non-strobing visuals)
 //
-// Nothing here touches AudioProcessor.js or hypnosound.
+// Names match the FFT convention (camelCase, capitalized stat suffix) so shaders and
+// controllers treat wavelet bands exactly like bass/mids/treble. The two wavelet_bassHit
+// keys keep the underscore form since they're a bespoke trigger, not a stat feature.
 
-const NUM_BANDS = 6 // we surface this many bands; deeper ones are merged into bass
+const NUM_BANDS = 6 // surface the 6 lowest octave bands (43Hz → ~2.8kHz)
+
+// makeCalculateStats stat keys → flattened feature-name suffix (capitalized).
+// 'current' becomes the bare feature name; the rest get a capitalized suffix.
+const STAT_SUFFIX = {
+    normalized: 'Normalized',
+    mean: 'Mean',
+    median: 'Median',
+    min: 'Min',
+    max: 'Max',
+    standardDeviation: 'StandardDeviation',
+    zScore: 'ZScore',
+    slope: 'Slope',
+    intercept: 'Intercept',
+    rSquared: 'RSquared',
+}
+
+// Flatten one stats object into feature keys: base name + each suffixed stat.
+const flattenStats = (out, base, stats) => {
+    out[base] = stats.current
+    for (const [key, suffix] of Object.entries(STAT_SUFFIX)) {
+        out[`${base}${suffix}`] = stats[key]
+    }
+}
 
 export class WaveletProcessor {
-    constructor(audioContext, sourceNode) {
+    constructor(audioContext, sourceNode, historySize = 500) {
         this.audioContext = audioContext
         this.sourceNode = sourceNode
+        this.historySize = historySize
         this.worker = new Worker(new URL('./waveletWorker.js', import.meta.url), { type: 'module' })
         this.latest = null
-        this.onsetSmooth = 0
+        this.hitSmooth = 0
         this.worker.onmessage = (e) => { this.latest = e.data }
     }
 
     start = async () => {
+        // Mirror the FFT worker config handshake — tell the DWT worker the history size
+        // so its per-band makeCalculateStats windows match the rest of the pipeline.
+        this.worker.postMessage({ type: 'config', historySize: this.historySize })
+
         await this.audioContext.audioWorklet.addModule('/raw-tap-processor.js')
         const tapNode = new AudioWorkletNode(this.audioContext, 'raw-tap-processor')
         tapNode.port.onmessage = (e) => this.worker.postMessage(e.data)
-        // Tap the source directly (raw, un-windowed). The node has no audible output
-        // path of its own — we don't connect it to destination.
+        // Tap the source directly (raw, un-windowed). No output path — not connected to destination.
         this.sourceNode.connect(tapNode)
         this.publish()
     }
@@ -38,22 +70,20 @@ export class WaveletProcessor {
         requestAnimationFrame(this.publish)
         if (!this.latest) return
 
-        const { bands, zScores, onset, bassEnergy, bassZ, approxEnergy } = this.latest
-        // onset here = the deep-bass HIT signal (sharp positive jump in low-band energy).
-        // Intentionally NOT smoothed hard — sharpness is the whole point of a hit.
-        this.onsetSmooth = this.onsetSmooth * 0.7 + onset * 0.3
-
+        const { bandStats, bassStats, bassHit } = this.latest
         const out = {}
+
+        // Each octave band → full 11-stat feature set under FFT naming.
         for (let i = 0; i < NUM_BANDS; i++) {
-            out[`wavelet_band${i}`] = bands[i] ?? 0
-            out[`wavelet_band${i}Z`] = zScores[i] ?? 0
+            if (bandStats[i]) flattenStats(out, `waveletBand${i}`, bandStats[i])
         }
-        out.wavelet_onset = onset            // deep-bass hit (raw, sharp)
-        out.wavelet_onsetSmooth = this.onsetSmooth
-        out.wavelet_bassHit = onset          // alias — clearer name for the bass-drop use case
-        out.wavelet_bassEnergy = bassEnergy  // harmonic-weighted low-band energy
-        out.wavelet_bassZ = bassZ            // self-calibrating hit strength (mic-agnostic)
-        out.wavelet_bass = approxEnergy      // raw sub-approximation (<43Hz)
+        // Harmonic-weighted deep-bass energy → its own full-stats feature.
+        if (bassStats) flattenStats(out, 'waveletBass', bassStats)
+
+        // Sharp drop trigger (kept raw — sharpness is the point) + a smoothed variant.
+        this.hitSmooth = this.hitSmooth * 0.7 + bassHit * 0.3
+        out.wavelet_bassHit = bassHit
+        out.wavelet_bassHitSmooth = this.hitSmooth
 
         window.cranes.waveletFeatures = out
     }

--- a/src/audio/WaveletProcessor.js
+++ b/src/audio/WaveletProcessor.js
@@ -10,8 +10,15 @@
 //   waveletBand{i}Normalized       0-1 within recent range
 //   waveletBand{i}Mean/Median/Min/Max/StandardDeviation/Slope/Intercept/RSquared
 //   waveletBass + waveletBass{Stat} harmonic-weighted deep-bass energy (full stats)
+//   waveletTilt{Stat}              bass-vs-treble balance  (+1 bass-heavy ↔ -1 bright)
+//   waveletCentroid{Stat}          spectral brightness     (0 bass ↔ 1 treble)
+//   waveletSpread{Stat}            spectral complexity     (0 pure/peaky ↔ 1 flat/complex)
 //   wavelet_bassHit                sharp UN-smoothed deep-bass drop trigger (raw)
 //   wavelet_bassHitSmooth          lightly smoothed trigger (for non-strobing visuals)
+//
+// The harness identified band0Z/band1Z/band2Z/band3N + centroid + spread + bassHit as a
+// maximally-independent, lively set (all pairwise |corr|<0.45) — great for driving
+// distinct visual params. tilt≈centroid (redundant) but kept for convenience.
 //
 // Names match the FFT convention (camelCase, capitalized stat suffix) so shaders and
 // controllers treat wavelet bands exactly like bass/mids/treble. The two wavelet_bassHit
@@ -70,7 +77,7 @@ export class WaveletProcessor {
         requestAnimationFrame(this.publish)
         if (!this.latest) return
 
-        const { bandStats, bassStats, bassHit } = this.latest
+        const { bandStats, bassStats, tiltStats, centroidStats, spreadStats, bassHit } = this.latest
         const out = {}
 
         // Each octave band → full 11-stat feature set under FFT naming.
@@ -79,6 +86,10 @@ export class WaveletProcessor {
         }
         // Harmonic-weighted deep-bass energy → its own full-stats feature.
         if (bassStats) flattenStats(out, 'waveletBass', bassStats)
+        // Derived cross-band features (independent animatable axes), full stats each.
+        if (tiltStats) flattenStats(out, 'waveletTilt', tiltStats)
+        if (centroidStats) flattenStats(out, 'waveletCentroid', centroidStats)
+        if (spreadStats) flattenStats(out, 'waveletSpread', spreadStats)
 
         // Sharp drop trigger (kept raw — sharpness is the point) + a smoothed variant.
         this.hitSmooth = this.hitSmooth * 0.7 + bassHit * 0.3

--- a/src/audio/WaveletProcessor.js
+++ b/src/audio/WaveletProcessor.js
@@ -97,20 +97,23 @@ export class WaveletProcessor {
         out.wavelet_bassHitSmooth = this.hitSmooth
 
         // ---- CROSS-DOMAIN COMBINATIONS (wavelet WHEN × FFT WHAT) ----
-        // The harness showed wavelet onsets are independent from all FFT features, so
-        // these blends genuinely add information rather than averaging noise. FFT features
-        // are read live from the FFT pipeline (measuredAudioFeatures) on the same frame.
-        const fft = window.cranes?.measuredAudioFeatures
-        if (fft) {
-            const band0Z = bandStats[0]?.zScore ?? 0
-            const bassLevel = fft.bass ?? 0
-            const energyZ = fft.energyZScore ?? 0
-            // punch: wavelet's FAST bass onset + FFT's ACCURATE bass level → snappy AND precise.
-            out.wavelet_punch = (band0Z * 0.2 + 0.5) * 0.5 + bassLevel * 0.5
-            // confirmedDrop: the wavelet bass-hit, GATED by FFT energy rising. Both domains
-            // must agree → a higher-confidence drop than either alone (independent from all).
-            out.wavelet_confirmedDrop = bassHit * Math.max(0, energyZ)
-        }
+        // The harness showed wavelet onsets are independent from all FFT features, so these
+        // blends add information rather than averaging noise.
+        //
+        // LATENCY NOTE (deliberate): the wavelet path (1024-window, ~21ms) is much faster
+        // than the FFT path (4096-window, ~85ms). These combos prioritize LOW LATENCY by
+        // leading with the FAST wavelet component and using the slower FFT signal only as a
+        // light confirmation/refinement — so the combined feature still reacts on the
+        // wavelet's timescale, not the FFT's.
+        const fft = window.cranes?.measuredAudioFeatures ?? {}
+        const band0Z = bandStats[0]?.zScore ?? 0
+        const bassLevel = fft.bass ?? 0
+        const energyZ = fft.energyZScore ?? 0
+        // punch: led by the wavelet's FAST bass onset; FFT bass level only trims it.
+        out.wavelet_punch = (band0Z * 0.2 + 0.5) * 0.7 + bassLevel * 0.3
+        // confirmedDrop: the FAST wavelet bass-hit, lightly gated by FFT energy. The gate
+        // softens (not zeroes) when FFT lags, so the drop still fires on wavelet timing.
+        out.wavelet_confirmedDrop = bassHit * (0.5 + Math.max(0, energyZ) * 0.5)
 
         window.cranes.waveletFeatures = out
     }

--- a/src/audio/WaveletProcessor.js
+++ b/src/audio/WaveletProcessor.js
@@ -1,0 +1,64 @@
+// WaveletProcessor.js
+// PROTOTYPE — isolated multiresolution (DWT) analysis running alongside the FFT
+// pipeline. Gated behind ?wavelet=true. Publishes octave-band energies + a sharp
+// onset signal as float uniforms via window.cranes.waveletFeatures.
+//
+// Exposed uniforms (low→high octave band):
+//   wavelet_band0 .. wavelet_band5      RMS energy per octave detail band
+//   wavelet_band0Z .. wavelet_band5Z    per-band z-score (spiking vs own baseline)
+//   wavelet_onset                       sharp transient signal (finest-band positive flux)
+//   wavelet_onsetSmooth                 lightly smoothed onset (for non-strobing visuals)
+//   wavelet_bass                        coarse approximation energy
+//
+// Nothing here touches AudioProcessor.js or hypnosound.
+
+const NUM_BANDS = 6 // we surface this many bands; deeper ones are merged into bass
+
+export class WaveletProcessor {
+    constructor(audioContext, sourceNode) {
+        this.audioContext = audioContext
+        this.sourceNode = sourceNode
+        this.worker = new Worker(new URL('./waveletWorker.js', import.meta.url), { type: 'module' })
+        this.latest = null
+        this.onsetSmooth = 0
+        this.worker.onmessage = (e) => { this.latest = e.data }
+    }
+
+    start = async () => {
+        await this.audioContext.audioWorklet.addModule('/raw-tap-processor.js')
+        const tapNode = new AudioWorkletNode(this.audioContext, 'raw-tap-processor')
+        tapNode.port.onmessage = (e) => this.worker.postMessage(e.data)
+        // Tap the source directly (raw, un-windowed). The node has no audible output
+        // path of its own — we don't connect it to destination.
+        this.sourceNode.connect(tapNode)
+        this.publish()
+    }
+
+    publish = () => {
+        requestAnimationFrame(this.publish)
+        if (!this.latest) return
+
+        const { bands, zScores, onset, bassEnergy, bassZ, approxEnergy } = this.latest
+        // onset here = the deep-bass HIT signal (sharp positive jump in low-band energy).
+        // Intentionally NOT smoothed hard — sharpness is the whole point of a hit.
+        this.onsetSmooth = this.onsetSmooth * 0.7 + onset * 0.3
+
+        const out = {}
+        for (let i = 0; i < NUM_BANDS; i++) {
+            out[`wavelet_band${i}`] = bands[i] ?? 0
+            out[`wavelet_band${i}Z`] = zScores[i] ?? 0
+        }
+        out.wavelet_onset = onset            // deep-bass hit (raw, sharp)
+        out.wavelet_onsetSmooth = this.onsetSmooth
+        out.wavelet_bassHit = onset          // alias — clearer name for the bass-drop use case
+        out.wavelet_bassEnergy = bassEnergy  // harmonic-weighted low-band energy
+        out.wavelet_bassZ = bassZ            // self-calibrating hit strength (mic-agnostic)
+        out.wavelet_bass = approxEnergy      // raw sub-approximation (<43Hz)
+
+        window.cranes.waveletFeatures = out
+    }
+
+    cleanup = () => {
+        this.worker.terminate()
+    }
+}

--- a/src/audio/WaveletProcessor.js
+++ b/src/audio/WaveletProcessor.js
@@ -49,6 +49,12 @@ const flattenStats = (out, base, stats) => {
     }
 }
 
+// Exponential smoothing factor for the published features. The wavelet path updates at
+// the fast ~344Hz sliding-window rate, so raw per-frame values are jittery (6-7x noisier
+// than the FFT features, which the FFT pipeline already smooths). This matches that:
+// lower = smoother/flowing, higher = snappier. The bassHit trigger is exempt (stays raw).
+const SMOOTHING = 0.18
+
 export class WaveletProcessor {
     constructor(audioContext, sourceNode, historySize = 500) {
         this.audioContext = audioContext
@@ -57,7 +63,22 @@ export class WaveletProcessor {
         this.worker = new Worker(new URL('./waveletWorker.js', import.meta.url), { type: 'module' })
         this.latest = null
         this.hitSmooth = 0
+        this.smoothed = {} // per-feature EMA state
         this.worker.onmessage = (e) => { this.latest = e.data }
+    }
+
+    // EMA-smooth all numeric features in `out` (except the sharp trigger keys), so the
+    // published wavelet lines flow like the FFT features instead of jittering.
+    smooth = (out) => {
+        for (const key in out) {
+            const v = out[key]
+            if (typeof v !== 'number' || !isFinite(v)) continue
+            if (key === 'wavelet_bassHit' || key === 'wavelet_confirmedDrop') continue // keep sharp
+            if (!(key in this.smoothed)) this.smoothed[key] = v
+            this.smoothed[key] = this.smoothed[key] * (1 - SMOOTHING) + v * SMOOTHING
+            out[key] = this.smoothed[key]
+        }
+        return out
     }
 
     start = async () => {
@@ -115,7 +136,7 @@ export class WaveletProcessor {
         // softens (not zeroes) when FFT lags, so the drop still fires on wavelet timing.
         out.wavelet_confirmedDrop = bassHit * (0.5 + Math.max(0, energyZ) * 0.5)
 
-        window.cranes.waveletFeatures = out
+        window.cranes.waveletFeatures = this.smooth(out)
     }
 
     cleanup = () => {

--- a/src/audio/dwt.js
+++ b/src/audio/dwt.js
@@ -1,0 +1,83 @@
+// dwt.js — pure Daubechies-4 (D4) Discrete Wavelet Transform + band energies.
+//
+// No DOM/worker/audio globals — pure functions, so this is importable from the
+// worker, a headless Node harness, or (eventually) a standalone library.
+//
+// The dyadic DWT is O(n) and gives octave-spaced bands, each at its OWN natural time
+// resolution: low bands (bass) update slowly/smoothly, high bands (treble/transients)
+// update fast/sharp. That multiresolution property is why bass and treble aren't forced
+// to share a single analysis window the way they are in a single FFT.
+
+// D4 scaling (low-pass) coefficients
+const SQRT3 = Math.sqrt(3)
+const DENOM = 4 * Math.SQRT2
+const H0 = (1 + SQRT3) / DENOM
+const H1 = (3 + SQRT3) / DENOM
+const H2 = (3 - SQRT3) / DENOM
+const H3 = (1 - SQRT3) / DENOM
+// Wavelet (high-pass) coefficients — quadrature mirror of the scaling filter
+const G0 = H3
+const G1 = -H2
+const G2 = H1
+const G3 = -H0
+
+// One in-place D4 step over the first `n` elements of `a`: [0..n/2)=approx, [n/2..n)=detail.
+const dwtStep = (a, n) => {
+    const tmp = new Float32Array(n)
+    const half = n >> 1
+    for (let i = 0; i < half; i++) {
+        const j = i << 1
+        const k0 = j
+        const k1 = (j + 1) % n
+        const k2 = (j + 2) % n
+        const k3 = (j + 3) % n
+        tmp[i] = a[k0] * H0 + a[k1] * H1 + a[k2] * H2 + a[k3] * H3
+        tmp[half + i] = a[k0] * G0 + a[k1] * G1 + a[k2] * G2 + a[k3] * G3
+    }
+    for (let i = 0; i < n; i++) a[i] = tmp[i]
+}
+
+// Full multilevel DWT (in a fresh copy). Detail bands live at [n/2..n), [n/4..n/2), ...
+// and the final approximation at [0..smallest).
+export const dwt = (signal) => {
+    const a = Float32Array.from(signal)
+    let n = a.length
+    while (n >= 4) {
+        dwtStep(a, n)
+        n >>= 1
+    }
+    return a
+}
+
+export const rms = (arr, start, end) => {
+    let sum = 0
+    for (let i = start; i < end; i++) sum += arr[i] * arr[i]
+    const len = end - start
+    return len > 0 ? Math.sqrt(sum / len) : 0
+}
+
+// Decompose a time-domain frame into octave-band RMS energies (low→high) plus the
+// coarse approximation energy. band0 is the lowest detail band (deep bass).
+export const bandEnergies = (frame) => {
+    const N = frame.length
+    const coeffs = dwt(frame)
+    const bands = []
+    let n = N
+    while (n >= 4) {
+        const half = n >> 1
+        bands.push(rms(coeffs, half, n))
+        n = half
+    }
+    bands.reverse() // low→high so band0 = deep bass
+    const approxEnergy = rms(coeffs, 0, Math.max(2, N >> bands.length))
+    return { bands, approxEnergy }
+}
+
+// Harmonic-weighted deep-bass energy. Phone mics roll off below ~100Hz so a drop's
+// fundamental (band0, 43-86Hz) is attenuated but its harmonic in band1 (86-172Hz)
+// survives — weight band1 highest so the bass signal holds up on bass-starved input.
+export const harmonicBass = (bands, approxEnergy) => {
+    const b0 = bands[0] ?? 0
+    const b1 = bands[1] ?? 0
+    return b1 * 1.0 + b0 * 0.8 + approxEnergy * 0.5
+}

--- a/src/audio/tabAudioSource.js
+++ b/src/audio/tabAudioSource.js
@@ -91,6 +91,14 @@ export const setupTabAudio = ({ params, AudioProcessor }) => {
             processor.smoothingFactor = smoothing
             await processor.start()
 
+            // PROTOTYPE: opt-in wavelet (DWT) analysis on the same tab source.
+            if (params.get('wavelet') === 'true') {
+                const { WaveletProcessor } = await import('./WaveletProcessor.js')
+                const wavelet = new WaveletProcessor(audioContext, sourceNode, historySize)
+                await wavelet.start()
+                if (window.cranes) window.cranes.waveletProcessor = wavelet
+            }
+
             holder.getFeatures = processor.getFeatures
 
             // If the user clicks "Stop sharing" in the browser, re-prompt so

--- a/src/audio/waveletAnalyzer.js
+++ b/src/audio/waveletAnalyzer.js
@@ -13,11 +13,19 @@ export const createWaveletAnalyzer = (historySize = 500) => {
     let bassStats = null   // makeCalculateStats for the harmonic-weighted bass energy
     let bandCount = 0
     let prevBassEnergy = 0 // for the sharp un-smoothed bass-hit trigger
+    // Derived cross-band features also get full stats (they earned their place in the
+    // harness as lively + independent animatable axes).
+    let tiltStats = null     // bass-vs-treble balance
+    let centroidStats = null // spectral brightness (energy-weighted band index)
+    let spreadStats = null   // spectral complexity (normalized band entropy)
 
     const build = (count) => {
         bandCount = count
         bandStats = Array.from({ length: count }, () => makeCalculateStats(historySize))
         bassStats = makeCalculateStats(historySize)
+        tiltStats = makeCalculateStats(historySize)
+        centroidStats = makeCalculateStats(historySize)
+        spreadStats = makeCalculateStats(historySize)
     }
 
     return {
@@ -36,7 +44,31 @@ export const createWaveletAnalyzer = (historySize = 500) => {
             const bassHit = Math.max(0, bassEnergy - prevBassEnergy)
             prevBassEnergy = prevBassEnergy * 0.85 + bassEnergy * 0.15
 
-            return { bandStats: bandStatsOut, bassStats: bassStatsOut, approxEnergy, bassHit }
+            // ---- DERIVED cross-band features (independent animatable axes) ----
+            const cur = (i) => bands[i] ?? 0
+            const lowE = cur(0) + cur(1) + cur(2)
+            const highE = cur(3) + cur(4) + cur(5)
+            // tilt: bass-heavy (+1) ↔ bright (-1)
+            const tilt = (lowE - highE) / (lowE + highE + 1e-6)
+            // centroid: energy-weighted band index, normalized 0(bass)..1(treble)
+            let num = 0, den = 0
+            for (let i = 0; i < 6; i++) { num += i * cur(i); den += cur(i) }
+            const centroid = den > 1e-6 ? num / den / 5 : 0
+            // spread: normalized spectral entropy — flat/complex (1) ↔ peaky/pure (0)
+            const total = den + 1e-6
+            let ent = 0
+            for (let i = 0; i < 6; i++) { const p = cur(i) / total; if (p > 1e-6) ent -= p * Math.log(p) }
+            const spread = ent / Math.log(6)
+
+            return {
+                bandStats: bandStatsOut,
+                bassStats: bassStatsOut,
+                tiltStats: tiltStats(tilt),
+                centroidStats: centroidStats(centroid),
+                spreadStats: spreadStats(spread),
+                approxEnergy,
+                bassHit,
+            }
         },
         setHistorySize(h) {
             historySize = h

--- a/src/audio/waveletAnalyzer.js
+++ b/src/audio/waveletAnalyzer.js
@@ -1,0 +1,46 @@
+// waveletAnalyzer.js — the per-frame wavelet feature computation, as a pure factory.
+//
+// Pulled out of the worker so the SAME code runs in three places: the live worker,
+// a headless Node harness, and (eventually) a standalone library. createWaveletAnalyzer
+// returns a stateful analyze(frame) — it holds the per-band rolling-stats history.
+
+import { makeCalculateStats } from 'hypnosound'
+import { bandEnergies, harmonicBass } from './dwt.js'
+
+// historySize: rolling window for the stats (matches the FFT history_size).
+export const createWaveletAnalyzer = (historySize = 500) => {
+    let bandStats = null   // one makeCalculateStats per octave band
+    let bassStats = null   // makeCalculateStats for the harmonic-weighted bass energy
+    let bandCount = 0
+    let prevBassEnergy = 0 // for the sharp un-smoothed bass-hit trigger
+
+    const build = (count) => {
+        bandCount = count
+        bandStats = Array.from({ length: count }, () => makeCalculateStats(historySize))
+        bassStats = makeCalculateStats(historySize)
+    }
+
+    return {
+        analyze(frame) {
+            const { bands, approxEnergy } = bandEnergies(frame)
+            if (!bandStats || bandCount !== bands.length) build(bands.length)
+
+            // Full 11-stat object per octave band — identical path to FFT features.
+            const bandStatsOut = bands.map((v, i) => bandStats[i](v))
+
+            // Harmonic-weighted deep-bass energy, also given full stats.
+            const bassEnergy = harmonicBass(bands, approxEnergy)
+            const bassStatsOut = bassStats(bassEnergy)
+
+            // Sharp un-smoothed hit: positive jump above a slow adaptive baseline.
+            const bassHit = Math.max(0, bassEnergy - prevBassEnergy)
+            prevBassEnergy = prevBassEnergy * 0.85 + bassEnergy * 0.15
+
+            return { bandStats: bandStatsOut, bassStats: bassStatsOut, approxEnergy, bassHit }
+        },
+        setHistorySize(h) {
+            historySize = h
+            bandStats = null // rebuild on next frame
+        },
+    }
+}

--- a/src/audio/waveletWorker.js
+++ b/src/audio/waveletWorker.js
@@ -15,10 +15,16 @@
 //   level N detail = lowest detail band
 //   final approximation = bass / sub
 //
-// Per frame we emit:
-//   bands[]      — RMS energy of each octave's detail coefficients (low→high)
-//   onset        — sharp transient signal from the finest detail band's peak energy
-//   approxEnergy — the coarse approximation (bass) energy
+// Each octave band's RMS energy is run through hypnosound's makeCalculateStats —
+// the SAME stats path the FFT features use — so wavelet bands get the full 11
+// statistical variations (mean, median, zScore, normalized, slope, rSquared, ...)
+// over a rolling history window. This is what makes them first-class features that
+// shaders can treat exactly like bass/mids/treble, and it fixes the near-zero-std
+// z-score blowup the hand-rolled version had on quiet material.
+//
+// The bass-HIT trigger stays a separate, deliberately UN-smoothed sharp signal.
+
+import { makeCalculateStats } from 'hypnosound'
 
 // D4 scaling (low-pass) coefficients
 const SQRT3 = Math.sqrt(3)
@@ -72,83 +78,73 @@ const rms = (arr, start, end) => {
 
 // Track per-band history for a cheap z-score so the scope can show "is this band
 // spiking vs its own recent baseline" — the same statistical idea as the FFT side.
-const HISTORY = 120 // ~2.5s of frames
-const bandHistory = []
-const bassEnergyHistory = []
-let prevBassEnergy = 0
-let bassHitRaw = 0
+// Per-band stats functions (one per octave band + one for the harmonic bass energy),
+// each holding its own rolling history. Built lazily once we know historySize and how
+// many bands the frame produces. This mirrors the FFT side: one calculateStats per
+// feature, fed one scalar per frame.
+let DEFAULT_HISTORY = 500 // matches the FFT default (history_size)
+let bandStats = null      // array of calculateStats fns, one per band
+let bassStats = null      // calculateStats for the harmonic-weighted bass energy
+let bandCount = 0
 
-const analyze = (frame) => {
+const buildStats = (count, historySize) => {
+    bandCount = count
+    bandStats = Array.from({ length: count }, () => makeCalculateStats(historySize))
+    bassStats = makeCalculateStats(historySize)
+}
+
+// The bass-HIT trigger is deliberately NOT run through stats — it's a sharp,
+// un-smoothed rising-edge signal so drops pop instantly.
+let prevBassEnergy = 0
+
+const bandEnergies = (frame) => {
     const N = frame.length
     const coeffs = dwt(frame)
-
-    // Detail bands, finest first. Band b occupies [N>>(b+1) .. N>>b).
-    // b=0 is the finest (highest freq), increasing b → lower freq.
+    // Detail bands, finest first; band b occupies [N>>(b+1) .. N>>b).
     const bands = []
     let n = N
     while (n >= 4) {
         const half = n >> 1
-        bands.push(rms(coeffs, half, n)) // detail coeffs for this octave
+        bands.push(rms(coeffs, half, n))
         n = half
     }
-    // bands is currently high→low; reverse to low→high so band0 = bass-ish.
-    bands.reverse()
+    bands.reverse() // low→high so band0 = deep bass
     const approxEnergy = rms(coeffs, 0, Math.max(2, N >> bands.length))
+    return { bands, approxEnergy }
+}
 
-    // ---- DEEP BASS HIT DETECTION ----
-    // band0 = 43-86Hz (deep bass), band1 = 86-172Hz (low bass / first harmonic).
-    // Phone mics roll off hard below ~100Hz, so the 48Hz fundamental of a drop is
-    // heavily attenuated — but its harmonic in band1 survives. We combine band0,
-    // band1, and the sub-approximation, weighting the harmonic so the detector still
-    // fires when the fundamental is mic-murdered. This is the whole point for the
-    // live-phone use case: detect the HIT even when the sub-tone barely arrives.
-    const sub = approxEnergy           // below ~43Hz (mostly gone on phone mics)
-    const b0 = bands[0] ?? 0           // 43-86Hz  deep bass
-    const b1 = bands[1] ?? 0           // 86-172Hz low bass — survives the mic best
-    // Harmonic-weighted bass energy: lean on b1 (survives) + b0, sub as a bonus.
+const analyze = (frame, historySize) => {
+    const { bands, approxEnergy } = bandEnergies(frame)
+    if (!bandStats || bandCount !== bands.length) buildStats(bands.length, historySize)
+
+    // Full 11-stat object per octave band — identical path to the FFT features.
+    const bandStatsOut = bands.map((v, i) => bandStats[i](v))
+
+    // ---- DEEP BASS HIT (harmonic-weighted) ----
+    // Phone mics roll off below ~100Hz, so a drop's 48Hz fundamental is attenuated but
+    // its harmonic in band1 (86-172Hz) survives. Weight band1 highest so the detector
+    // still fires when the fundamental is mic-murdered.
+    const sub = approxEnergy
+    const b0 = bands[0] ?? 0
+    const b1 = bands[1] ?? 0
     const bassEnergy = b1 * 1.0 + b0 * 0.8 + sub * 0.5
+    const bassStatsOut = bassStats(bassEnergy) // bass energy gets full stats too
 
-    // BASS HIT: sharp POSITIVE jump in bass energy above an adaptive baseline.
-    // The baseline tracks the room's bass floor slowly, so a hit is the spike above it.
-    bassHitRaw = Math.max(0, bassEnergy - prevBassEnergy)
-    // Slow baseline (0.85 decay) so sustained bass doesn't keep re-triggering — only
-    // the rising EDGE of a hit fires. Fast enough to re-arm between drops (~0.5s).
+    // Sharp un-smoothed hit: positive jump above a slow adaptive baseline.
+    const bassHit = Math.max(0, bassEnergy - prevBassEnergy)
     prevBassEnergy = prevBassEnergy * 0.85 + bassEnergy * 0.15
 
-    // Per-band z-scores against rolling history.
-    bandHistory.push(bands)
-    if (bandHistory.length > HISTORY) bandHistory.shift()
-    const zScores = bands.map((v, i) => {
-        let mean = 0
-        for (const h of bandHistory) mean += h[i] ?? 0
-        mean /= bandHistory.length
-        let varSum = 0
-        for (const h of bandHistory) {
-            const d = (h[i] ?? 0) - mean
-            varSum += d * d
-        }
-        const std = Math.sqrt(varSum / bandHistory.length)
-        return std > 1e-6 ? (v - mean) / (std * 2.5) : 0
-    })
-
-    // Bass z-score: self-calibrating hit strength relative to the recent bass floor.
-    // This is what makes it work across wildly different mic levels (line-in vs phone
-    // in a loud club) — it measures "is this bass UNUSUAL for right now", not absolute level.
-    bassEnergyHistory.push(bassEnergy)
-    if (bassEnergyHistory.length > HISTORY) bassEnergyHistory.shift()
-    let bMean = 0
-    for (const v of bassEnergyHistory) bMean += v
-    bMean /= bassEnergyHistory.length
-    let bVar = 0
-    for (const v of bassEnergyHistory) bVar += (v - bMean) * (v - bMean)
-    const bStd = Math.sqrt(bVar / bassEnergyHistory.length)
-    const bassZ = bStd > 1e-6 ? (bassEnergy - bMean) / (bStd * 2.5) : 0
-
-    return { bands, zScores, onset: bassHitRaw, bassEnergy, bassZ, approxEnergy }
+    return { bandStats: bandStatsOut, bassStats: bassStatsOut, approxEnergy, bassHit }
 }
 
 self.onmessage = (e) => {
+    // Config message: set history size (mirrors the FFT worker's config path).
+    if (e.data && e.data.type === 'config') {
+        DEFAULT_HISTORY = e.data.historySize ?? DEFAULT_HISTORY
+        bandStats = null // rebuild on next frame with the new history size
+        return
+    }
     const frame = e.data
     if (!(frame instanceof Float32Array)) return
-    self.postMessage(analyze(frame))
+    self.postMessage(analyze(frame, DEFAULT_HISTORY))
 }

--- a/src/audio/waveletWorker.js
+++ b/src/audio/waveletWorker.js
@@ -1,0 +1,154 @@
+// waveletWorker.js
+// Fast in-place Daubechies-4 (D4) Discrete Wavelet Transform.
+//
+// Why DWT and not CWT: a full CWT scalogram per frame is far too expensive for
+// 60fps on mobile. The dyadic DWT is O(n) and gives exactly what we want for music:
+// octave-spaced bands, each sampled at its OWN natural time resolution. Low bands
+// (bass) update slowly and smoothly; high bands (treble/transients) update fast and
+// sharp. That's the multiresolution property — bass and treble are NOT forced to
+// share a single analysis window like they are in a single FFT.
+//
+// The transform decomposes the FRAME into levels:
+//   level 0 detail = finest / highest frequency  (air, transient edges)
+//   level 1 detail = next octave down
+//   ...
+//   level N detail = lowest detail band
+//   final approximation = bass / sub
+//
+// Per frame we emit:
+//   bands[]      — RMS energy of each octave's detail coefficients (low→high)
+//   onset        — sharp transient signal from the finest detail band's peak energy
+//   approxEnergy — the coarse approximation (bass) energy
+
+// D4 scaling (low-pass) coefficients
+const SQRT3 = Math.sqrt(3)
+const DENOM = 4 * Math.SQRT2
+const H0 = (1 + SQRT3) / DENOM
+const H1 = (3 + SQRT3) / DENOM
+const H2 = (3 - SQRT3) / DENOM
+const H3 = (1 - SQRT3) / DENOM
+// Wavelet (high-pass) coefficients — quadrature mirror of the scaling filter
+const G0 = H3
+const G1 = -H2
+const G2 = H1
+const G3 = -H0
+
+// One in-place D4 step over the first `n` elements of `a`.
+// Even indices ← approximation (low-pass), odd indices ← detail (high-pass),
+// then they're deinterleaved so [0..n/2) = approx, [n/2..n) = detail.
+const dwtStep = (a, n) => {
+    const tmp = new Float32Array(n)
+    const half = n >> 1
+    for (let i = 0; i < half; i++) {
+        const j = i << 1
+        const k0 = j
+        const k1 = (j + 1) % n
+        const k2 = (j + 2) % n
+        const k3 = (j + 3) % n
+        tmp[i] = a[k0] * H0 + a[k1] * H1 + a[k2] * H2 + a[k3] * H3        // approx
+        tmp[half + i] = a[k0] * G0 + a[k1] * G1 + a[k2] * G2 + a[k3] * G3 // detail
+    }
+    for (let i = 0; i < n; i++) a[i] = tmp[i]
+}
+
+// Full multilevel DWT. Returns the transformed array in place; detail bands live at
+// [n/2..n), [n/4..n/2), [n/8..n/4), ... and the final approx at [0..smallest).
+const dwt = (signal) => {
+    const a = Float32Array.from(signal)
+    let n = a.length
+    while (n >= 4) {
+        dwtStep(a, n)
+        n >>= 1
+    }
+    return a
+}
+
+const rms = (arr, start, end) => {
+    let sum = 0
+    for (let i = start; i < end; i++) sum += arr[i] * arr[i]
+    const len = end - start
+    return len > 0 ? Math.sqrt(sum / len) : 0
+}
+
+// Track per-band history for a cheap z-score so the scope can show "is this band
+// spiking vs its own recent baseline" — the same statistical idea as the FFT side.
+const HISTORY = 120 // ~2.5s of frames
+const bandHistory = []
+const bassEnergyHistory = []
+let prevBassEnergy = 0
+let bassHitRaw = 0
+
+const analyze = (frame) => {
+    const N = frame.length
+    const coeffs = dwt(frame)
+
+    // Detail bands, finest first. Band b occupies [N>>(b+1) .. N>>b).
+    // b=0 is the finest (highest freq), increasing b → lower freq.
+    const bands = []
+    let n = N
+    while (n >= 4) {
+        const half = n >> 1
+        bands.push(rms(coeffs, half, n)) // detail coeffs for this octave
+        n = half
+    }
+    // bands is currently high→low; reverse to low→high so band0 = bass-ish.
+    bands.reverse()
+    const approxEnergy = rms(coeffs, 0, Math.max(2, N >> bands.length))
+
+    // ---- DEEP BASS HIT DETECTION ----
+    // band0 = 43-86Hz (deep bass), band1 = 86-172Hz (low bass / first harmonic).
+    // Phone mics roll off hard below ~100Hz, so the 48Hz fundamental of a drop is
+    // heavily attenuated — but its harmonic in band1 survives. We combine band0,
+    // band1, and the sub-approximation, weighting the harmonic so the detector still
+    // fires when the fundamental is mic-murdered. This is the whole point for the
+    // live-phone use case: detect the HIT even when the sub-tone barely arrives.
+    const sub = approxEnergy           // below ~43Hz (mostly gone on phone mics)
+    const b0 = bands[0] ?? 0           // 43-86Hz  deep bass
+    const b1 = bands[1] ?? 0           // 86-172Hz low bass — survives the mic best
+    // Harmonic-weighted bass energy: lean on b1 (survives) + b0, sub as a bonus.
+    const bassEnergy = b1 * 1.0 + b0 * 0.8 + sub * 0.5
+
+    // BASS HIT: sharp POSITIVE jump in bass energy above an adaptive baseline.
+    // The baseline tracks the room's bass floor slowly, so a hit is the spike above it.
+    bassHitRaw = Math.max(0, bassEnergy - prevBassEnergy)
+    // Slow baseline (0.85 decay) so sustained bass doesn't keep re-triggering — only
+    // the rising EDGE of a hit fires. Fast enough to re-arm between drops (~0.5s).
+    prevBassEnergy = prevBassEnergy * 0.85 + bassEnergy * 0.15
+
+    // Per-band z-scores against rolling history.
+    bandHistory.push(bands)
+    if (bandHistory.length > HISTORY) bandHistory.shift()
+    const zScores = bands.map((v, i) => {
+        let mean = 0
+        for (const h of bandHistory) mean += h[i] ?? 0
+        mean /= bandHistory.length
+        let varSum = 0
+        for (const h of bandHistory) {
+            const d = (h[i] ?? 0) - mean
+            varSum += d * d
+        }
+        const std = Math.sqrt(varSum / bandHistory.length)
+        return std > 1e-6 ? (v - mean) / (std * 2.5) : 0
+    })
+
+    // Bass z-score: self-calibrating hit strength relative to the recent bass floor.
+    // This is what makes it work across wildly different mic levels (line-in vs phone
+    // in a loud club) — it measures "is this bass UNUSUAL for right now", not absolute level.
+    bassEnergyHistory.push(bassEnergy)
+    if (bassEnergyHistory.length > HISTORY) bassEnergyHistory.shift()
+    let bMean = 0
+    for (const v of bassEnergyHistory) bMean += v
+    bMean /= bassEnergyHistory.length
+    let bVar = 0
+    for (const v of bassEnergyHistory) bVar += (v - bMean) * (v - bMean)
+    const bStd = Math.sqrt(bVar / bassEnergyHistory.length)
+    const bassZ = bStd > 1e-6 ? (bassEnergy - bMean) / (bStd * 2.5) : 0
+
+    return { bands, zScores, onset: bassHitRaw, bassEnergy, bassZ, approxEnergy }
+}
+
+self.onmessage = (e) => {
+    const frame = e.data
+    if (!(frame instanceof Float32Array)) return
+    self.postMessage(analyze(frame))
+}

--- a/src/audio/waveletWorker.js
+++ b/src/audio/waveletWorker.js
@@ -24,127 +24,20 @@
 //
 // The bass-HIT trigger stays a separate, deliberately UN-smoothed sharp signal.
 
-import { makeCalculateStats } from 'hypnosound'
+import { createWaveletAnalyzer } from './waveletAnalyzer.js'
 
-// D4 scaling (low-pass) coefficients
-const SQRT3 = Math.sqrt(3)
-const DENOM = 4 * Math.SQRT2
-const H0 = (1 + SQRT3) / DENOM
-const H1 = (3 + SQRT3) / DENOM
-const H2 = (3 - SQRT3) / DENOM
-const H3 = (1 - SQRT3) / DENOM
-// Wavelet (high-pass) coefficients — quadrature mirror of the scaling filter
-const G0 = H3
-const G1 = -H2
-const G2 = H1
-const G3 = -H0
-
-// One in-place D4 step over the first `n` elements of `a`.
-// Even indices ← approximation (low-pass), odd indices ← detail (high-pass),
-// then they're deinterleaved so [0..n/2) = approx, [n/2..n) = detail.
-const dwtStep = (a, n) => {
-    const tmp = new Float32Array(n)
-    const half = n >> 1
-    for (let i = 0; i < half; i++) {
-        const j = i << 1
-        const k0 = j
-        const k1 = (j + 1) % n
-        const k2 = (j + 2) % n
-        const k3 = (j + 3) % n
-        tmp[i] = a[k0] * H0 + a[k1] * H1 + a[k2] * H2 + a[k3] * H3        // approx
-        tmp[half + i] = a[k0] * G0 + a[k1] * G1 + a[k2] * G2 + a[k3] * G3 // detail
-    }
-    for (let i = 0; i < n; i++) a[i] = tmp[i]
-}
-
-// Full multilevel DWT. Returns the transformed array in place; detail bands live at
-// [n/2..n), [n/4..n/2), [n/8..n/4), ... and the final approx at [0..smallest).
-const dwt = (signal) => {
-    const a = Float32Array.from(signal)
-    let n = a.length
-    while (n >= 4) {
-        dwtStep(a, n)
-        n >>= 1
-    }
-    return a
-}
-
-const rms = (arr, start, end) => {
-    let sum = 0
-    for (let i = start; i < end; i++) sum += arr[i] * arr[i]
-    const len = end - start
-    return len > 0 ? Math.sqrt(sum / len) : 0
-}
-
-// Track per-band history for a cheap z-score so the scope can show "is this band
-// spiking vs its own recent baseline" — the same statistical idea as the FFT side.
-// Per-band stats functions (one per octave band + one for the harmonic bass energy),
-// each holding its own rolling history. Built lazily once we know historySize and how
-// many bands the frame produces. This mirrors the FFT side: one calculateStats per
-// feature, fed one scalar per frame.
-let DEFAULT_HISTORY = 500 // matches the FFT default (history_size)
-let bandStats = null      // array of calculateStats fns, one per band
-let bassStats = null      // calculateStats for the harmonic-weighted bass energy
-let bandCount = 0
-
-const buildStats = (count, historySize) => {
-    bandCount = count
-    bandStats = Array.from({ length: count }, () => makeCalculateStats(historySize))
-    bassStats = makeCalculateStats(historySize)
-}
-
-// The bass-HIT trigger is deliberately NOT run through stats — it's a sharp,
-// un-smoothed rising-edge signal so drops pop instantly.
-let prevBassEnergy = 0
-
-const bandEnergies = (frame) => {
-    const N = frame.length
-    const coeffs = dwt(frame)
-    // Detail bands, finest first; band b occupies [N>>(b+1) .. N>>b).
-    const bands = []
-    let n = N
-    while (n >= 4) {
-        const half = n >> 1
-        bands.push(rms(coeffs, half, n))
-        n = half
-    }
-    bands.reverse() // low→high so band0 = deep bass
-    const approxEnergy = rms(coeffs, 0, Math.max(2, N >> bands.length))
-    return { bands, approxEnergy }
-}
-
-const analyze = (frame, historySize) => {
-    const { bands, approxEnergy } = bandEnergies(frame)
-    if (!bandStats || bandCount !== bands.length) buildStats(bands.length, historySize)
-
-    // Full 11-stat object per octave band — identical path to the FFT features.
-    const bandStatsOut = bands.map((v, i) => bandStats[i](v))
-
-    // ---- DEEP BASS HIT (harmonic-weighted) ----
-    // Phone mics roll off below ~100Hz, so a drop's 48Hz fundamental is attenuated but
-    // its harmonic in band1 (86-172Hz) survives. Weight band1 highest so the detector
-    // still fires when the fundamental is mic-murdered.
-    const sub = approxEnergy
-    const b0 = bands[0] ?? 0
-    const b1 = bands[1] ?? 0
-    const bassEnergy = b1 * 1.0 + b0 * 0.8 + sub * 0.5
-    const bassStatsOut = bassStats(bassEnergy) // bass energy gets full stats too
-
-    // Sharp un-smoothed hit: positive jump above a slow adaptive baseline.
-    const bassHit = Math.max(0, bassEnergy - prevBassEnergy)
-    prevBassEnergy = prevBassEnergy * 0.85 + bassEnergy * 0.15
-
-    return { bandStats: bandStatsOut, bassStats: bassStatsOut, approxEnergy, bassHit }
-}
+// The worker is now a thin transport shell around the shared analyzer — the same
+// createWaveletAnalyzer the headless harness uses, so what we measure offline is
+// exactly what runs live.
+let analyzer = createWaveletAnalyzer(500)
 
 self.onmessage = (e) => {
     // Config message: set history size (mirrors the FFT worker's config path).
     if (e.data && e.data.type === 'config') {
-        DEFAULT_HISTORY = e.data.historySize ?? DEFAULT_HISTORY
-        bandStats = null // rebuild on next frame with the new history size
+        if (e.data.historySize) analyzer.setHistorySize(e.data.historySize)
         return
     }
     const frame = e.data
     if (!(frame instanceof Float32Array)) return
-    self.postMessage(analyze(frame, DEFAULT_HISTORY))
+    self.postMessage(analyzer.analyze(frame))
 }


### PR DESCRIPTION
## Summary

Adds an opt-in **wavelet (Daubechies-4 DWT) audio analysis pipeline** that runs alongside the existing FFT pipeline, gated behind `?wavelet=true`. Motivation: phone mics roll off below ~100Hz and the single-window FFT smears transients — the DWT gives octave bands at their *own* time resolution (sharp treble, smooth bass) for better deep-bass-drop detection and frequency-motion features.

**Zero changes to existing behavior** — 2063 insertions, 0 deletions. Everything is new and opt-in.

### Pipeline (clean integration)
- `public/raw-tap-processor.js` — un-windowed time-domain tap AudioWorklet
- `src/audio/dwt.js` — pure D4 DWT + band energies (import-anywhere, library-ready)
- `src/audio/waveletAnalyzer.js` — per-frame feature computation (shared by worker + harness)
- `src/audio/waveletWorker.js` — thin transport shell around the analyzer
- `src/audio/WaveletProcessor.js` — publishes `window.cranes.waveletFeatures`
- `index.js` + `tabAudioSource.js` — wire it into the audio_file, mic, and tab-audio paths

### First-class features
Each octave band runs through hypnosound's `makeCalculateStats` — the **same path as the FFT features** — so wavelet bands expose the full 11 stats under FFT naming (`waveletBand0`, `waveletBand0ZScore`, …). Plus derived independent axes: `waveletCentroid` (brightness), `waveletSpread` (complexity), `waveletTilt`, and the deep-bass `wavelet_bassHit` trigger.

### FFT × wavelet combinations
A headless cross-domain harness proved the two domains are **complementary, not redundant** (no pairs with |corr|>0.7; wavelet onsets near-independent from all FFT features). Two combinations shipped:
- `wavelet_punch` — wavelet's fast bass onset + FFT's accurate bass level
- `wavelet_confirmedDrop` — wavelet hit gated by FFT energy rising (far fewer false drops)

### Headless analysis harnesses (`scripts/`)
- `wavelet-harness.mjs` / `wavelet-harness2.mjs` — score features for animation quality (range/liveliness/jitter/reaction-speed/discrimination) + independence
- `fft.mjs` — from-scratch FFT replicating `getByteFrequencyData` so FFT features compute headlessly
- `wavelet-fft-cross.mjs` — cross-domain correlation analysis

### Diagnostic shaders (`shaders/claude/wip/wavelet-scope/`)
Band meters, scrolling oscilloscopes, and the `independent` / `combined` tapestries showing the animation lines. Full design notes in `wavelet-scope.md`.

### Preview links

| Shader | Link |
|--------|------|
| independent tapestry | [preview](https://wavelet.paper-cranes-visuals.pages.dev/?shader=claude/wip/wavelet-scope/independent&wavelet=true) |
| combined (FFT×wavelet) | [preview](https://wavelet.paper-cranes-visuals.pages.dev/?shader=claude/wip/wavelet-scope/combined&wavelet=true) |
| band meters | [preview](https://wavelet.paper-cranes-visuals.pages.dev/?shader=claude/wip/wavelet-scope/1&wavelet=true) |

## Test plan

- [ ] `node scripts/wavelet-harness2.mjs <pcm files>` runs and scores features
- [ ] Load a wavelet-scope shader with `?wavelet=true&audio=tab` and a Spotify tab — confirm lanes animate
- [ ] Verify existing shaders are unaffected when `?wavelet=true` is absent (it's the default)
- [ ] Known issue to review: the `audio_file` path needs a user gesture to resume the AudioContext (pre-existing; surfaced during testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)