### PR TITLE
iris/wavelet: de-strobe kick + cymbal flashes (keep reactivity)

### DIFF
--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -520,7 +520,11 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
       float emit = (0.35 + 0.55 * audioL) * outsideMask * voidFade;
       // tendril hue rides the peach palette (mostly CORONA blue-violet, peach core warming closer in)
       // — multiply col3 (which is already blue-bias) by a peach-tinted lift on transients
-      vec3 warmLift = oklch2rgb(vec3(0.75, 0.14, CORE_HUE + float(slot) * 0.25)) * clamp(spectralFluxZScore, 0.0, 1.0) * 0.3;
+      // SMOOTH driver for this GLOBAL background tint (was raw spectralFluxZScore — it spiked
+      // on every cymbal and flashed the whole void peach for a frame). Use smooth energy +
+      // treble so it still LIFTS on bright/loud sections, but eases instead of strobing.
+      // (The local rim/catchlight/feedback terms keep their raw snappy flux — reactivity stays.)
+      vec3 warmLift = oklch2rgb(vec3(0.75, 0.14, CORE_HUE + float(slot) * 0.25)) * clamp(energySpring * 0.4 + waveletBand5Spring * 0.3, 0.0, 1.0) * 0.3;
       col += col3 * emit + warmLift * outsideMask * voidFade;
     }
   }

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -35,6 +35,7 @@ uniform float waveletCentroidSpring;   // wavelet brightness
 uniform float energySpring;            // loudness
 uniform float wubDepth;                // dubstep wobble intensity
 uniform float melodyFlow;              // flowing melody/pitch contour
+uniform float wavelet_bassHit;         // sharp kick/drop trigger — drives the zoom punch
 // spectralCrestNormalized, spectralRoughnessNormalized, spectralEntropyNormalized,
 // spectralFluxZScore are FFT features — auto-declared by the wrapper.
 
@@ -185,7 +186,10 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   vec2  q2 = q - gazeV * 0.25;                              // recentre screen-space lookup for rr
   vec2 p = 2.0*(q - 0.5 - gazeV * 0.5);                     // shift fractal space (whole eye turns)
   p.x *= iResolution.x/iResolution.y;
-  p *= ZOOM * (1.0 - bass_pump * BASS_REACT * 0.12);   // bass ZOOM PUNCH — sub hits push in
+  // KICK = ZOOM (not a color flash). The kick punches the camera IN, then it springs back.
+  // Uses the smooth bass_pump (no one-frame strobe) + a touch of the sharp hit for snap.
+  float kickZoom = bass_pump * BASS_REACT * 0.22 + clamp(wavelet_bassHit, 0.0, 1.0) * 0.08;
+  p *= ZOOM * (1.0 - kickZoom);                        // sub/kick hits push the camera in
   float d = df(p);
   // ZOOM-DEEP SUB-LAYER — compound nested fractal: a second pass at half scale, rotated,
   // blended in by ZOOM_DEEP. As knob_1 climbs, more recursion levels accumulate.
@@ -312,7 +316,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
           + 0.18 * knob_16 * tipW * (0.4 + 0.6*treble_env) * (1.0 - 0.45 * centroid_env)
           + 0.12 * limbal                            // limbal shifts hue toward blue
           - 0.06 * crypts
-          + 0.08 * pitch_pulse                       // melodic jumps shift palette zone
+          + 0.08 * (melodyFlow - 0.5)                 // MELODY (smooth) shifts palette zone — not the kick
           // PLASMA MIX-IN (iter31): on sub-bass passages, pull t toward the orange→blue
           // gradient zone of the plasma series. CORE_HUE 0.6 rad / CORONA 4.2 rad map into
           // t-space at roughly t=0.10 (orange) ↔ t=0.67 (blue-violet). monsterBass biases


### PR DESCRIPTION
## Summary

Two flash fixes for the wavelet-driven iris, both surgical and reactivity-preserving:

- **Kick** no longer flashes the palette — the palette-zone shift now follows smooth `melodyFlow` (real melodic motion), and the kick's energy drives a **zoom punch** instead (camera pushes in, springs back). Geometry only, no global color/brightness change.
- **Cymbal** no longer flashes the whole screen — the one global `warmLift` background tint (was raw `spectralFluxZScore`, spiked on every cymbal) now eases via smooth energy + treble. Every **local** reactive term (rim pulse, catchlight specular, feedback swirl) keeps its raw snappy flux/crest/roughness, so the cymbal sparkle stays.

## Test plan

- [ ] `?shader=claude/wip/iris/wavelet&wavelet=true&controller=wavelet-ease&fullscreen=true&knob_1=0.45&knob_2=0.1&knob_4=1.0&knob_5=0.4&knob_7=0.66&knob_8=1&knob_11=1&knob_17=0.7&knob_18=0.8` — kick zooms (no palette flash), cymbals sparkle locally (no full-screen color jump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)