### PR TITLE
Tab audio: fall back to mic when browser can't capture tab audio

### DIFF
--- a/docs/tab-audio.md
+++ b/docs/tab-audio.md
@@ -33,10 +33,19 @@ If the user clicks "Stop sharing" in the browser chrome, the system automaticall
 |---------|-----------|-------|
 | Chrome | Yes | Full support |
 | Edge | Yes | Full support (Chromium-based) |
-| Firefox | No | `getDisplayMedia` doesn't expose audio tracks |
-| Safari | No | `getDisplayMedia` doesn't expose audio tracks |
+| Firefox | Falls back to mic | `getDisplayMedia` doesn't expose audio tracks |
+| Safari | Falls back to mic | `getDisplayMedia` doesn't expose audio tracks |
 
 Desktop only. Mobile browsers do not support `getDisplayMedia`.
+
+### Microphone Fallback
+
+When `?audio=tab` is requested in a browser that can't capture tab audio (Firefox,
+Safari, mobile — anywhere `getDisplayMedia` is unavailable), the system falls back
+to **microphone input** instead of leaving the visualizer silent. A warning is
+logged to the console, and the visualization reacts to whatever the mic picks up.
+This is detected up front via `isTabAudioSupported()`, so no "Share tab audio"
+overlay appears in unsupported browsers.
 
 ## vs. Virtual Audio Loopback
 

--- a/index.js
+++ b/index.js
@@ -116,39 +116,10 @@ const setupCanvasEvents = (canvas) => {
 
 const noAudio = { getFeatures: () => ({}) }
 
-const setupAudio = async () => {
-    // audio=none disables audio input (consistent with audio=tab pattern)
-    // noaudio=true and embed=true are kept for backwards compatibility
-    if (params.get('audio') === 'none' || params.get('noaudio') === 'true' || params.get('embed') === 'true') {
-        return noAudio
-    }
-
-    if (params.get('audio') === 'tab') {
-        const { setupTabAudio } = await import('./src/audio/tabAudioSource.js')
-        return setupTabAudio({ params, AudioProcessor })
-    }
-
-    const fileConfig = createAudioFileSource({ params })
-    if (fileConfig) {
-        try {
-            const audioContext = new AudioContext()
-            const { sourceNode, audioBuffer, startSource } = await initAudioFromFile({ config: fileConfig, audioContext })
-            window.cranes.audioBuffer = audioBuffer
-            window.cranes.startSource = startSource
-
-            const audioProcessor = new AudioProcessor(audioContext, sourceNode, fileConfig.historySize, fileConfig.fftSize)
-            audioProcessor.smoothingFactor = fileConfig.smoothing
-            await audioProcessor.start()
-            // Route through speakers (unlike mic input, file playback has no feedback risk)
-            audioProcessor.fftAnalyzer.connect(audioContext.destination)
-            await maybeStartWavelet(params, audioContext, sourceNode)
-            return audioProcessor
-        } catch (err) {
-            console.error('Audio file initialization failed:', err)
-            return noAudio
-        }
-    }
-
+// Mic capture path. Acquires getUserMedia, builds an AudioProcessor, and wires
+// up the optional wavelet pass. This is the default audio source and also the
+// fallback when ?audio=tab is requested in a browser that can't capture tab audio.
+const setupMicAudio = async () => {
     try {
         // get the default audio input
         const devices = await navigator.mediaDevices.enumerateDevices();
@@ -180,6 +151,49 @@ const setupAudio = async () => {
         console.error('Audio initialization failed:', err);
         return noAudio
     }
+}
+
+const setupAudio = async () => {
+    // audio=none disables audio input (consistent with audio=tab pattern)
+    // noaudio=true and embed=true are kept for backwards compatibility
+    if (params.get('audio') === 'none' || params.get('noaudio') === 'true' || params.get('embed') === 'true') {
+        return noAudio
+    }
+
+    if (params.get('audio') === 'tab') {
+        const { setupTabAudio, isTabAudioSupported } = await import('./src/audio/tabAudioSource.js')
+        // Tab audio relies on getDisplayMedia exposing audio tracks — only
+        // Chromium desktop does. Everywhere else (Firefox, Safari, mobile)
+        // fall back to the mic so the visualizer still reacts to sound.
+        if (!isTabAudioSupported()) {
+            console.warn('Tab audio capture unsupported in this browser — falling back to microphone input.')
+            return setupMicAudio()
+        }
+        return setupTabAudio({ params, AudioProcessor })
+    }
+
+    const fileConfig = createAudioFileSource({ params })
+    if (fileConfig) {
+        try {
+            const audioContext = new AudioContext()
+            const { sourceNode, audioBuffer, startSource } = await initAudioFromFile({ config: fileConfig, audioContext })
+            window.cranes.audioBuffer = audioBuffer
+            window.cranes.startSource = startSource
+
+            const audioProcessor = new AudioProcessor(audioContext, sourceNode, fileConfig.historySize, fileConfig.fftSize)
+            audioProcessor.smoothingFactor = fileConfig.smoothing
+            await audioProcessor.start()
+            // Route through speakers (unlike mic input, file playback has no feedback risk)
+            audioProcessor.fftAnalyzer.connect(audioContext.destination)
+            await maybeStartWavelet(params, audioContext, sourceNode)
+            return audioProcessor
+        } catch (err) {
+            console.error('Audio file initialization failed:', err)
+            return noAudio
+        }
+    }
+
+    return setupMicAudio()
 };
 
 // Parse URL params as numbers when possible


### PR DESCRIPTION
## Summary

When `?audio=tab` is requested in a browser that can't capture tab audio (Firefox, Safari, mobile — anywhere `getDisplayMedia` doesn't expose audio tracks), the visualizer now falls back to **microphone input** instead of leaving the visualization silent.

- Extracted the existing mic-capture logic into a reusable `setupMicAudio()` function in `index.js` (previously inlined as the default branch of `setupAudio`).
- The `audio=tab` branch now imports `isTabAudioSupported` and checks it *before* showing the "Share tab audio" overlay. If unsupported, it logs a `console.warn` and returns `setupMicAudio()`.
- Detection reuses the existing `isTabAudioSupported()` helper, so unsupported browsers never even render the share overlay — they go straight to the mic.
- Updated `docs/tab-audio.md`: browser-support table now reads "Falls back to mic" for Firefox/Safari, plus a new *Microphone Fallback* section.

This is a real capability boundary where a fallback is intentional, and it logs a warning so the substitution is visible (no silent swallow).

## Test plan

- [ ] Chrome/Edge desktop with `?audio=tab` → still shows the "Share tab audio" overlay and captures tab audio as before.
- [ ] Firefox/Safari with `?audio=tab` → no overlay; mic permission prompt appears; visualizer reacts to mic audio. Console shows the fallback warning.
- [ ] Default (no `audio` param) → mic path unchanged.
- [ ] `?audio=none` / `?noaudio=true` / `?embed=true` → still silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)