### PR TITLE
wavelet: auto-declare DWT uniforms + iris/wavelet polish

### DIFF
--- a/controllers/wavelet-ease.js
+++ b/controllers/wavelet-ease.js
@@ -67,6 +67,7 @@ export function make() {
     let tonalSmooth = 0       // smoothed tonal strength
     const spectralSmooth = { crest: 0, rough: 0, entropy: 0 } // smoothed jittery spectral texture
     let quietGate = 0         // 0 in silence → 1 when loud; fades reactivity to stop quiet-noise flashing
+    const phase = { spin: 0, morph: 0, flow: 0, hue: 0 } // monotonic accumulators (rate*dt) — no iTime*rate acceleration
     let bassNoteFlow = null   // flowing bassline-pitch contour
     let wubBaseline = 0       // slow bass average, for wub-depth detection
     let wubDepth = 0          // smoothed wobble amplitude
@@ -88,6 +89,22 @@ export function make() {
             s.pos += s.vel * dt
             out[`${f}Spring`] = s.pos
         }
+
+        // ── MONOTONIC PHASE ACCUMULATORS ── phase += rate*dt, so a CHANGING rate only changes
+        // the speed FROM NOW ON. (A shader doing `iTime * rate` instead jumps the whole angle
+        // by iTime*Δrate whenever the rate changes — and that jump GROWS as iTime grows, so the
+        // spin appears to ACCELERATE over time. Accumulating here fixes that at the source.)
+        const bassS = spring.waveletBass?.pos ?? 0
+        const band3S = spring.waveletBand3?.pos ?? 0
+        const energyS = spring.energy?.pos ?? 0
+        phase.spin  += (0.02 + bassS  * 0.10) * dt
+        phase.morph += (0.02 + band3S * 0.10) * dt
+        phase.flow  += (0.06 + energyS * 0.15) * dt
+        phase.hue   += (0.04 + tonalSmooth * 0.10) * dt
+        out.spinPhase  = phase.spin
+        out.morphPhase = phase.morph
+        out.flowPhase  = phase.flow
+        out.huePhase   = phase.hue
 
         // ── MELODY FLOW: ease the (categorical, circular) pitch into a flowing contour ──
         const pitch = features.pitchClassNormalized ?? 0

--- a/controllers/wavelet-ease.js
+++ b/controllers/wavelet-ease.js
@@ -66,6 +66,7 @@ export function make() {
     let melodyFlow = null     // flowing pitch contour
     let tonalSmooth = 0       // smoothed tonal strength
     const spectralSmooth = { crest: 0, rough: 0, entropy: 0 } // smoothed jittery spectral texture
+    let quietGate = 0         // 0 in silence → 1 when loud; fades reactivity to stop quiet-noise flashing
     let bassNoteFlow = null   // flowing bassline-pitch contour
     let wubBaseline = 0       // slow bass average, for wub-depth detection
     let wubDepth = 0          // smoothed wobble amplitude
@@ -118,6 +119,16 @@ export function make() {
         out.spectralCrestSmooth = spectralSmooth.crest
         out.spectralRoughnessSmooth = spectralSmooth.rough
         out.spectralEntropySmooth = spectralSmooth.entropy
+
+        // ── QUIET GATE ── In quiet passages (only cymbals/hiss), the Normalized & z-score
+        // features divide by a near-zero recent range and BLOW UP — pure noise becomes wild
+        // full-range swings, flashing hue & spinning fast. quietGate smoothly fades 0→1 with
+        // loudness so shaders can multiply their audio offsets by it: at low energy the
+        // reactivity fades out (visual holds calm) instead of being driven by noise.
+        const eRaw = features.energy ?? 0                       // absolute loudness (gain-independent enough at the low end)
+        const gateTarget = Math.min(1, Math.max(0, (eRaw - 0.015) / 0.05)) // 0 below ~0.015, 1 by ~0.065
+        quietGate = quietGate * 0.9 + gateTarget * 0.1          // smooth so the gate itself never flashes
+        out.quietGate = quietGate
 
         // ── BASS NOTE FLOW: energy-weighted "bass centroid" across the low bands ──
         const e0 = features.waveletBand0 ?? 0, e1 = features.waveletBand1 ?? 0

--- a/controllers/wavelet-ease.js
+++ b/controllers/wavelet-ease.js
@@ -90,12 +90,15 @@ export function make() {
         // ── MELODY FLOW: ease the (categorical, circular) pitch into a flowing contour ──
         const pitch = features.pitchClassNormalized ?? 0
         const tonal = features.spectralCrest ?? 0
-        const confident = Math.min(1, Math.max(0, (tonal - 0.3) * 2)) // only chase a clear tonal note
+        // Looser gate (was tonal>0.3) so melodic instruments with MODERATE crest — flutes,
+        // strings, pads, slides — still drive the melody, and a faster chase (0.18) so the
+        // contour follows gliding/portamento pitch instead of lagging behind it.
+        const confident = Math.min(1, Math.max(0, (tonal - 0.15) * 2.5))
         if (melodyFlow === null) melodyFlow = pitch
         let diff = pitch - melodyFlow            // step along the SHORTER arc (pitch wraps at 1.0)
         if (diff > 0.5) diff -= 1.0
         if (diff < -0.5) diff += 1.0
-        melodyFlow += diff * 0.12 * confident    // ease toward the note when confident, else hold
+        melodyFlow += diff * 0.18 * confident    // ease toward the note when confident, else hold
         melodyFlow = (melodyFlow + 1.0) % 1.0
         out.melodyFlow = melodyFlow
         out.tonalStrength = (tonalSmooth = tonalSmooth * 0.85 + tonal * 0.15)

--- a/controllers/wavelet-ease.js
+++ b/controllers/wavelet-ease.js
@@ -65,6 +65,7 @@ export function make() {
     const spring = {}        // per-feature { pos, vel }
     let melodyFlow = null     // flowing pitch contour
     let tonalSmooth = 0       // smoothed tonal strength
+    const spectralSmooth = { crest: 0, rough: 0, entropy: 0 } // smoothed jittery spectral texture
     let bassNoteFlow = null   // flowing bassline-pitch contour
     let wubBaseline = 0       // slow bass average, for wub-depth detection
     let wubDepth = 0          // smoothed wobble amplitude
@@ -98,10 +99,25 @@ export function make() {
         let diff = pitch - melodyFlow            // step along the SHORTER arc (pitch wraps at 1.0)
         if (diff > 0.5) diff -= 1.0
         if (diff < -0.5) diff += 1.0
-        melodyFlow += diff * 0.18 * confident    // ease toward the note when confident, else hold
+        // RATE-LIMIT the step so a melodic LEAP (or pitch jumping to the opposite side of the
+        // circle) can't teleport melodyFlow ~1.0 in one frame — that flashed everything driven
+        // by it. Now it always GLIDES between notes, even across big intervals (slew cap 0.03/frame).
+        let step = diff * 0.18 * confident
+        step = Math.max(-0.03, Math.min(0.03, step))
+        melodyFlow += step
         melodyFlow = (melodyFlow + 1.0) % 1.0
         out.melodyFlow = melodyFlow
         out.tonalStrength = (tonalSmooth = tonalSmooth * 0.85 + tonal * 0.15)
+
+        // ── SMOOTHED SPECTRAL TEXTURE features ── these raw FFT features (crest/roughness/
+        // entropy) are JITTERY frame-to-frame (jump 0.12-0.17/frame) and make any visual they
+        // drive SHIVER. EMA-smooth them here so shaders can use texture features without flicker.
+        spectralSmooth.crest = spectralSmooth.crest * 0.85 + (features.spectralCrestNormalized ?? 0) * 0.15
+        spectralSmooth.rough = spectralSmooth.rough * 0.85 + (features.spectralRoughnessNormalized ?? 0) * 0.15
+        spectralSmooth.entropy = spectralSmooth.entropy * 0.85 + (features.spectralEntropyNormalized ?? 0) * 0.15
+        out.spectralCrestSmooth = spectralSmooth.crest
+        out.spectralRoughnessSmooth = spectralSmooth.rough
+        out.spectralEntropySmooth = spectralSmooth.entropy
 
         // ── BASS NOTE FLOW: energy-weighted "bass centroid" across the low bands ──
         const e0 = features.waveletBand0 ?? 0, e1 = features.waveletBand1 ?? 0

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -79,6 +79,12 @@ uniform float spectralCrestSmooth;      // smoothed spectral crest (was jittery 
 uniform float spectralRoughnessSmooth;  // smoothed spectral roughness (was jittery raw)
 uniform float spectralEntropySmooth;    // smoothed spectral entropy (was jittery raw)
 uniform float quietGate;                // 0 in quiet → 1 loud; gates audio offsets (no quiet-noise flashing)
+// NEW fractal-complexity dimensions — measured lively AND smooth on melodic audio (jit<0.06):
+uniform float spectralSkewNormalized;       // spectral tilt/asymmetry → petal lean
+uniform float spectralKurtosisNormalized;   // peakedness → focus vs diffuse petals
+uniform float spectralSpreadNormalized;     // spectral width → ring spread
+uniform float spectralRolloffNormalized;    // high-freq cutoff → outer reach
+// waveletTilt (bass↔treble lean) + waveletBand1 (sub layer) auto-declare.
 
 // === Knobs ===
 // knob_1 ZOOM: 0=zoomed-out flat, 1=plunged deep into the fractal tunnel.
@@ -99,13 +105,13 @@ uniform float quietGate;                // 0 in quiet → 1 loud; gates audio of
 // across unrelated aspects.
 
 #define ZOOM_K      (knob_1)
-// ZOOM ← LEVEL (loudness): louder pushes the camera in.
-#define ZOOM        (0.35 + ZOOM_K * 2.65 + energySpring * 0.2)
+// ZOOM ← LEVEL (loudness) × RING_REACH (rolloff sets outer reach — defined just below).
+#define ZOOM        ((0.35 + ZOOM_K * 2.65 + energySpring * 0.2) * RING_REACH)
 #define ZOOM_DEEP   (ZOOM_K * ZOOM_K)
 
-// PITCH FAMILY → COLOR. melody + brightness set the palette; GATED by loudness so quiet
-// noise can't flash the hue (the audio offset fades to 0 when quiet, leaving the knob base).
-#define MASTER_HUE  (knob_2 * 6.28318 + (melodyFlow * 0.8 + waveletCentroidSpring * 0.4) * quietGate)
+// PITCH FAMILY → COLOR. melody + brightness set the palette + SUB_LEAN (bass↔treble tilt);
+// GATED by loudness so quiet noise can't flash the hue (offset fades to 0 when quiet).
+#define MASTER_HUE  (knob_2 * 6.28318 + (melodyFlow * 0.8 + waveletCentroidSpring * 0.4) * quietGate + SUB_LEAN)
 
 // LEVEL FAMILY → SIZE / DEPTH / THICKNESS. Band energies set how BIG/BOLD/DEEP, by region.
 #define LINE_THICK  (width * (5.0 + energy_env * 5.0) * (0.4 + knob_18 * 1.6))            // loudness = line weight
@@ -114,7 +120,10 @@ uniform float quietGate;                // 0 in quiet → 1 loud; gates audio of
 #define DEPTH (mix(0.18, 0.50, knob_17) + waveletBassSpring * 0.14)                       // bass energy = core depth
 
 // TEXTURE FAMILY → DETAIL / SPARKLE / EDGE. Transients/grit set fine structure (below + IRIDESCENCE/EDGE_GLOW).
-#define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 8.0 + spectralRoughnessSmooth * 6.0) // grit = ring detail
+// SHAPE FAMILY (NEW): spectral SPREAD/ROLLOFF → ring spacing & outer reach (how wide the spectrum = how far the structure spreads).
+#define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 8.0 + spectralRoughnessSmooth * 6.0 + (spectralSpreadNormalized - 0.5) * 8.0 * quietGate) // spread = ring spacing
+#define RING_REACH  (1.0 + (spectralRolloffNormalized - 0.5) * 0.18 * quietGate)  // rolloff = how far the iris reaches outward
+#define SUB_LEAN    ((waveletTiltNormalized - 0.5) * 0.25 * quietGate)            // bass↔treble lean tints the hue (small — tilt is the jitteriest of the new set, 0.075/frame)
 #define TWIST (knob_10 * 3.14159 + ZOOM_DEEP * 1.6 + tonalStrength * 0.5)  // static twist; melody drives SHAPE (above), not rotation — no rocking back
 #define BASS_REACT (0.8 + knob_11 * 1.4)
 
@@ -167,12 +176,17 @@ float df(vec2 p) {
   // chrysanthemum geometry slowly opening/closing — classic DMT-aesthetic move.
   // Amplitude tiny (~0.05 rad ≈ 3°), phase from morph_phase + per-petal offset (golden-ratio
   // step to avoid resonance), so each petal moves independently.
+  // NEW dimensions (subtle, quietGate-protected so they don't blow up in quiet):
+  // SKEW → petals LEAN: an extra rotational offset that tilts the whole flower one way.
+  float petalLean = (spectralSkewNormalized - 0.5) * 0.5 * quietGate;
+  // KURTOSIS → FOCUS vs DIFFUSE: pulls petals inward (focused star) or pushes out (open flower).
+  float petalFocus = 1.0 + (spectralKurtosisNormalized - 0.5) * 0.22 * quietGate;
   for (int i = 0; i < rep; ++i) {
     vec2 ip = p;
     float petalI = float(i);
     float petalBreath = 0.05 * sin(morph_phase * 0.7 + petalI * 2.39996);  // golden-angle phase
-    rot(ip, petalI * TAU/float(rep) + TWIST + petalBreath);
-    ip -= vec2(offc*size, 0.0);
+    rot(ip, petalI * TAU/float(rep) + TWIST + petalBreath + petalLean);     // SKEW leans the flower
+    ip -= vec2(offc*size*petalFocus, 0.0);                                  // KURTOSIS focuses/diffuses
     vec2 cp = ip;
     rot(ip, spin_angle);                         // continuous monotonic spin
     float dd = dodec(vec3(ip, off*size));

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -1,5 +1,5 @@
 // @fullscreen: true
-//https://visuals.beadfamous.com/?shader=claude/wip/iris/wavelet&wavelet=true&controller=wavelet-ease&fullscreen=true&knob_1=0.45&knob_2=0.1&knob_4=1.0&knob_5=0.2&knob_7=0.66&knob_8=1&knob_11=1&knob_17=0.7&knob_18=0.8&knob_20=0.6&knob_21=0.7&knob_22=0.6&knob_23=0.6&knob_24=0.6&knob_25=0.6&knob_26=1.0&knob_27=0.4
+//https://visuals.beadfamous.com/?shader=claude/wip/iris/wavelet&wavelet=true&controller=wavelet-ease&fullscreen=true&knob_1=0.45&knob_2=0.1&knob_4=1.0&knob_5=0.2&knob_7=0.66&knob_8=1&knob_11=1&knob_17=0.7&knob_18=0.8&knob_20=0.6&knob_21=0.7&knob_22=0.6&knob_23=0.6&knob_24=0.6&knob_25=0.6&knob_26=1.0&knob_27=0.4&knob_28=0.5&knob_29=0.4
 // @mobile: false
 // License: CC0
 //  iris/7 driven by the WAVELET + SPECTRAL features (forked from iris/7, swapping the
@@ -67,6 +67,8 @@ uniform float waveletBassZScore;       // self-calibrating bass spike — kick z
 //    knob_25 = ROLLOFF → outer reach
 //    knob_26 = energy/band level reactivity (size/depth breathing)
 //    knob_27 = TILT → hue sub-lean
+//    knob_28 = TUNNEL zoom speed (feedback push — a big part of apparent SPEED)
+//    knob_29 = TUNNEL swirl speed (feedback rotation — the OTHER fast-spin source)
 // Each knob is a 0→1 depth: 0 = that effect OFF, 1 = full. The preset URL sets good starting
 // values; turn any knob down live to calm that effect, up to intensify it. Direct + simple.
 #define MOD_SPIN_AUDIO  (knob_20)
@@ -621,14 +623,17 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   // (iter8 swap — drop_glow drives the held-drop "we're falling into it" feel without a new layer)
   // iter79 add flux + roughness to the tunnel-rush velocity. Timbral motion and
   // dissonance deepen the tunnel — feels like the eye "reacts" to texture changes.
-  float rush = 0.025
-             + ZOOM_DEEP * 0.040
-             + bass_pump * BASS_REACT * 0.020
-             + drop_glow * 0.030
-             + clamp(spectralFluxZScore, 0.0, 1.0) * 0.025
-             + spectralRoughnessSmooth * 0.018;
+  // FEEDBACK TUNNEL motion — this is the dominant apparent SPEED (the prior frame zooming +
+  // swirling every frame at 60fps), NOT the geometry phases. knob_28 = tunnel zoom speed,
+  // knob_29 = tunnel swirl speed. Both were way too fast; scaled down + knob-controlled.
+  float rush = (0.008
+             + ZOOM_DEEP * 0.020
+             + bass_pump * BASS_REACT * 0.012
+             + drop_glow * 0.015
+             + clamp(spectralFluxZScore, 0.0, 1.0) * 0.012
+             + spectralRoughnessSmooth * 0.010) * knob_28;
   float zoomF = 1.0 - rush;                              // <1 = prior frame zooms outward
-  float mrot = 0.015 + ZOOM_DEEP * 0.035 + drop_glow * 0.020;  // drop also adds swirl
+  float mrot = (0.004 + ZOOM_DEEP * 0.012 + drop_glow * 0.010) * knob_29;  // tunnel swirl (was 0.015 base — far too fast)
   vec2 ruv = q - CEN;
   ruv = mat2(cos(mrot), -sin(mrot), sin(mrot), cos(mrot)) * ruv;
   ruv = ruv * zoomF + CEN;

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -44,12 +44,14 @@ uniform float waveletBassZScore;       // self-calibrating bass spike — kick z
 // Speed modulated by audio LEVELS so motion quickens with intensity, knob_5 = base speed.
 // Slowed way down — was spinning too fast. Rates are monotonic (always forward); audio
 // gently modulates SPEED via a small +term, never the angle (so no rotate-back).
-#define spin_angle   (iTime * (0.04 + knob_5 * 0.12) + waveletBassSpring * 0.12)
-#define morph_phase  (iTime * 0.035 + waveletBand3Spring * 0.2)
-#define flow_phase   (iTime * 0.06 + energySpring * 0.25)
+// quietGate (0 in quiet, 1 when loud) multiplies the AUDIO offsets so quiet-noise can't
+// drive fast spin / hue flashing — at low energy these fall back to their gentle base rate.
+#define spin_angle   (iTime * (0.04 + knob_5 * 0.12) + waveletBassSpring * 0.12 * quietGate)
+#define morph_phase  (iTime * 0.035 + waveletBand3Spring * 0.2 * quietGate)
+#define flow_phase   (iTime * 0.06 + energySpring * 0.25 * quietGate)
 // hue_phase MONOTONIC — melody modulates the RATE (always forward), never the angle, so
 // the palette journeys forward and never rotates back when the melody slides down.
-#define hue_phase    (iTime * (0.04 + tonalStrength * 0.10))
+#define hue_phase    (iTime * (0.04 + tonalStrength * 0.10 * quietGate))
 
 // LEVELS — map our smooth wavelet/spectral features onto iris's reactive envelopes.
 #define bass_env     (waveletBassSpring)                  // core thickness / bass reactivity
@@ -76,6 +78,7 @@ uniform float waveletBand1Spring;       // low-bass
 uniform float spectralCrestSmooth;      // smoothed spectral crest (was jittery raw)
 uniform float spectralRoughnessSmooth;  // smoothed spectral roughness (was jittery raw)
 uniform float spectralEntropySmooth;    // smoothed spectral entropy (was jittery raw)
+uniform float quietGate;                // 0 in quiet → 1 loud; gates audio offsets (no quiet-noise flashing)
 
 // === Knobs ===
 // knob_1 ZOOM: 0=zoomed-out flat, 1=plunged deep into the fractal tunnel.
@@ -100,8 +103,9 @@ uniform float spectralEntropySmooth;    // smoothed spectral entropy (was jitter
 #define ZOOM        (0.35 + ZOOM_K * 2.65 + energySpring * 0.2)
 #define ZOOM_DEEP   (ZOOM_K * ZOOM_K)
 
-// PITCH FAMILY → COLOR. melody + brightness set the palette position; nothing else.
-#define MASTER_HUE  (knob_2 * 6.28318 + melodyFlow * 0.8 + waveletCentroidSpring * 0.4)  // pitch & brightness tint the palette
+// PITCH FAMILY → COLOR. melody + brightness set the palette; GATED by loudness so quiet
+// noise can't flash the hue (the audio offset fades to 0 when quiet, leaving the knob base).
+#define MASTER_HUE  (knob_2 * 6.28318 + (melodyFlow * 0.8 + waveletCentroidSpring * 0.4) * quietGate)
 
 // LEVEL FAMILY → SIZE / DEPTH / THICKNESS. Band energies set how BIG/BOLD/DEEP, by region.
 #define LINE_THICK  (width * (5.0 + energy_env * 5.0) * (0.4 + knob_18 * 1.6))            // loudness = line weight
@@ -119,8 +123,8 @@ uniform float spectralEntropySmooth;    // smoothed spectral entropy (was jitter
 #define EDGE_GLOW   (0.9 + 0.4 * energy_env + spectralCrestSmooth * 0.4)       // articulation glints the edges
 
 // PITCH FAMILY → COLOR (continued). Brightness/crest set the core & corona hues.
-#define CORE_HUE   (0.6 + waveletCentroidSpring * 0.8)
-#define CORONA_HUE (4.2 - spectralCrestSmooth * 0.6)
+#define CORE_HUE   (0.6 + waveletCentroidSpring * 0.8 * quietGate)
+#define CORONA_HUE (4.2 - spectralCrestSmooth * 0.6 * quietGate)
 
 const vec3 plnormal = normalize(vec3(1, 1, -1));
 const vec3 n1 = normalize(vec3(-PHI,PHI-1.0,1.0));
@@ -478,7 +482,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
                     + spectralRoughnessSmooth * 0.25;
   float rimAmp      = mix(0.0, 0.55, knob_49) * rimPulse;
   float rimHue      = mix(CORE_HUE, CORONA_HUE, 0.85) + (knob_46 - 0.5) * 1.2
-                    + pitchClassNormalized * 0.5;                   // pitch tints rim hue
+                    + melodyFlow * 0.5;                             // SMOOTH melody tints rim (was raw pitchClassNormalized — flashed in quiet)
   vec3  rimColor    = oklch2rgb(vec3(0.78, 0.18, rimHue));
   col += rimColor * (rimGauss + rimHalo) * rimAmp;
 

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -42,10 +42,14 @@ uniform float waveletBassZScore;       // self-calibrating bass spike — kick z
 
 // MOTION phases — monotonic from iTime (the controller did this in JS; iTime is monotonic).
 // Speed modulated by audio LEVELS so motion quickens with intensity, knob_5 = base speed.
-#define spin_angle   (iTime * (0.15 + knob_5 * 0.6) + waveletBassSpring * 0.4)
-#define morph_phase  (iTime * 0.08 + waveletBand3Spring * 0.5)
-#define flow_phase   (iTime * 0.12 + energySpring * 0.6)
-#define hue_phase    (iTime * 0.04 + melodyFlow * 1.2)   // MELODY drives the palette journey
+// Slowed way down — was spinning too fast. Rates are monotonic (always forward); audio
+// gently modulates SPEED via a small +term, never the angle (so no rotate-back).
+#define spin_angle   (iTime * (0.04 + knob_5 * 0.12) + waveletBassSpring * 0.12)
+#define morph_phase  (iTime * 0.035 + waveletBand3Spring * 0.2)
+#define flow_phase   (iTime * 0.06 + energySpring * 0.25)
+// hue_phase MONOTONIC — melody modulates the RATE (always forward), never the angle, so
+// the palette journeys forward and never rotates back when the melody slides down.
+#define hue_phase    (iTime * (0.04 + tonalStrength * 0.10))
 
 // LEVELS — map our smooth wavelet/spectral features onto iris's reactive envelopes.
 #define bass_env     (waveletBassSpring)                  // core thickness / bass reactivity
@@ -80,19 +84,24 @@ uniform float waveletBand1Spring;       // low-bass
 #define ZOOM_K      (knob_1)
 #define ZOOM        (0.35 + ZOOM_K * 2.65 + energySpring * 0.2)        // loudness pushes you in (gentler)
 #define ZOOM_DEEP   (ZOOM_K * ZOOM_K)
-#define MASTER_HUE  (knob_2 * 6.28318 + melodyFlow * 1.6)             // MELODY shifts the master hue
+// FLUTE/MELODIC tailoring: this audio is all gliding melody, so the MELODY drives the
+// fractal SHAPE — facet size, arm spread, ripple density, core depth all morph with the
+// pitch slide (these are non-rotational, so going up/down with the melody is GOOD — the
+// fractal flowers/contracts with the line). Hue still sweeps with melody (color, not spin).
+// Rotation phases stay monotonic (rate-modulated), so NOTHING rotates back. Bass zoom kept.
+#define MASTER_HUE  (knob_2 * 6.28318 + melodyFlow * 0.8)             // MELODY gently tints the palette (small sweep — no full-cycle color flash)
 #define LINE_THICK  (width * (5.0 + energy_env * 5.0) * (0.4 + knob_18 * 1.6))
-#define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 10.0) // high-mid = ring density (gentler)
-// fractal exploration:
-#define size  (baseSize * mix(0.55, 1.10, knob_7) * (1.0 + waveletBand2Spring * 0.10)) // mids breathe facet size (gentler)
-#define offc  (baseOffc * mix(0.70, 1.45, knob_8) * (1.0 + waveletBand5Spring * 0.08)) // treble spreads the arms (gentler)
-#define DEPTH (mix(0.18, 0.50, knob_17) + waveletBand1Spring * 0.07)  // low-bass deepens the core (gentler)
-#define TWIST (knob_10 * 3.14159 + ZOOM_DEEP * 1.6 + tonalStrength * 0.5)  // tonal-ness curls the spiral (gentler)
+#define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 10.0 + melodyFlow * 14.0) // MELODY rings the iris
+// fractal exploration — MELODY drives these hard (this is melodic audio):
+#define size  (baseSize * mix(0.55, 1.10, knob_7) * (1.0 + waveletBand2Spring * 0.10 + (melodyFlow - 0.5) * 0.30)) // melody flowers the facets
+#define offc  (baseOffc * mix(0.70, 1.45, knob_8) * (1.0 + waveletBand5Spring * 0.08 + (melodyFlow - 0.5) * 0.25)) // melody spreads/closes the arms
+#define DEPTH (mix(0.18, 0.50, knob_17) + waveletBand1Spring * 0.07 + (melodyFlow - 0.5) * 0.16)  // melody breathes the core depth
+#define TWIST (knob_10 * 3.14159 + ZOOM_DEEP * 1.6 + tonalStrength * 0.5)  // static twist; melody drives SHAPE (above), not rotation — no rocking back
 #define BASS_REACT (0.8 + knob_11 * 1.4)
 
 // brightness (smoothed levels — never flicker)
 #define IRIDESCENCE (0.7 + 0.6 * entropy_env + spectralRoughnessNormalized * 0.3) // grit adds shimmer
-#define EDGE_GLOW   (0.9 + 0.4 * energy_env + waveletCentroidSpring * 0.3)         // brightness lifts edges
+#define EDGE_GLOW   (0.9 + 0.4 * energy_env + waveletCentroidSpring * 0.3 + spectralCrestNormalized * 0.35) // flute articulation glints the edges
 
 // plasma palette — Oklch hue in radians; centroid warms the core, crest cools the corona
 #define CORE_HUE   (0.6 + waveletCentroidSpring * 0.8)
@@ -244,7 +253,9 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
   // EVERYTHING multiplies the structure -> void is ALWAYS 0 -> ZERO background activity.
   // drops + pitch brighten ONLY where structure already exists.
-  float intensity = clamp(structure * (0.55 + 0.9*regionGlow) * (1.0 + drop_glow*0.9 + pitch_pulse*0.6), 0.0, 1.0);
+  // GENTLER global brightness response — drop_glow/pitch_pulse ride crest, which spikes on
+  // each flute note; at the old 0.9/0.6 gains that flashed the whole iris. Halved so it lifts softly.
+  float intensity = clamp(structure * (0.55 + 0.9*regionGlow) * (1.0 + drop_glow*0.4 + pitch_pulse*0.25), 0.0, 1.0);
 
   // === iter19 IQ-STYLE OKLAB PALETTE (rewrite, no multiplier cascade) ===
   // All previous L *= and C *= mods were stacking past saturation -> persistent washout.

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -46,11 +46,11 @@ uniform float waveletBassZScore;       // self-calibrating bass spike — kick z
 // gently modulates SPEED via a small +term, never the angle (so no rotate-back).
 // quietGate (0 in quiet, 1 when loud) multiplies the AUDIO offsets so quiet-noise can't
 // drive fast spin / hue flashing — at low energy these fall back to their gentle base rate.
-#define spin_angle   (iTime * (0.04 + knob_5 * 0.12) + waveletBassSpring * 0.12 * quietGate)
-#define morph_phase  (iTime * 0.035 + waveletBand3Spring * 0.2 * quietGate)
-#define flow_phase   (iTime * 0.06 + energySpring * 0.25 * quietGate)
-// hue_phase MONOTONIC — melody modulates the RATE (always forward), never the angle, so
-// the palette journeys forward and never rotates back when the melody slides down.
+// STRICTLY MONOTONIC: audio modulates the RATE (inside the iTime multiplier), never adds to
+// the angle — so these only ever move FORWARD, faster on louder/bassier audio, never back.
+#define spin_angle   (iTime * (0.04 + knob_5 * 0.12 + waveletBassSpring * 0.12 * quietGate))
+#define morph_phase  (iTime * (0.035 + waveletBand3Spring * 0.10 * quietGate))
+#define flow_phase   (iTime * (0.06 + energySpring * 0.15 * quietGate))
 #define hue_phase    (iTime * (0.04 + tonalStrength * 0.10 * quietGate))
 
 // LEVELS — map our smooth wavelet/spectral features onto iris's reactive envelopes.
@@ -124,7 +124,7 @@ uniform float spectralRolloffNormalized;    // high-freq cutoff → outer reach
 #define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 8.0 + spectralRoughnessSmooth * 6.0 + (spectralSpreadNormalized - 0.5) * 8.0 * quietGate) // spread = ring spacing
 #define RING_REACH  (1.0 + (spectralRolloffNormalized - 0.5) * 0.18 * quietGate)  // rolloff = how far the iris reaches outward
 #define SUB_LEAN    ((waveletTiltNormalized - 0.5) * 0.25 * quietGate)            // bass↔treble lean tints the hue (small — tilt is the jitteriest of the new set, 0.075/frame)
-#define TWIST (knob_10 * 3.14159 + ZOOM_DEEP * 1.6 + tonalStrength * 0.5)  // static twist; melody drives SHAPE (above), not rotation — no rocking back
+#define TWIST (knob_10 * 3.14159 + ZOOM_DEEP * 1.6)  // STATIC twist (knob only) — NO audio, so the petals never rock back. Audio drives SHAPE, not this rotation.
 #define BASS_REACT (0.8 + knob_11 * 1.4)
 
 // TEXTURE FAMILY → SHIMMER / SPARKLE (continued). Grit & articulation drive the fine glints.
@@ -176,19 +176,21 @@ float df(vec2 p) {
   // chrysanthemum geometry slowly opening/closing — classic DMT-aesthetic move.
   // Amplitude tiny (~0.05 rad ≈ 3°), phase from morph_phase + per-petal offset (golden-ratio
   // step to avoid resonance), so each petal moves independently.
-  // NEW dimensions (subtle, quietGate-protected so they don't blow up in quiet):
-  // SKEW → petals LEAN: an extra rotational offset that tilts the whole flower one way.
-  float petalLean = (spectralSkewNormalized - 0.5) * 0.5 * quietGate;
+  // NEW dimensions (subtle, quietGate-protected so they don't blow up in quiet).
+  // IMPORTANT: skew does NOT rotate the petals (that made them rock BACK when skew slid down).
+  // Instead SKEW stretches the petal SHAPE asymmetrically — a lean you can see, but no spin-back.
   // KURTOSIS → FOCUS vs DIFFUSE: pulls petals inward (focused star) or pushes out (open flower).
   float petalFocus = 1.0 + (spectralKurtosisNormalized - 0.5) * 0.22 * quietGate;
+  float skewStretch = (spectralSkewNormalized - 0.5) * 0.18 * quietGate;   // asymmetric SHAPE, not rotation
   for (int i = 0; i < rep; ++i) {
     vec2 ip = p;
     float petalI = float(i);
-    float petalBreath = 0.05 * sin(morph_phase * 0.7 + petalI * 2.39996);  // golden-angle phase
-    rot(ip, petalI * TAU/float(rep) + TWIST + petalBreath + petalLean);     // SKEW leans the flower
-    ip -= vec2(offc*size*petalFocus, 0.0);                                  // KURTOSIS focuses/diffuses
+    float petalBreath = 0.05 * sin(morph_phase * 0.7 + petalI * 2.39996);  // golden-angle phase (a slow oscillation — intentional)
+    rot(ip, petalI * TAU/float(rep) + TWIST + petalBreath);                // only static knob TWIST + the breath; NO audio rotation
+    ip -= vec2(offc*size*petalFocus, 0.0);                                 // KURTOSIS focuses/diffuses
+    ip.y += ip.x * skewStretch;                                            // SKEW shears the petal shape (leans, never spins back)
     vec2 cp = ip;
-    rot(ip, spin_angle);                         // continuous monotonic spin
+    rot(ip, spin_angle);                         // the ONLY continuous rotation — monotonic
     float dd = dodec(vec3(ip, off*size));
     float cd = length(cp - vec2(0.2*sin(morph_phase*0.7), 0.0)) - 0.125*size;
     cd = abs(cd) - width*0.5;

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -147,7 +147,10 @@ uniform float spectralRolloffNormalized;    // high-freq cutoff → outer reach
 
 // PITCH FAMILY → COLOR. melody + brightness set the palette + SUB_LEAN (bass↔treble tilt);
 // GATED by loudness so quiet noise can't flash the hue (offset fades to 0 when quiet).
-#define MASTER_HUE  (knob_2 * 6.28318 + (melodyFlow * 0.8 + waveletCentroidSpring * 0.4) * MOD_HUE * quietGate + SUB_LEAN)
+// Like iris/7, MASTER_HUE is primarily the knob_2 palette rotation. Audio only GENTLY tints it
+// (small coefficients) so the color stays inside iris/7's tuned Oklab journey instead of swinging
+// into harsh RGB primaries (the "cheap" look). melodyFlow gives a subtle melodic drift, no more.
+#define MASTER_HUE  (knob_2 * 6.28318 + (melodyFlow - 0.5) * 0.5 * MOD_HUE * quietGate + SUB_LEAN)
 
 // LEVEL FAMILY → SIZE / DEPTH / THICKNESS. Band energies set how BIG/BOLD/DEEP, by region.
 #define LINE_THICK  (width * (5.0 + energy_env * 5.0) * (0.4 + knob_18 * 1.6))            // loudness = line weight
@@ -399,7 +402,9 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   float t = 0.05 * fiber
           + 0.55 * irisR
           + 0.20 * hue_phase / TAU                   // monotonic palette drift
-          + (knob_2 - 0.5)                           // hue base
+          // (removed `+ (knob_2 - 0.5)` — that shoved the palette zone off iris/7's tuned
+          //  warm-gold↔green↔teal↔violet journey into harsh zones. knob_2 rotates the FINAL
+          //  hue via MASTER_HUE instead, like iris/7 — keeps the refined palette intact.)
           // iter63 OF THE TREES PREP — HAUNTED SHIMMER: amplitude quadratic in entropy.
           // Calm passages (entropy_env<0.5) keep the iter19 amount; eerie/chaotic passages
           // (Ghoul-type tracks at entropy_env>0.7) get up to 2x the iris-fiber hue jitter.

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -1,5 +1,5 @@
 // @fullscreen: true
-//https://visuals.beadfamous.com/?shader=claude/wip/iris/wavelet&wavelet=true&controller=wavelet-ease&fullscreen=true&knob_1=0.45&knob_2=0.1&knob_4=1.0&knob_5=0.4&knob_7=0.66&knob_8=1&knob_11=1&knob_17=0.7&knob_18=0.8
+//https://visuals.beadfamous.com/?shader=claude/wip/iris/wavelet&wavelet=true&controller=wavelet-ease&fullscreen=true&knob_1=0.45&knob_2=0.1&knob_4=1.0&knob_5=0.2&knob_7=0.66&knob_8=1&knob_11=1&knob_17=0.7&knob_18=0.8&knob_20=0.6&knob_21=0.7&knob_22=0.6&knob_23=0.6&knob_24=0.6&knob_25=0.6&knob_26=1.0&knob_27=0.4
 // @mobile: false
 // License: CC0
 //  iris/7 driven by the WAVELET + SPECTRAL features (forked from iris/7, swapping the
@@ -48,10 +48,35 @@ uniform float waveletBassZScore;       // self-calibrating bass spike — kick z
 // drive fast spin / hue flashing — at low energy these fall back to their gentle base rate.
 // STRICTLY MONOTONIC: audio modulates the RATE (inside the iTime multiplier), never adds to
 // the angle — so these only ever move FORWARD, faster on louder/bassier audio, never back.
-#define spin_angle   (iTime * (0.04 + knob_5 * 0.12 + waveletBassSpring * 0.12 * quietGate))
-#define morph_phase  (iTime * (0.035 + waveletBand3Spring * 0.10 * quietGate))
+// SPIN SPEED is now fully knob-controlled: knob_5 sets base spin (0 = nearly still), knob_20
+// sets how much the BASS speeds it up. Base rate cut way down — at knob_5=0 it barely drifts.
+#define spin_angle   (iTime * (knob_5 * 0.10 + waveletBassSpring * 0.10 * MOD_SPIN_AUDIO * quietGate))
+#define morph_phase  (iTime * (0.02 + waveletBand3Spring * 0.10 * quietGate))
 #define flow_phase   (iTime * (0.06 + energySpring * 0.15 * quietGate))
 #define hue_phase    (iTime * (0.04 + tonalStrength * 0.10 * quietGate))
+
+// ════════════════════════════════════════════════════════════════════════════════════════
+//  LIVE MODULATION KNOBS — dial each audio effect's DEPTH (0 = off, 1 = full). Map these to
+//  MIDI or set in the URL. Defaults below give the current look; turn any to 0 to disable it.
+//    knob_5  = SPIN base speed       (0 = nearly still)        ← slow the spin here
+//    knob_20 = how much BASS speeds the spin
+//    knob_21 = MELODY → hue amount
+//    knob_22 = SKEW → petal lean (shape shear)
+//    knob_23 = KURTOSIS → focus/diffuse
+//    knob_24 = SPREAD → ring spacing
+//    knob_25 = ROLLOFF → outer reach
+//    knob_26 = energy/band level reactivity (size/depth breathing)
+//    knob_27 = TILT → hue sub-lean
+// Each knob is a 0→1 depth: 0 = that effect OFF, 1 = full. The preset URL sets good starting
+// values; turn any knob down live to calm that effect, up to intensify it. Direct + simple.
+#define MOD_SPIN_AUDIO  (knob_20)
+#define MOD_HUE         (knob_21)
+#define MOD_SKEW        (knob_22)
+#define MOD_KURT        (knob_23)
+#define MOD_SPREAD      (knob_24)
+#define MOD_REACH       (knob_25)
+#define MOD_LEVEL       (knob_26)
+#define MOD_TILT        (knob_27)
 
 // LEVELS — map our smooth wavelet/spectral features onto iris's reactive envelopes.
 #define bass_env     (waveletBassSpring)                  // core thickness / bass reactivity
@@ -111,19 +136,19 @@ uniform float spectralRolloffNormalized;    // high-freq cutoff → outer reach
 
 // PITCH FAMILY → COLOR. melody + brightness set the palette + SUB_LEAN (bass↔treble tilt);
 // GATED by loudness so quiet noise can't flash the hue (offset fades to 0 when quiet).
-#define MASTER_HUE  (knob_2 * 6.28318 + (melodyFlow * 0.8 + waveletCentroidSpring * 0.4) * quietGate + SUB_LEAN)
+#define MASTER_HUE  (knob_2 * 6.28318 + (melodyFlow * 0.8 + waveletCentroidSpring * 0.4) * MOD_HUE * quietGate + SUB_LEAN)
 
 // LEVEL FAMILY → SIZE / DEPTH / THICKNESS. Band energies set how BIG/BOLD/DEEP, by region.
 #define LINE_THICK  (width * (5.0 + energy_env * 5.0) * (0.4 + knob_18 * 1.6))            // loudness = line weight
-#define size  (baseSize * mix(0.55, 1.10, knob_7) * (1.0 + waveletBand2Spring * 0.18))   // mid energy = facet size
-#define offc  (baseOffc * mix(0.70, 1.45, knob_8) * (1.0 + waveletBand5Spring * 0.15))   // treble energy = arm spread
-#define DEPTH (mix(0.18, 0.50, knob_17) + waveletBassSpring * 0.14)                       // bass energy = core depth
+#define size  (baseSize * mix(0.55, 1.10, knob_7) * (1.0 + waveletBand2Spring * 0.18 * MOD_LEVEL))   // mid energy = facet size
+#define offc  (baseOffc * mix(0.70, 1.45, knob_8) * (1.0 + waveletBand5Spring * 0.15 * MOD_LEVEL))   // treble energy = arm spread
+#define DEPTH (mix(0.18, 0.50, knob_17) + waveletBassSpring * 0.14 * MOD_LEVEL)                       // bass energy = core depth
 
 // TEXTURE FAMILY → DETAIL / SPARKLE / EDGE. Transients/grit set fine structure (below + IRIDESCENCE/EDGE_GLOW).
 // SHAPE FAMILY (NEW): spectral SPREAD/ROLLOFF → ring spacing & outer reach (how wide the spectrum = how far the structure spreads).
-#define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 8.0 + spectralRoughnessSmooth * 6.0 + (spectralSpreadNormalized - 0.5) * 8.0 * quietGate) // spread = ring spacing
-#define RING_REACH  (1.0 + (spectralRolloffNormalized - 0.5) * 0.18 * quietGate)  // rolloff = how far the iris reaches outward
-#define SUB_LEAN    ((waveletTiltNormalized - 0.5) * 0.25 * quietGate)            // bass↔treble lean tints the hue (small — tilt is the jitteriest of the new set, 0.075/frame)
+#define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 8.0 + spectralRoughnessSmooth * 6.0 + (spectralSpreadNormalized - 0.5) * 8.0 * MOD_SPREAD * quietGate) // spread = ring spacing
+#define RING_REACH  (1.0 + (spectralRolloffNormalized - 0.5) * 0.18 * MOD_REACH * quietGate)  // rolloff = how far the iris reaches outward
+#define SUB_LEAN    ((waveletTiltNormalized - 0.5) * 0.25 * MOD_TILT * quietGate)            // bass↔treble lean tints the hue
 #define TWIST (knob_10 * 3.14159 + ZOOM_DEEP * 1.6)  // STATIC twist (knob only) — NO audio, so the petals never rock back. Audio drives SHAPE, not this rotation.
 #define BASS_REACT (0.8 + knob_11 * 1.4)
 
@@ -180,8 +205,8 @@ float df(vec2 p) {
   // IMPORTANT: skew does NOT rotate the petals (that made them rock BACK when skew slid down).
   // Instead SKEW stretches the petal SHAPE asymmetrically — a lean you can see, but no spin-back.
   // KURTOSIS → FOCUS vs DIFFUSE: pulls petals inward (focused star) or pushes out (open flower).
-  float petalFocus = 1.0 + (spectralKurtosisNormalized - 0.5) * 0.22 * quietGate;
-  float skewStretch = (spectralSkewNormalized - 0.5) * 0.18 * quietGate;   // asymmetric SHAPE, not rotation
+  float petalFocus = 1.0 + (spectralKurtosisNormalized - 0.5) * 0.22 * MOD_KURT * quietGate;
+  float skewStretch = (spectralSkewNormalized - 0.5) * 0.18 * MOD_SKEW * quietGate;   // asymmetric SHAPE, not rotation
   for (int i = 0; i < rep; ++i) {
     vec2 ip = p;
     float petalI = float(i);

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -50,10 +50,15 @@ uniform float waveletBassZScore;       // self-calibrating bass spike — kick z
 // the angle — so these only ever move FORWARD, faster on louder/bassier audio, never back.
 // SPIN SPEED is now fully knob-controlled: knob_5 sets base spin (0 = nearly still), knob_20
 // sets how much the BASS speeds it up. Base rate cut way down — at knob_5=0 it barely drifts.
-#define spin_angle   (iTime * (knob_5 * 0.10 + waveletBassSpring * 0.10 * MOD_SPIN_AUDIO * quietGate))
-#define morph_phase  (iTime * (0.02 + waveletBand3Spring * 0.10 * quietGate))
-#define flow_phase   (iTime * (0.06 + energySpring * 0.15 * quietGate))
-#define hue_phase    (iTime * (0.04 + tonalStrength * 0.10 * quietGate))
+// PHASES come from the controller as MONOTONIC ACCUMULATORS (phase += rate*dt). This avoids
+// the iTime*rate ACCELERATION bug: with iTime*rate, any change in rate jumps the angle by
+// iTime*Δrate, and that jump grows as iTime grows → the spin speeds up over time. Accumulated
+// phases never do that — the bass-speedup is baked into the accumulator's RATE in the
+// controller, so here we only scale by the STATIC knob (a constant factor can't accelerate).
+#define spin_angle   (spinPhase * knob_5 * 2.0)
+#define morph_phase  (morphPhase)
+#define flow_phase   (flowPhase)
+#define hue_phase    (huePhase)
 
 // ════════════════════════════════════════════════════════════════════════════════════════
 //  LIVE MODULATION KNOBS — dial each audio effect's DEPTH (0 = off, 1 = full). Map these to
@@ -106,6 +111,10 @@ uniform float spectralCrestSmooth;      // smoothed spectral crest (was jittery 
 uniform float spectralRoughnessSmooth;  // smoothed spectral roughness (was jittery raw)
 uniform float spectralEntropySmooth;    // smoothed spectral entropy (was jittery raw)
 uniform float quietGate;                // 0 in quiet → 1 loud; gates audio offsets (no quiet-noise flashing)
+uniform float spinPhase;                // monotonic spin accumulator (rate*dt — no iTime*rate acceleration)
+uniform float morphPhase;               // monotonic morph accumulator
+uniform float flowPhase;                // monotonic flow accumulator
+uniform float huePhase;                 // monotonic hue accumulator
 // NEW fractal-complexity dimensions — measured lively AND smooth on melodic audio (jit<0.06):
 uniform float spectralSkewNormalized;       // spectral tilt/asymmetry → petal lean
 uniform float spectralKurtosisNormalized;   // peakedness → focus vs diffuse petals

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -37,7 +37,7 @@ uniform float wubDepth;                // dubstep wobble intensity
 uniform float melodyFlow;              // flowing melody/pitch contour
 uniform float wavelet_bassHit;         // sharp kick/drop trigger — drives the zoom punch
 uniform float waveletBassZScore;       // self-calibrating bass spike — kick zoom (works at any gain)
-// spectralCrestNormalized, spectralRoughnessNormalized, spectralEntropyNormalized,
+// spectralCrestSmooth, spectralRoughnessSmooth, spectralEntropyNormalized,
 // spectralFluxZScore are FFT features — auto-declared by the wrapper.
 
 // MOTION phases — monotonic from iTime (the controller did this in JS; iTime is monotonic).
@@ -56,12 +56,15 @@ uniform float waveletBassZScore;       // self-calibrating bass spike — kick z
 #define mids_env     (waveletBand2Spring)                 // arms — vocal/instrument body
 #define treble_env   (waveletBand5Spring)                 // tips — horn air / sibilance
 #define energy_env   (energySpring)                       // overall edge glow / line weight
-#define entropy_env  (clamp(spectralEntropyNormalized, 0.0, 1.0)) // iridescence — tonal vs noisy
+// entropy_env was spectralEntropyNormalized — raw & JITTERY (jumped 0.17/frame, 20x the others)
+// and it drives IRIDESCENCE, so it made the shimmer SHIVER. Use smooth tonalStrength instead
+// (also "tonal vs noisy", but eased) so iridescence breathes smoothly.
+#define entropy_env  (clamp(1.0 - tonalStrength, 0.0, 1.0)) // low tonal = high "entropy" (noisy), smooth
 #define centroid_env (waveletCentroidSpring)              // brightness
 #define bass_pump    (clamp(wubDepth + waveletBassSpring * 0.5, 0.0, 1.0)) // FAST punch + wub
 // drop_glow & pitch_pulse SMOOTHED (not raw z-scores) so the iris breathes, doesn't strobe:
-#define drop_glow    (clamp(energySpring * 0.5 + spectralCrestNormalized * 0.4 + knob_6, 0.0, 1.0))
-#define pitch_pulse  (clamp(spectralCrestNormalized * 0.6 + tonalStrength * 0.4, 0.0, 1.0))
+#define drop_glow    (clamp(energySpring * 0.5 + spectralCrestSmooth * 0.4 + knob_6, 0.0, 1.0))
+#define pitch_pulse  (clamp(spectralCrestSmooth * 0.6 + tonalStrength * 0.4, 0.0, 1.0))
 
 // ── MANY-FEATURE MODULATION ──────────────────────────────────────────────────────────────
 // Spread reactivity across the WHOLE iris: each shape/color constant is a knob BASE plus a
@@ -70,6 +73,9 @@ uniform float waveletBassZScore;       // self-calibrating bass spike — kick z
 uniform float tonalStrength;            // how melodic vs noisy (from wavelet-ease)
 uniform float waveletBand4Spring;       // high-mid
 uniform float waveletBand1Spring;       // low-bass
+uniform float spectralCrestSmooth;      // smoothed spectral crest (was jittery raw)
+uniform float spectralRoughnessSmooth;  // smoothed spectral roughness (was jittery raw)
+uniform float spectralEntropySmooth;    // smoothed spectral entropy (was jittery raw)
 
 // === Knobs ===
 // knob_1 ZOOM: 0=zoomed-out flat, 1=plunged deep into the fractal tunnel.
@@ -81,31 +87,40 @@ uniform float waveletBand1Spring;       // low-bass
 // spring features already ride the self-calibrating Normalized variants (so they sit ~0-1
 // on both mic AND direct-in), so reactivity is consistent across environments — these
 // gains just set how much that 0-1 swing moves the geometry.
+// ── COHERENT MAPPING: SIMILAR AUDIO FEATURES → SIMILAR FRACTAL FEATURES ──────────────────
+// Three families, each driving one coherent aspect of the iris:
+//   PITCH family  (melody, centroid)  → COLOR + angular position (pitch is circular = hue wheel)
+//   LEVEL family  (bass/mids/treble/energy) → SIZE / DEPTH / THICKNESS (more energy = bigger/bolder)
+//   TEXTURE family (flux/crest/roughness/wub) → DETAIL / SPARKLE / EDGE (sharp sound = sharp detail)
+// This keeps related sounds moving related parts together, instead of one feature scattered
+// across unrelated aspects.
+
 #define ZOOM_K      (knob_1)
-#define ZOOM        (0.35 + ZOOM_K * 2.65 + energySpring * 0.2)        // loudness pushes you in (gentler)
+// ZOOM ← LEVEL (loudness): louder pushes the camera in.
+#define ZOOM        (0.35 + ZOOM_K * 2.65 + energySpring * 0.2)
 #define ZOOM_DEEP   (ZOOM_K * ZOOM_K)
-// FLUTE/MELODIC tailoring: this audio is all gliding melody, so the MELODY drives the
-// fractal SHAPE — facet size, arm spread, ripple density, core depth all morph with the
-// pitch slide (these are non-rotational, so going up/down with the melody is GOOD — the
-// fractal flowers/contracts with the line). Hue still sweeps with melody (color, not spin).
-// Rotation phases stay monotonic (rate-modulated), so NOTHING rotates back. Bass zoom kept.
-#define MASTER_HUE  (knob_2 * 6.28318 + melodyFlow * 0.8)             // MELODY gently tints the palette (small sweep — no full-cycle color flash)
-#define LINE_THICK  (width * (5.0 + energy_env * 5.0) * (0.4 + knob_18 * 1.6))
-#define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 10.0 + melodyFlow * 14.0) // MELODY rings the iris
-// fractal exploration — MELODY drives these hard (this is melodic audio):
-#define size  (baseSize * mix(0.55, 1.10, knob_7) * (1.0 + waveletBand2Spring * 0.10 + (melodyFlow - 0.5) * 0.30)) // melody flowers the facets
-#define offc  (baseOffc * mix(0.70, 1.45, knob_8) * (1.0 + waveletBand5Spring * 0.08 + (melodyFlow - 0.5) * 0.25)) // melody spreads/closes the arms
-#define DEPTH (mix(0.18, 0.50, knob_17) + waveletBand1Spring * 0.07 + (melodyFlow - 0.5) * 0.16)  // melody breathes the core depth
+
+// PITCH FAMILY → COLOR. melody + brightness set the palette position; nothing else.
+#define MASTER_HUE  (knob_2 * 6.28318 + melodyFlow * 0.8 + waveletCentroidSpring * 0.4)  // pitch & brightness tint the palette
+
+// LEVEL FAMILY → SIZE / DEPTH / THICKNESS. Band energies set how BIG/BOLD/DEEP, by region.
+#define LINE_THICK  (width * (5.0 + energy_env * 5.0) * (0.4 + knob_18 * 1.6))            // loudness = line weight
+#define size  (baseSize * mix(0.55, 1.10, knob_7) * (1.0 + waveletBand2Spring * 0.18))   // mid energy = facet size
+#define offc  (baseOffc * mix(0.70, 1.45, knob_8) * (1.0 + waveletBand5Spring * 0.15))   // treble energy = arm spread
+#define DEPTH (mix(0.18, 0.50, knob_17) + waveletBassSpring * 0.14)                       // bass energy = core depth
+
+// TEXTURE FAMILY → DETAIL / SPARKLE / EDGE. Transients/grit set fine structure (below + IRIDESCENCE/EDGE_GLOW).
+#define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 8.0 + spectralRoughnessSmooth * 6.0) // grit = ring detail
 #define TWIST (knob_10 * 3.14159 + ZOOM_DEEP * 1.6 + tonalStrength * 0.5)  // static twist; melody drives SHAPE (above), not rotation — no rocking back
 #define BASS_REACT (0.8 + knob_11 * 1.4)
 
-// brightness (smoothed levels — never flicker)
-#define IRIDESCENCE (0.7 + 0.6 * entropy_env + spectralRoughnessNormalized * 0.3) // grit adds shimmer
-#define EDGE_GLOW   (0.9 + 0.4 * energy_env + waveletCentroidSpring * 0.3 + spectralCrestNormalized * 0.35) // flute articulation glints the edges
+// TEXTURE FAMILY → SHIMMER / SPARKLE (continued). Grit & articulation drive the fine glints.
+#define IRIDESCENCE (0.7 + 0.6 * entropy_env + spectralRoughnessSmooth * 0.3) // grit adds shimmer
+#define EDGE_GLOW   (0.9 + 0.4 * energy_env + spectralCrestSmooth * 0.4)       // articulation glints the edges
 
-// plasma palette — Oklch hue in radians; centroid warms the core, crest cools the corona
+// PITCH FAMILY → COLOR (continued). Brightness/crest set the core & corona hues.
 #define CORE_HUE   (0.6 + waveletCentroidSpring * 0.8)
-#define CORONA_HUE (4.2 - spectralCrestNormalized * 0.6)
+#define CORONA_HUE (4.2 - spectralCrestSmooth * 0.6)
 
 const vec3 plnormal = normalize(vec3(1, 1, -1));
 const vec3 n1 = normalize(vec3(-PHI,PHI-1.0,1.0));
@@ -224,7 +239,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   // iter79 PLASMA-SOFT EDGES: widen the edge anti-alias and modulate with roughness.
   // Plasma's signature is glowing softness, not sharp lines. Was 0.0025 (razor); now
   // 0.0065 baseline + roughness expands it further on dissonant passages.
-  float fuzzy = 0.0065 + 0.012 * spectralRoughnessNormalized;
+  float fuzzy = 0.0065 + 0.012 * spectralRoughnessSmooth;
   float edges = smoothstep(fuzzy, -fuzzy, d);
   vec3 rgb = 0.5 + 0.5*vec3(sin(TAU*vec3(50.0, 49.0, 48.0)*(d - 0.050) + flow_phase*0.6));
   float bands = pow(clamp(dot(rgb, vec3(0.34)), 0.0, 1.0), 8.0);
@@ -460,7 +475,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
                     + max(bassZScore, 0.0) * 0.5
                     + dropLift * 0.4
                     + clamp(spectralFluxZScore, 0.0, 1.0) * 0.35
-                    + spectralRoughnessNormalized * 0.25;
+                    + spectralRoughnessSmooth * 0.25;
   float rimAmp      = mix(0.0, 0.55, knob_49) * rimPulse;
   float rimHue      = mix(CORE_HUE, CORONA_HUE, 0.85) + (knob_46 - 0.5) * 1.2
                     + pitchClassNormalized * 0.5;                   // pitch tints rim hue
@@ -495,11 +510,11 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
       else if (slot ==  4) audioL = spectralEntropyNormalized;
       else if (slot ==  5) audioL = spectralCentroidNormalized;
       else if (slot ==  6) audioL = pitchClassNormalized;
-      else if (slot ==  7) audioL = spectralRoughnessNormalized;
+      else if (slot ==  7) audioL = spectralRoughnessSmooth;
       else if (slot ==  8) audioL = spectralSpreadNormalized;
       else if (slot ==  9) audioL = spectralKurtosisNormalized;
       else if (slot == 10) audioL = clamp(spectralSkewZScore*0.5+0.5, 0.0, 1.0);
-      else if (slot == 11) audioL = spectralCrestNormalized;
+      else if (slot == 11) audioL = spectralCrestSmooth;
       else if (slot == 12) audioL = spectralRolloffNormalized;
       else if (slot == 13) audioL = clamp(energyZScore*0.5+0.5, 0.0, 1.0);
       else                 audioL = clamp(bassZScore*0.5+0.5, 0.0, 1.0);
@@ -566,7 +581,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
              + bass_pump * BASS_REACT * 0.020
              + drop_glow * 0.030
              + clamp(spectralFluxZScore, 0.0, 1.0) * 0.025
-             + spectralRoughnessNormalized * 0.018;
+             + spectralRoughnessSmooth * 0.018;
   float zoomF = 1.0 - rush;                              // <1 = prior frame zooms outward
   float mrot = 0.015 + ZOOM_DEEP * 0.035 + drop_glow * 0.020;  // drop also adds swirl
   vec2 ruv = q - CEN;
@@ -590,11 +605,11 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   // Reads as the eye "reacting" without anything moving. iter33: ALSO pulses on flux events
   // (dialogue / foley / cuts) so movie audio drives a visible eye reaction even when bass
   // isn't kicking. The two terms cover music + movie audio independently.
-  // iter79 add spectralCrestNormalized (peakiness) — spiky audio = sharper glint.
+  // iter79 add spectralCrestSmooth (peakiness) — spiky audio = sharper glint.
   float catchPulse = 1.0
                    + bass_pump * BASS_REACT * 0.6
                    + clamp(spectralFluxZScore, 0.0, 1.0) * 0.8
-                   + spectralCrestNormalized * 0.45;
+                   + spectralCrestSmooth * 0.45;
   // iter53: knob_36 catchlight intensity master — user pinned at ~0.6, give them control.
   float catchlight = (1.0 - smoothstep(0.008, 0.022, catchD)) * knob_19 * onEye * catchPulse * mix(0.4, 1.8, knob_36);
   col += vec3(0.85, 0.88, 0.95) * catchlight;                   // bright cool-white specular

--- a/shaders/claude/wip/iris/wavelet.frag
+++ b/shaders/claude/wip/iris/wavelet.frag
@@ -36,6 +36,7 @@ uniform float energySpring;            // loudness
 uniform float wubDepth;                // dubstep wobble intensity
 uniform float melodyFlow;              // flowing melody/pitch contour
 uniform float wavelet_bassHit;         // sharp kick/drop trigger — drives the zoom punch
+uniform float waveletBassZScore;       // self-calibrating bass spike — kick zoom (works at any gain)
 // spectralCrestNormalized, spectralRoughnessNormalized, spectralEntropyNormalized,
 // spectralFluxZScore are FFT features — auto-declared by the wrapper.
 
@@ -71,17 +72,22 @@ uniform float waveletBand1Spring;       // low-bass
 // Compounds detail on the way in (more ripple density + sub-layer + deeper twist).
 // Every constant below = knob BASE + a gentle offset from a DISTINCT feature, so the iris
 // reacts across its whole structure to many parts of the music at once (not one flashy thing).
+// ENVIRONMENT-ROBUST: the audio offsets below are tuned to ~half their old amount so the
+// full-range direct-in signal produces the same gentle motion the quiet mic did. The
+// spring features already ride the self-calibrating Normalized variants (so they sit ~0-1
+// on both mic AND direct-in), so reactivity is consistent across environments — these
+// gains just set how much that 0-1 swing moves the geometry.
 #define ZOOM_K      (knob_1)
-#define ZOOM        (0.35 + ZOOM_K * 2.65 + energySpring * 0.4)        // loudness pushes you in
+#define ZOOM        (0.35 + ZOOM_K * 2.65 + energySpring * 0.2)        // loudness pushes you in (gentler)
 #define ZOOM_DEEP   (ZOOM_K * ZOOM_K)
 #define MASTER_HUE  (knob_2 * 6.28318 + melodyFlow * 1.6)             // MELODY shifts the master hue
 #define LINE_THICK  (width * (5.0 + energy_env * 5.0) * (0.4 + knob_18 * 1.6))
-#define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 20.0) // high-mid = ring density
+#define RIPPLE_FREQ (10.0 + knob_13 * 16.0 + ZOOM_DEEP * 32.0 + waveletBand4Spring * 10.0) // high-mid = ring density (gentler)
 // fractal exploration:
-#define size  (baseSize * mix(0.55, 1.10, knob_7) * (1.0 + waveletBand2Spring * 0.18)) // mids breathe facet size
-#define offc  (baseOffc * mix(0.70, 1.45, knob_8) * (1.0 + waveletBand5Spring * 0.15)) // treble spreads the arms
-#define DEPTH (mix(0.18, 0.50, knob_17) + waveletBand1Spring * 0.12)  // low-bass deepens the core
-#define TWIST (knob_10 * 3.14159 + ZOOM_DEEP * 1.6 + tonalStrength * 0.8)  // tonal-ness curls the spiral
+#define size  (baseSize * mix(0.55, 1.10, knob_7) * (1.0 + waveletBand2Spring * 0.10)) // mids breathe facet size (gentler)
+#define offc  (baseOffc * mix(0.70, 1.45, knob_8) * (1.0 + waveletBand5Spring * 0.08)) // treble spreads the arms (gentler)
+#define DEPTH (mix(0.18, 0.50, knob_17) + waveletBand1Spring * 0.07)  // low-bass deepens the core (gentler)
+#define TWIST (knob_10 * 3.14159 + ZOOM_DEEP * 1.6 + tonalStrength * 0.5)  // tonal-ness curls the spiral (gentler)
 #define BASS_REACT (0.8 + knob_11 * 1.4)
 
 // brightness (smoothed levels — never flicker)
@@ -188,8 +194,14 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   p.x *= iResolution.x/iResolution.y;
   // KICK = ZOOM (not a color flash). The kick punches the camera IN, then it springs back.
   // Uses the smooth bass_pump (no one-frame strobe) + a touch of the sharp hit for snap.
-  float kickZoom = bass_pump * BASS_REACT * 0.22 + clamp(wavelet_bassHit, 0.0, 1.0) * 0.08;
-  p *= ZOOM * (1.0 - kickZoom);                        // sub/kick hits push the camera in
+  // SLIGHT zoom on the WAVELET BEAT. waveletBassZScore is the self-calibrating bass-spike —
+  // it fires on the beat at ANY input gain (mic OR direct-in), so the pulse is consistent
+  // across environments. Kept slight (max ~8% push-in) + a little raw hit/pump when present.
+  float waveletBeat = clamp(max(waveletBassZScore, 0.0), 0.0, 1.0);   // the beat, self-calibrating
+  float kickZoom = clamp(waveletBeat * 0.07
+                       + bass_pump * BASS_REACT * 0.05
+                       + clamp(wavelet_bassHit, 0.0, 1.0) * 0.04, 0.0, 0.12);
+  p *= ZOOM * (1.0 - kickZoom);                        // beat pushes the camera slightly in
   float d = df(p);
   // ZOOM-DEEP SUB-LAYER — compound nested fractal: a second pass at half scale, rotated,
   // blended in by ZOOM_DEEP. As knob_1 climbs, more recursion levels accumulate.

--- a/src/shader-transformers/shader-wrapper.js
+++ b/src/shader-transformers/shader-wrapper.js
@@ -55,7 +55,7 @@ export const shaderWrapper = (shader) => {
     }
     if (shader.includes('mainImage')) {
         const compatUniforms = shaderToyCompatibilityUniforms()
-        const audioUniforms = getAudioUniforms()
+        const audioUniforms = getAudioUniforms(shader)
         const knobUniforms = getKnobUniforms(shader)
         const pcUniforms = paperCranes()
         const otherUniforms = compatUniforms + audioUniforms + knobUniforms + pcUniforms
@@ -97,9 +97,24 @@ uniform sampler2D iChannel2;
 uniform sampler2D iChannel3;
 uniform int iFrame;
 `
-const getAudioUniforms = () => {
-    return [...Object.keys(getFlatAudioFeatures()), 'beat']
+// Wavelet (DWT) features published by WaveletProcessor when ?wavelet=true. They aren't in
+// hypnosound's AudioFeatures list, so they must be enumerated here to auto-declare as uniforms
+// just like the FFT features — otherwise every wavelet shader has to declare them by hand.
+const STAT_SUFFIXES = ['', 'Normalized', 'Mean', 'Median', 'Min', 'Max', 'StandardDeviation', 'ZScore', 'Slope', 'Intercept', 'RSquared']
+const WAVELET_BASES = ['waveletBand0', 'waveletBand1', 'waveletBand2', 'waveletBand3', 'waveletBand4', 'waveletBand5', 'waveletBass', 'waveletTilt', 'waveletCentroid', 'waveletSpread']
+const getWaveletUniforms = () => {
+    const stat = WAVELET_BASES.flatMap(base => STAT_SUFFIXES.map(s => `${base}${s}`))
+    const trigger = ['wavelet_bassHit', 'wavelet_bassHitSmooth', 'wavelet_punch', 'wavelet_confirmedDrop']
+    return [...stat, ...trigger]
+}
+
+const getAudioUniforms = (shader = '') => {
+    // Skip any uniform the shader already declares itself, so explicit declarations (common
+    // in wavelet shaders written before these auto-declared) don't cause a redefinition error.
+    const code = shader.replace(/\s+/g, ' ')
+    return [...Object.keys(getFlatAudioFeatures()), ...getWaveletUniforms(), 'beat']
         .sort()
+        .filter(f => !code.includes(`uniform float ${f};`) && !code.includes(`uniform bool ${f};`))
         .map(f => `uniform ${f === 'beat' ? 'bool' : 'float'} ${f};`)
         .join('\n')
 }


### PR DESCRIPTION
Brings the wavelet (DWT) work onto `main`. The WaveletProcessor audio pipeline already landed on main; this adds the missing piece so shaders can actually use it.

## What's in here
- **Auto-declare wavelet uniforms** in `src/shader-transformers/shader-wrapper.js` — `waveletBand0..5`, `waveletBass`, `waveletTilt`, `waveletCentroid`, `waveletSpread` (each with all stat suffixes) plus triggers (`wavelet_bassHit`, `wavelet_bassHitSmooth`, `wavelet_punch`, `wavelet_confirmedDrop`). Published when `?wavelet=true`. Dedupes against hand-declared uniforms so older wavelet shaders don't hit redefinition errors.
- **`iris/wavelet.frag` polish** — monotonic rotation (no rocking back), quiet-passage hue-flash gate, fixed spin acceleration, tuned Oklab palette journey cribbed from iris/7, 4 new smooth feature dimensions.
- **`controllers/wavelet-ease.js`** updates — spring-smoothed animation features + wub detection.

Fast-forward of `main` (main is 0 commits ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)