### PR TITLE
handstand/1: port the-coat effect library (chromadepth-adapted)

### DIFF
--- a/journals/handstand-1-cool-moments.md
+++ b/journals/handstand-1-cool-moments.md
@@ -1,0 +1,180 @@
+# handstand/1 — Session Journal
+
+ChromaDepth handstand portal. This `/vibej` run **evolves in effects from the the-coat series**,
+one coat motif per tick, each adapted to keep the chromadepth read intact.
+
+## Status
+RUN ENDED (iter 20). Stopped the cron — the music settled back into the bright/entropy corner and ticks were no-opping (iter 16/17/19/20 all the same covered corner; iter 18 was the one new-corner win). Shader is feature-complete + healthy and ready to /fork. To resume: `/vibej redaphid/handstand/1` when a new set is playing.
+
+### Final state — handstand/1 (chromadepth)
+9 coat motifs ported (FUR FIBERS, SIGIL SWIRL, EMBER RISE, PRISM RIM, STEP RIPPLE, WARM HEARTH, HEART PULSE,
+GROOVE BREATH, GHOST ECHO, GROUND QUAKE, SUB RING) + 6 refinements. Feature map covers every band. All
+chromadepth-clean (0% white verified throughout). User flags all handled: bass-zoom amplitude (iter9),
+no-white (hard rule), no-grey (iter10), grit-frequency (early). quietGate-floor learning generalized to all
+bass/mid-gated effects (iter15/18).
+
+## HARD RULE (user, this session)
+**No white.** This is chromadepth (red=near, green=mid, violet=far). White has no hue → kills the 3D read.
+- Figure effects feed `figLit`, then `figLit = min(figLit, 0.62)` before `chromadepth()`.
+- Never add raw white to `col`. Far-field sparks ride the violet band (t≥0.85) so they recede.
+
+## History of changes (coat ports)
+- **iter 1** — three coat effects ported to the figure interior / far-field:
+  - **FUR FIBERS** (the-coat headline) — double domain-warped `flow2` shaped into sharp ridges
+    (`pow(abs(sin(...)),3)`), flowing through the body as light-strands. Gated by spectral CHAOS
+    (entropy+roughness), warp rate driven by `spectralCentroidNormalized` (pitch-aware swirl, the coat trick).
+    Feeds `figLit` only → red→green interior holds.
+  - **SIGIL SWIRL** — radial spiral wave on the figure (`sin(angle*5 + r*14 - FLOW*1.4 + mids*3)`),
+    band-limited to the body radius. Coat used full hue; here kept brightness-only (figLit) so chromadepth holds.
+    Gated by mids + bassZScore.
+  - **EMBER RISE** — 6 deterministic sparks rising in the lower far-field on the warm-low corner
+    (mids-dominant + low centroid). Coat used amber; here recolored to the FAR violet band (t=0.88) so
+    they recede behind the dancer. Masked outside the figure, lower half.
+
+- **iter 1 (live flag)** — user: "grit outline effect should happen less frequently." Raised the RIM GRIT
+  gate from `smoothstep(0.20,0.45,entropy)` to `smoothstep(0.55,0.80,entropy) * smoothstep(0.40,0.70,roughness)`
+  — now needs BOTH high entropy and high roughness, so the fraying outline only fires on genuinely gnarly moments.
+
+- **iter 2 (live flag — KEY LEARNING)** — user: "the water-like effect lifted from the coat texture
+  washes out the inside of the handstand — colors become less vibrant, lowers the chromadepth." That was
+  FUR FIBERS (+ SIGIL SWIRL) adding to `figLit`. **Root cause: in HSL, raising L past ~0.5 desaturates
+  toward white.** Any additive-lightness effect on a saturated chromadepth figure bleaches it.
+  **Fix (the general translation rule for porting coat glows to chromadepth):** express the effect as
+  `figT -= amt` (pull toward red/near) + `figSat += amt` (MORE vibrant), with only a whisper of `figLit`.
+  Result: fibers now read as vibrant near-red depth detail that DEEPENS the 3D pop instead of bleaching it.
+  Verified 0% white with fibers active.
+
+- **iter 3** — **PRISM RIM** ported. Coat cycled a full rainbow rim by uv-angle+time; on chromadepth
+  a full rainbow rim is forbidden (a blue rim reads as FAR, contradicting "the edge pops forward").
+  So the hue cycle is clamped to `fract(...) * 0.14` — the NEAR band only (red→orange→yellow). The edge
+  shimmers prismatically while every hue still reads near. Gated by the bright corner (treble × centroid).
+  Audio when added: treb 0.85, entropy 0.92, centroid 0.76, bass 0.06 — a bright airy passage, exactly
+  the coat's intended prism-rim territory.
+
+- **iter 4** — **STEP RIPPLE** ported. Coat radiated a horizontal beat-wave from the chest (1,2-step
+  dance move). Recast here as vertical far-violet bands sweeping OUTWARD from the figure's centerline
+  through the nebula — energy rippling away into space. Gated by the bright corner (treble × centroid ×
+  energy) because the rotation kept landing in treble-dominant/no-bass passages (the bass-gated coat
+  effects DRIP/QUAKE/HEART couldn't fire). Far band + outside-figure mask → recedes, chromadepth-safe.
+  **Note for next session: this room's audio has been bass-starved (bass ~0.05) — the bass-gated coat
+  ports won't get exercised until a bassy track plays.**
+
+- **iter 5** — **WARM HEARTH** ported. Coat's mid-dominant signature: slow amber glow blooming OUTWARD
+  from the figure on warm-dark-instrumental passages. Chromadepth adaptation: kept in the NEAR red-orange
+  band (t≈0.05) so the halo reads as the figure's own warmth pushing toward the viewer — never white/blue.
+  Outward falloff built from an 8-tap mask dilation (radii 0.05 + 0.10) masked to outside the silhouette,
+  slow `sin(iTime*0.4)` breathe. Gated mids>centroid + low energy — DORMANT in the current treble passage;
+  will bloom when a warm mid-heavy track plays. Picked this over another treble effect to avoid over-
+  stacking the bright corner (already PRISM RIM + STEP RIPPLE + TREBLE SHIMMER there).
+
+- **iter 9 (live flag — FIGURE ZOOM)** — user: "I need the zoom to have more amplitude with the bass."
+  Cranked the FIGURE_ZOOM bass coefficients ~2× (swell 0.10→0.20, kick 0.20→0.40, hit 0.14→0.28, FFT
+  bassZ 0.10→0.20) and widened the clamp ranges 1.0→1.5 so strong hits push further. Base 1.22 → ~0.45
+  on a hard slam (was ~0.85). The figure now lunges much bigger toward the viewer on the kick.
+- **iter 9** — **GROUND QUAKE** ported. Coat's amber floor-rumble recast as far-VIOLET elliptical rings
+  expanding up from below the figure — deep-bass shockwave receding into the background. Gated bass ×
+  low-centroid (sub territory), masked outside figure. Dormant on the current treble passage; fires on real low-end.
+
+- **iter 10** — **SUB RING** ported (last distinct coat motif). Coat fired an expanding cone ring on
+  bass but gated it to REAL drops so it didn't drown the figure — same discipline here: gated TIGHT on
+  energyZ × bassZ (a genuine drop) so it does NOT stack with per-kick HEART PULSE / GROUND QUAKE / BASS
+  BLOOM (the bass-stacking pitfall). One clean far-violet ring from the figure base on big moments only.
+  **DRIP consciously SKIPPED:** its teardrop-from-chest overlaps HEART PULSE's pure-red core too directly,
+  and a 4th bass-radial would over-saturate drops. Coat roadmap complete: 9 motifs ported.
+
+## Cool moments
+- **iter 18 — WARM-DARK corner finally arrived + got fixed (audio: mids 0.93, centroid 0.16, treble 0.11,
+  energy 0.11, quietGate 0.00).** The music spent the whole run bass-light/bright; this was the FIRST
+  mid-dominant warm-dark passage — exactly what WARM HEARTH / MID WARMTH / EMBER RISE were built for. But
+  they were fully MUTED: quietGate read 0.00 (mids-heavy passages read mic-quiet, same under-read as the
+  iter15 solo-bass case). Floored quietGate→0.45 on both warm effects; warm near-band response jumped to
+  7.9% of frame, 0% white. **Confirmed design hypothesis: the mid-dominant warmth effects work — they just
+  needed the quietGate floor that bass effects already had. Generalize: ANY non-treble-gated figure effect
+  needs a quietGate floor, because the mic-derived quietGate only tracks broadband energy and under-reads
+  spectrally-narrow (pure bass OR pure mids) passages.**
+
+- **iter 6 — HEART PULSE landed (audio fingerprint: bass 0.65, bassZ 1.17, mids 0.80, centroid 0.11,
+  entropy 0.12, energy 0.10 — deep warm-low corner).** Coat's chest-glow recast as a pure-red (t=0 =
+  nearest) throb from the figure's core, confined to figMask. On the bass spike it measured 7.6% red
+  pixels with 0% white — the dancer's center visibly punches forward. **Why it worked:** pure red is
+  the strongest chromadepth pop, and gating on bassZScore (with a quietGate floor of 0.35, since the mic
+  reads bassy passages as quiet) means it fires exactly on the hit. **Design hypothesis:** the figure
+  CORE (not the rim) is the right place for the "near-most" red event — rim already does edge-pop, core
+  does mass-pop; together they give two depth layers of red.
+
+- **iter 7** — **GROOVE BREATH** ported. Coat's slow full-frame brightness breath on calm-groove
+  passages. **Chromadepth refinement of the translation rule:** instead of ADDING brightness (washes),
+  made it MULTIPLICATIVE: `col *= 1 + grooveGate*breath*0.10`. Multiplying scales existing colors up/down,
+  preserving hue AND saturation exactly → mathematically zero white risk, unlike additive. Bell-curve
+  energy gate (peaks ~0.45 groove pocket) × mids × not-during-surges. Added on a balanced mid-energy
+  passage (bass 0.35, mids 0.41, energy 0.44). **New rule for full-frame breaths on chromadepth: multiply, don't add.**
+
+- **iter 8** — **GHOST ECHO** ported. Coat raised feedback on bass spikes for a coat afterimage. Here
+  it modulates the EXISTING feedback blend (`fbBlend = mix(0.12, 0.42, ghost)`) rather than adding a new
+  overlay — so it doesn't over-stack the composition. **Free chromadepth win:** the feedback path already
+  ages trails toward blue + dims them, so the lingering echo recedes into the far band as it fades — a
+  ghost peeling off the dancer into the distance. Chose it over the 3 remaining bass-additive effects
+  (GROUND QUAKE/SUB RING/DRIP) precisely because it reuses feedback instead of piling on a new layer.
+  NOTE: did NOT add crystalline/diamond glitch for the high-entropy passage — coat history vetoed
+  "crystalline facets" + "flannel diamonds" (user). Stayed away.
+
+- **iter 10 (live flag — FIBER GREY, hardened)** — user: "that water effect can still make the inside of
+  the handstand greyish — make sure this can't happen." The iter-2 fix still left a `figLit += strandM*0.04`
+  whisper, and any lightness add toward mid-grey desaturates. **Bulletproof fix: removed the figLit term
+  entirely from BOTH FUR FIBERS and SIGIL SWIRL.** They now ONLY pull figT toward red (depth) and ONLY
+  ADD saturation (`figSat = clamp(figSat + amt, figSat, 1.0)` — floor at current, can't drop). With zero
+  lightness contribution and saturation that can only rise, the interior is *mathematically incapable* of
+  greying from these effects. Verified figure-center mean saturation = 0.935 (highly vibrant), grey 0.06%.
+
+- **iter 11 (refinement, audio: entropy 0.95, treble 0.86, centroid 0.80, bass 0.02 — peak chaos corner)**
+  — **CHAOS RECEDE.** Roadmap done, so this tick TUNED the existing far field instead of adding a motif.
+  At extreme entropy the nebula filaments + PRISM RIM + STEP RIPPLE all max out and start competing with
+  the figure. Fix: as entropy climbs (smoothstep 0.55→0.95) the far-field brightness cap drops 0.26→0.18,
+  so the busier the nebula, the HARDER it recedes — sharpens the chromadepth read exactly when it's most
+  threatened. Verified: corner (far field) mean brightness ~14% at entropy 0.95, figure stays dominant.
+  **Design hypothesis:** "the chromadepth-correct response to MORE background activity is MORE recession,
+  not matching brightness — push the busy field further back, don't let it climb forward."
+
+- **iter 12 (refinement, audio: energy 0.29, quietGate 0.29, entropy 0.71, pitch 0.73 — breakdown,
+  melodic)** — **MELODIC BREATH.** Noticed pitchClass swinging wide across ticks (0.09→0.91→0.36→0.73)
+  = the music is melodic, but the shader only used pitch as a tiny palette tint. In breakdowns the figure
+  had QUIET BREATH (a fixed sine swell) but nothing musical. Added a pitch→figT (depth) nudge gated to
+  quiet passages: the body drifts a touch nearer/further with the melody note, ±0.03, clamped 0..0.45 so
+  it stays in the near/mid band. Pure depth (hue) modulation → chromadepth-correct, no white. Quiet
+  sections now feel like the dancer is breathing WITH the melody, not on a timer.
+
+- **iter 13 (refinement, audio: energy 0.85, treble 0.79, centroid 0.67, bass 0.13 — bright sustained,
+  bass-light)** — **ENERGY-LIFT.** Observed a gap: when the track is DRIVING (high energy) but bass-light,
+  the figure went static because nearly all its motion (zoom/pop/heart/shake) is bass-gated. Added an
+  energy term to TREBLE SHIMMER's `airy` gate (smoothstep 0.55→0.9 energy × 0.4) so the limbs crackle
+  with the track's drive even without bass. **Gap identified for the feature-map: handstand had NO pure-
+  energy-driven figure response — everything keyed off bass or treble-character. This fills it.**
+
+- **iter 14 (refinement, measured)** — extended CHAOS RECEDE to trigger on high centroid too. Diagnostic
+  showed the far field at ~25% brightness in bright-but-not-chaotic passages (centroid 0.75) because the
+  field's PRISM/STEP glow was lifting it — entropy-only recede missed those. Now `max(entropy, centroid)`
+  drives the recede and the cap floor dropped 0.18→0.16. Result (measured): bg 65→56, contrast 1.7×→2.1×.
+  **Used a live pixel-diagnostic (figure vs background mean brightness + contrast ratio) to PICK the edit
+  rather than guess — the right way to do refinement ticks when no new motif is needed.**
+
+- **iter 15 (refinement, audio: bass 0.96 / bassZ 0.87 but treble/centroid/energy ~0, quietGate 0 —
+  a deep SOLO-BASS intro, mix otherwise empty)** — caught a real gap: in solo-bass passages the
+  mic-derived quietGate reads ~0 (it thinks it's silence), so effects that fully multiply by quietGate
+  vanish — BASS BLOOM was muted exactly when a sub was slamming. Gave its `kick` a `max(quietGate, 0.4)`
+  floor (matching FIGURE_ZOOM/HEART PULSE) + an FFT bassZ fallback. **Pattern worth remembering: quietGate
+  under-reads on deep-bass-only intros through a mic; bass-reactive effects must floor it, not trust it.**
+
+- **iter 16 (NO-OP)** — audio in the same bright/entropy corner (treble 0.71, entropy 0.79) that's already
+  maximally covered (PRISM RIM, STEP RIPPLE, ENERGY-LIFT, FUR FIBERS, ENTROPY FRACTURE, CHAOS RECEDE).
+  Health-checked instead of editing: compile OK, 0% white/grey, fig sat 0.95, contrast 2.46×. Chose NOT to
+  edit — forcing a change here would violate "one MEANINGFUL move per tick." The build-out + refinement
+  phases are done; shader is in a finished, forkable state. Further meaningful ticks need NEW music corners.
+
+## Todo (coat effects still to port — see vj-state.json coatEffectsTodo)
+- [ ] DRIP, GROUND QUAKE, STEP RIPPLE, WARM HEARTH, HEART PULSE, GHOST ECHO, PRISM RIM (band-clamped),
+      GROOVE BREATH, SUB RING — each adapted to chromadepth (no white, correct depth band).
+
+## Design hypotheses for v(next)
+- The coat's effect library is mostly additive glows; on chromadepth they MUST be expressed as
+  lightness-within-a-depth-band, never as white. The translation rule is: pick the hue (depth) first,
+  then modulate lightness — exactly what `chromadepth(t, sat, lit)` enforces.

--- a/shaders/redaphid/handstand/1.frag
+++ b/shaders/redaphid/handstand/1.frag
@@ -102,10 +102,13 @@ uniform float energyLong;  // minutes-long energy average (set intensity)
 // terms (zScore/hit = the BEAT) dominate and only floor-gate at 0.4 (not full quietGate, which
 // reads shy through a mic), plus an FFT bassZScore fallback, so the figure visibly PUMPS bigger
 // on every beat. Smooth swell rides under it. (1.22 base → as low as ~0.85 on a hard hit.)
-#define FIGURE_ZOOM (1.22 - waveletBassSpring * 0.10 * quietGate \
-                          - clamp(waveletBassZScore, 0.0, 1.0) * 0.20 * max(quietGate, 0.4) \
-                          - clamp(wavelet_bassHit, 0.0, 1.0) * 0.14 * max(quietGate, 0.4) \
-                          - clamp(bassZScore, 0.0, 1.0) * 0.10)
+// AMPLITUDE CRANKED (user: "the zoom needs more amplitude with the bass"). Coefficients ~2× and
+// clamp ranges widened to 1.5 so strong hits push further — the figure PUMPS much bigger on the kick.
+// Base 1.22 → as low as ~0.45 on a hard slam (was ~0.85). Smooth swell rides under the punchy spikes.
+#define FIGURE_ZOOM (1.22 - waveletBassSpring * 0.20 * quietGate \
+                          - clamp(waveletBassZScore, 0.0, 1.5) * 0.40 * max(quietGate, 0.4) \
+                          - clamp(wavelet_bassHit, 0.0, 1.5) * 0.28 * max(quietGate, 0.4) \
+                          - clamp(bassZScore, 0.0, 1.5) * 0.20)
 // #define FIGURE_ZOOM 1.22
 
 // Figure BOUNCE — kept SMALL: a tiny vertical lift so the pump isn't perfectly centered, but
@@ -254,7 +257,14 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // capped, so it shimmers without washing out. The figure stays the focal point.
     float highEnd = clamp(spectralCentroidNormalized * clamp(energyNormalized, 0.0, 1.0), 0.0, 1.0) * quietGate;
     float fieldLit = FIELD_BRIGHT + filament * (0.12 + waveletBand5Spring * 0.10 * quietGate + highEnd * 0.10) - calm * 0.04;
-    fieldLit = min(fieldLit, 0.26);                                      // hard cap: far field stays DARK so it recedes
+    // CHAOS RECEDE (iter11, extended iter14) — the busier the nebula gets, the HARDER it recedes:
+    // drop the brightness cap so an active far field sinks back instead of competing with the figure.
+    // iter14: extended the trigger from entropy-only to ALSO high centroid (brightness) — measured the
+    // background sitting at ~25% in bright-but-not-chaotic passages (centroid 0.75), where the field's
+    // PRISM/STEP glow was lifting it. Now bright OR chaotic both push it back. Cap 0.26 → 0.16 at peak.
+    float chaosRecede = max(smoothstep(0.55, 0.95, spectralEntropyNormalized),
+                            smoothstep(0.55, 0.85, spectralCentroidNormalized)) * quietGate;
+    fieldLit = min(fieldLit, mix(0.26, 0.16, chaosRecede));              // hard cap: far field stays DARK, darker on activity
     // SECTION MODE shifts the field's saturation character per section (cool-band only → no warm wash).
     float fieldSat = clamp(0.92 - tonalStrength * 0.05 + sin(sectionMode * 1.7) * 0.06 * sectionMix, 0.6, 1.0);
     vec3 background = chromadepth(fieldT, fieldSat, fieldLit);
@@ -303,11 +313,20 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // MID WARMTH — when mids dominate over brightness (warm, bodied passage, not screechy)
     // the whole interior swells with a soft inner glow. Fills the mid feature-gap; pure
     // lightness on the figure's red→green band → chromadepth read holds.
-    float warmth = clamp(midsNormalized - spectralCentroidNormalized, 0.0, 1.0) * quietGate;
+    // iter18: floor quietGate (mids-heavy warm passages read mic-quiet too — same quietGate under-read
+    // as the solo-bass case in iter15). Caught live at mids 0.93 / centroid 0.16 / quietGate 0.00 — the
+    // warm-dark corner the figure's MID WARMTH was built for but never fired because quietGate zeroed it.
+    float warmth = clamp(midsNormalized - spectralCentroidNormalized, 0.0, 1.0) * max(quietGate, 0.45);
     // QUIET BREATH — in breakdowns/silence (quietGate low) the figure isn't frozen: a slow
     // time-driven swell makes it gently "breathe" so the dancer stays alive between sections.
     // Gated by (1-quietGate) so it fades out the moment the music kicks back in. Slow → no flash.
     float breath = (0.5 + 0.5 * sin(iTime * 0.8)) * (1.0 - quietGate) * 0.08;
+    // MELODIC BREATH (iter12 refinement) — in breakdowns the music is often melodic (pitch swings
+    // wide). Let the note gently shift the figure's DEPTH so the quiet sections feel musical, not just
+    // a fixed sine: the body drifts a touch nearer/further with the melody. Pure figT (hue band) nudge,
+    // tiny (±0.03), gated to quiet passages only → chromadepth-correct, no lightness/white risk.
+    figT += (pitchClassNormalized - 0.5) * 0.06 * (1.0 - quietGate);
+    figT = clamp(figT, 0.0, 0.45);
     float figLit = 0.32 + plasma * 0.22 + waveletBand2Spring * 0.10 * quietGate
                  + smoothstep(0.6, 1.0, fill) * 0.06        // dense core glows a bit hotter
                  + warmth * 0.14                             // mid-dominant warm body swell
@@ -318,7 +337,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Airy/bright passages (treble + roughness) make the thin limbs (low fill = the
     // green mid-depth band) twinkle with fine high-freq sparkle. Brightness-only,
     // confined to the figure's extremities → green=mid chromadepth read deepens.
-    float airy = clamp(trebleNormalized * 0.7 + spectralRoughnessNormalized * 0.5, 0.0, 1.0) * quietGate;
+    // ENERGY-LIFT (iter13 refinement) — sustained bright high-energy passages (this corner: energy
+    // 0.85, treble 0.79, bass quiet) left the figure feeling static since its big moves are bass-gated.
+    // Now overall energy intensifies the limb shimmer so the extremities CRACKLE when the track is
+    // driving but bass-light. Energy term added on top of the treble/roughness gate.
+    float airy = clamp(trebleNormalized * 0.7 + spectralRoughnessNormalized * 0.5
+                     + smoothstep(0.55, 0.9, energyNormalized) * 0.4, 0.0, 1.3) * quietGate;
     float limb = figMask * (1.0 - smoothstep(0.15, 0.55, fill));   // thin extremities only
     float spark = flow2(ip * 6.0 + vec2(FLOW * 2.0, -melodyFlow));
     spark = pow(spark, 3.0) * (0.5 + 0.5 * sin(FLOW * 9.0 + uv.x * 24.0));
@@ -330,6 +354,57 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float scanY = fract(uv.y * 1.5 - iTime * (0.6 + scanBright * 1.2));
     float scanBand = smoothstep(0.96, 1.0, scanY) * scanBright;
     figLit += figMask * scanBand * 0.3;
+
+    // ---- FUR FIBERS (ported from the-coat) — interior DEPTH strands, NOT light ----
+    // The coat's headline effect: double domain-warped flow shaped into sharp ridges that
+    // read as individual fur strands. CHROMADEPTH FIX (user: "the water-like effect washes out
+    // the inside of the handstand — colors less vibrant, lowers the chromadepth"): the strands
+    // used to ADD lightness, and raising HSL-L past ~0.5 desaturates toward white = the wash-out.
+    // Now the strands carve DEPTH + SATURATION instead of brightness: each strand pulls figT
+    // toward RED (nearer) and BOOSTS figSat, so the body gets vibrant near-red fiber detail that
+    // DEEPENS the 3D read rather than bleaching it. Brightness barely moves (tiny dark-biased ripple).
+    float fiberTrig = clamp(spectralEntropyNormalized * 0.8 + spectralRoughnessNormalized * 0.6, 0.0, 1.0) * quietGate;
+    float fiberAmt = smoothstep(0.45, 0.85, fiberTrig);
+    if (fiberAmt > 0.01) {
+        vec2 fp = (uv - 0.5) * vec2(aspect, 1.0) * 16.0;
+        float warpT = FLOW * 0.6 + spectralCentroidNormalized * 1.5;   // pitch-aware swirl rate (coat trick)
+        vec2 fwarp = vec2(flow2(fp + vec2(warpT, 0.0)), flow2(fp + vec2(0.0, warpT + 3.7))) - 0.5;
+        vec2 fp2 = fp + fwarp * 3.5;                                    // second domain warp = deeper swirl
+        float fibers = flow2(fp2 + (vec2(flow2(fp2 + vec2(warpT * 0.7, 1.3)),
+                                         flow2(fp2 + vec2(2.1, warpT * 0.5))) - 0.5) * 1.5);
+        float strand = pow(abs(sin(fibers * PI * (4.0 + clamp(spectralFluxZScore, 0.0, 2.0) * 1.5))), 3.0);
+        float strandM = figMask * strand * fiberAmt;
+        // BULLETPROOF (user: "the water effect can still make the inside greyish — make sure this
+        // can't happen"). Greyish = desaturated. So the fibers now ONLY pull toward red (depth) and
+        // ONLY ADD saturation — they contribute ZERO lightness. With no lightness term and figSat that
+        // can only RISE, the interior is mathematically incapable of going grey/washed from this effect.
+        figT -= strandM * 0.10;                                        // toward red (nearer) → 3D pops
+        figT = max(figT, 0.0);
+        figSat = clamp(figSat + strandM * 0.10, figSat, 1.0);          // strictly MORE vibrant, never less
+        // (no figLit term — lightness add is what greyed it; removed entirely)
+    }
+
+    // ---- SIGIL SWIRL (ported from the-coat) — iridescent body spiral ----
+    // Radial spiral wave on the figure surface, hue cycling with angle + time. The coat
+    // used full hue; here we keep it a SUBTLE warm-tint brightness boost so the figure's
+    // red→green chromadepth read isn't overwritten — the swirl shows as a glinting spiral
+    // of light, brightest on mid-dominant groove passages + harmony-ish pitch motion.
+    {
+        vec2 sc = (uv - vec2(0.5, 0.5)) * vec2(aspect, 1.0);
+        float sr = length(sc);
+        float sa = atan(sc.y, sc.x);
+        float spiral = sin(sa * 5.0 + sr * 14.0 - FLOW * 1.4 + midsNormalized * 3.0);
+        float swirlBand = smoothstep(0.02, 0.18, sr) * smoothstep(0.42, 0.20, sr);
+        float swirl = pow(0.5 + 0.5 * spiral, 3.0) * swirlBand;
+        float swirlGain = (0.3 + midsNormalized * 0.7 + clamp(bassZScore, 0.0, 1.5) * 0.4) * quietGate;
+        // Same bulletproof rule as FUR FIBERS: ZERO lightness, saturation can only rise → can't grey out.
+        float swirlM = figMask * swirl * swirlGain;
+        figSat = clamp(figSat + swirlM * 0.08, figSat, 1.0);           // strictly more vibrant
+        figT -= swirlM * 0.05;                                         // toward red (nearer)
+        figT = max(figT, 0.0);
+        // (no figLit term)
+    }
+    figLit = min(figLit, 0.62);                                        // keep within chromadepth lightness band
     figure = chromadepth(figT, figSat, figLit);
 
     // ---- COMPOSITE figure over field ----
@@ -342,6 +417,16 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float scoop = clamp(trebleNormalized * (1.0 - midsNormalized), 0.0, 1.0) * quietGate;
     float rimPulse = 0.6 + 0.4 * sin(FLOW * 3.0 + uv.y * 6.0);
     vec3 rimCol = chromadepth(scoop * 0.06, 0.96, 0.5);     // t≈0 → reddest, heats to red-orange
+    // ---- PRISM RIM (ported from the-coat) — iridescent edge on bright/airy passages ----
+    // The coat's chrome rim cycled a FULL rainbow by uv-angle + time. On chromadepth a full
+    // rainbow rim is forbidden (blue rim = far = contradicts "edge pops forward"). So the hue
+    // cycle is CLAMPED to the NEAR band only (t 0.0→0.14 = red→orange→yellow): the edge
+    // shimmers with prismatic motion while every hue still reads as "near". Gated by the bright
+    // corner (treble + centroid) so it appears on airy/screechy passages like the coat intended.
+    float prismGate = clamp(trebleNormalized * smoothstep(0.45, 0.80, spectralCentroidNormalized), 0.0, 1.0) * quietGate;
+    float prismAngle = atan(uv.y - 0.5, (uv.x - 0.5) * aspect);       // edge position around the figure
+    float prismT = fract(prismAngle / 6.2831853 + FLOW * 0.4 + pitchClassNormalized * 0.2) * 0.14;  // cycle, NEAR band only
+    rimCol = mix(rimCol, chromadepth(prismT, 0.98, 0.52), prismGate);
     // RISER — build-up tension. flux + energy rising together (the climb before a drop)
     // pumps a fast-flickering charge into the rim, so the figure visibly "charges up"
     // before the DROP PUNCH releases it. Near-band red flicker → chromadepth safe.
@@ -353,8 +438,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Driven by GNARLINESS alone (entropy+roughness) so it isn't strangled by quietGate; entropy
     // is ~0 in true silence so it's its own quiet guard. The texture comes from smooth value-
     // noise (flow2) with SOFT thresholds → irregular chunky blobs that crawl, not 1px dots.
+    // GATE RAISED (user: "grit outline should happen less frequently") — now needs genuinely
+    // gnarly passages: high entropy AND high roughness both required, threshold pushed up so it
+    // fires only on the truly chaotic moments instead of most of the track.
     float grit = clamp(spectralEntropyNormalized * 1.3 + spectralRoughnessNormalized * 0.7, 0.0, 1.0)
-               * smoothstep(0.20, 0.45, spectralEntropyNormalized);
+               * smoothstep(0.55, 0.80, spectralEntropyNormalized)
+               * smoothstep(0.40, 0.70, spectralRoughnessNormalized);
     // organic noise field: low spatial freq (~big blobs) scrolling/boiling over time
     vec2 gp = uv * vec2(aspect, 1.0) * 14.0;
     float gN = flow2(gp + vec2(iTime * 1.7, -iTime * 1.3));
@@ -369,11 +458,145 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // ---- BASS BLOOM — kick-gated red halo from the core, only in DARK passages ----
     // High bass + low centroid (the skill's classic pairing): a near-field (red) radial
     // glow blooms out of the figure on each kick, then it's gone. Reinforces red=near.
-    float kick = clamp(waveletBassZScore, 0.0, 1.0) * quietGate;
+    // iter15: floor the quietGate (like FIGURE_ZOOM/HEART PULSE already do) + FFT bassZ fallback, so a
+    // deep SOLO-BASS intro (bass 0.96 but quietGate ~0 because the mix is otherwise empty) still blooms
+    // the red core. Observed live: sparse bassy passages were leaving the bloom fully muted by quietGate.
+    float kick = clamp(max(waveletBassZScore, bassZScore * 0.7), 0.0, 1.0) * max(quietGate, 0.4);
     float darkness = 1.0 - smoothstep(0.10, 0.40, spectralCentroidNormalized);
     float bloomR = length((uv - 0.5) * vec2(aspect, 1.0));
     float bloom = exp(-bloomR * bloomR * 9.0) * kick * darkness;
     col += chromadepth(0.0, 0.95, 0.5) * bloom * 0.45;
+
+    // ---- HEART PULSE (ported from the-coat) — pure-red core glow pulsing on bass ----
+    // The coat pulsed a red glow from the chest center on bass. Here it beats from the figure's
+    // CORE (center of mass) in the PUREST red (t=0 = nearest), so on a bass hit the dancer's
+    // center throbs forward — the single strongest chromadepth pop. Bass-gated with a floor
+    // (mic reads bass passages as quiet, so don't fully trust quietGate) like FIGURE_ZOOM does.
+    {
+        vec2 heartC = vec2(0.5, 0.46);                              // a touch above center = chest/core
+        float heartD = length((uv - heartC) * vec2(aspect, 1.0) * vec2(1.2, 1.0));
+        float heart = exp(-heartD * heartD * 16.0);                // tight core falloff
+        float heartPulse = (clamp(bassZScore, 0.0, 2.0) * 0.6 + waveletBassSpring * 0.5 + bassNormalized * 0.3)
+                         * max(quietGate, 0.35);
+        // confine to the figure so it reads as the dancer's heart, pure red = near
+        col += chromadepth(0.0, 1.0, 0.5) * heart * heartPulse * figMask * 0.5;
+    }
+
+    // ---- EMBER RISE (ported from the-coat) — sparks drifting up the far-field ----
+    // 6 deterministic embers rising through the lower nebula on the warm-low corner
+    // (mids-dominant + low centroid). The coat used pure amber; here the embers ride the
+    // chromadepth FAR band (violet/blue) so they read as distant glints receding behind
+    // the dancer rather than warm fire in front. Masked outside the figure, lower half only.
+    {
+        float emberGate = smoothstep(0.45, 0.75, midsNormalized)
+                        * smoothstep(0.30, 0.10, spectralCentroidNormalized) * quietGate;
+        if (emberGate > 0.02) {
+            float emberEmit = 0.0;
+            for (int i = 0; i < 6; i++) {
+                float fi = float(i);
+                float ex = (fract(fi * 0.31) - 0.5) * 1.6 + sin(iTime * 1.7 + fi * 1.3) * 0.04;
+                float speed = 0.16 + fract(fi * 0.13) * 0.18;
+                float phase = fract(FLOW * speed * 4.0 + fi * 0.27);
+                float ey = -0.5 + phase * 1.0;
+                vec2 dE = (uv - 0.5) * vec2(aspect, 1.0) - vec2(ex * 0.5, ey);
+                emberEmit += exp(-dot(dE, dE) * 700.0) * pow(1.0 - phase, 1.5);
+            }
+            float lowerMask = smoothstep(0.6, 0.1, uv.y);
+            // far-field violet glint (chromadepth far) so embers recede behind the figure
+            col += chromadepth(0.88, 0.8, 0.6) * emberEmit * emberGate * lowerMask * (1.0 - figMask) * 0.9;
+        }
+    }
+
+    // ---- WARM HEARTH (ported from the-coat) — near-red glow radiating from the silhouette ----
+    // The coat's signature mid-dominant move: a slow amber glow blooming OUTWARD from the figure
+    // on warm-dark-instrumental passages (mids dominant, low centroid, moderate energy). On
+    // chromadepth we keep it firmly in the NEAR red/orange band (t≈0.05) so the halo reads as the
+    // figure's own warmth pushing toward the viewer — never white, never blue. The outward glow
+    // uses the rim's outer presence (already a dilation of the silhouette) as its falloff.
+    {
+        float warmGate = smoothstep(0.40, 0.70, midsNormalized)
+                       * smoothstep(0.55, 0.25, spectralCentroidNormalized)
+                       * smoothstep(0.70, 0.20, energyNormalized) * max(quietGate, 0.45);  // iter18: floor (mids-heavy reads mic-quiet)
+        if (warmGate > 0.02) {
+            // soft outward halo: sample the mask in a wider ring than the rim to get a glow band
+            float halo = 0.0;
+            for (int i = 0; i < 8; i++) {
+                float a = float(i) * PI * 0.25;
+                vec2 d = vec2(cos(a), sin(a));
+                halo = max(halo, sampleMask(uv + d * 0.05) );
+                halo = max(halo, sampleMask(uv + d * 0.10) * 0.6);
+            }
+            halo *= (1.0 - figMask);                                   // only OUTSIDE the silhouette
+            float breathe = 0.85 + 0.15 * sin(iTime * 0.4);            // slow alive breathing
+            // near red-orange band → pops toward viewer, stays vibrant (sat 0.95), capped lightness
+            col += chromadepth(0.05, 0.95, 0.42) * halo * warmGate * breathe * 0.5;
+        }
+    }
+
+    // ---- GROUND QUAKE (ported from the-coat) — concentric floor rings on bass+low-centroid ----
+    // The coat rumbled amber wavefronts up from the floor on bass drops. Here they're recast as
+    // far-VIOLET elliptical rings expanding from below the figure — a deep-bass shockwave receding
+    // into the background (chromadepth far). Gated by bass × low-centroid (sub territory) so it only
+    // fires on real low-end. Masked outside the figure + lower-biased so it never washes the red core.
+    {
+        float quakeGate = clamp(bassNormalized - 0.25, 0.0, 1.0)
+                        * smoothstep(0.55, 0.15, spectralCentroidNormalized)
+                        * max(quietGate, 0.35);
+        quakeGate += clamp(waveletBassZScore, 0.0, 1.0) * smoothstep(0.55, 0.15, spectralCentroidNormalized) * 0.5;
+        if (quakeGate > 0.02) {
+            vec2 feetC = vec2(0.5, 0.92);                              // below the figure (screen-bottom)
+            vec2 dvec = (uv - feetC) * vec2(aspect, 1.0);
+            dvec.y *= 2.0;                                            // squash → ground-wave ellipse
+            float r = length(dvec);
+            float wavefronts = 0.0;
+            for (int wi = 0; wi < 3; wi++) {
+                float ringR = fract(FLOW * 2.4 + float(wi) * 0.33) * 1.2;
+                float dr = r - ringR;
+                wavefronts += exp(-dr * dr * 90.0) * (1.0 - ringR / 1.2);
+            }
+            // far violet band so the shockwave recedes; never touches the figure's near red
+            col += chromadepth(0.84, 0.85, 0.55) * wavefronts * quakeGate * (1.0 - figMask) * 0.7;
+        }
+    }
+
+    // ---- SUB RING (ported from the-coat) — single drop shockwave from the figure base ----
+    // The coat fired an expanding cone ring on bass spikes, but gated it to REAL drops so it didn't
+    // drown the figure on every ambient bass bump — same discipline here. This is the last distinct
+    // coat motif; it's deliberately gated TIGHT (energyZ × bassZ = a genuine drop) so it does NOT
+    // stack with the per-kick HEART PULSE / GROUND QUAKE / BASS BLOOM (the skill's bass-stacking
+    // pitfall). One clean far-violet ring sweeps out from the figure's base on the big moments only.
+    {
+        float dropHit = clamp(energyZScore, 0.0, 1.5) * clamp(waveletBassZScore + clamp(bassZScore,0.0,1.5)*0.5, 0.0, 1.5) * quietGate;
+        if (dropHit > 0.3) {
+            vec2 baseC = vec2(0.5, 0.75);                             // figure base
+            float sd = length((uv - baseC) * vec2(aspect, 1.0));
+            float ringSpeed = 1.2 + clamp(energyZScore, 0.0, 1.5) * 0.6;
+            float ringRadius = 0.15 + fract(FLOW * ringSpeed * 2.0) * 0.6;
+            float ringD = sd - ringRadius;
+            float ring = exp(-ringD * ringD * 350.0);
+            float ringFade = 1.0 - fract(FLOW * ringSpeed * 2.0);     // fades as it expands
+            col += chromadepth(0.84, 0.85, 0.55) * ring * dropHit * ringFade * (1.0 - figMask) * 0.6;
+        }
+    }
+
+    // ---- STEP RIPPLE (ported from the-coat) — lateral energy wave in the far field ----
+    // The coat radiated a horizontal beat-wave from the chest (a "1,2-step" dance move). Here it
+    // becomes a pair of vertical bands sweeping OUTWARD from the figure's centerline through the
+    // nebula — energy rippling away from the dancer into space. Gated by the BRIGHT corner
+    // (treble × centroid × energy) since that's where this airy passage lives. Tinted in the FAR
+    // violet band + masked outside the figure, so it reads as receding background motion (chromadepth-safe).
+    {
+        float stepGate = clamp(trebleNormalized * smoothstep(0.45, 0.80, spectralCentroidNormalized), 0.0, 1.0)
+                       * smoothstep(0.35, 0.75, energyNormalized) * quietGate;
+        if (stepGate > 0.02) {
+            float sweep = abs((uv.x - 0.5) * aspect);                  // distance from the figure's vertical axis
+            float wave = sin(sweep * 16.0 - FLOW * 5.0 + energyNormalized * 4.0);
+            wave = pow(0.5 + 0.5 * wave, 4.0);                         // sharp crests, dark troughs
+            float outward = smoothstep(0.05, 0.7, sweep) * smoothstep(1.1, 0.6, sweep);  // ring out, fade at edges
+            // far violet band so the ripple recedes behind the figure
+            col += chromadepth(0.86, 0.85, 0.55) * wave * outward * stepGate * (1.0 - figMask) * 0.5;
+        }
+    }
 
     // ---- FEEDBACK trail (subtle refraction, decays in HSL to avoid white-out) ----
     float lum = dot(col, vec3(0.3, 0.6, 0.1));
@@ -384,13 +607,36 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     prevHSL.z = min(prevHSL.z, 0.55);
     prevHSL.x = fract(prevHSL.x + 0.0015);                 // age trails toward blue (recede)
     prev = hsl2rgb(prevHSL);
-    col = mix(prev, col, 1.0 - FB_BLEND);
+    // GHOST ECHO (ported from the-coat) — a bass spike briefly retains MORE of the previous frame,
+    // leaving an afterimage of the figure that lingers and trails. The coat raised feedback on bass;
+    // here it rides the same idea but stays chromadepth-correct for free: the feedback path already
+    // ages trails toward BLUE + dims them, so the echo recedes into the far band as it fades — a
+    // ghost peeling off the dancer into the distance, not a bright smear. Gated with a quietGate floor
+    // (mic reads bass as quiet) so it fires on the real kick.
+    float ghost = clamp(bassZScore - 0.3, 0.0, 1.0) * max(quietGate, 0.35)
+                + clamp(waveletBassZScore, 0.0, 1.0) * max(quietGate, 0.35);
+    float fbBlend = mix(FB_BLEND, 0.42, clamp(ghost, 0.0, 1.0));    // up to ~0.42 retained on a kick
+    col = mix(prev, col, 1.0 - fbBlend);
 
     // ---- BEAT — brightness pulse only (hue is reserved for depth) ----
     if (beat) {
         vec3 bHSL = rgb2hsl(max(col, vec3(0.001)));
         bHSL.z = min(bHSL.z * 1.06, 0.6);
         col = hsl2rgb(bHSL);
+    }
+
+    // ---- GROOVE BREATH (ported from the-coat) — slow full-frame breath on calm-groove ----
+    // The coat added a slow brightness breath during mid-energy groove passages. On chromadepth
+    // an ADDITIVE white breath would wash, so this is MULTIPLICATIVE (col *= 1+tiny*breath) — it
+    // scales existing colors up/down, preserving hue + saturation perfectly = zero white risk.
+    // Bell-curve energy gate (peaks ~0.45, the groove pocket) + mids presence; suppressed on builds.
+    {
+        float grooveGate = smoothstep(0.20, 0.45, energyNormalized)
+                         * smoothstep(0.70, 0.45, energyNormalized)      // bell curve, peaks mid-energy
+                         * smoothstep(0.30, 0.55, midsNormalized)
+                         * smoothstep(0.6, 0.2, max(energyZScore, 0.0)) * quietGate;  // not during surges
+        float breathOsc = 0.5 + 0.5 * sin(iTime * 1.6);
+        col *= 1.0 + grooveGate * breathOsc * 0.10;                       // ±10% multiplicative, hue-safe
     }
 
     // ---- VIGNETTE — darken corners so the figure reads as the focal portal ----


### PR DESCRIPTION
## Summary

Ports the **the-coat** series' signature effect library onto the **chromadepth handstand portal** (`shaders/redaphid/handstand/1.frag`), each effect adapted so the chromadepth depth read (red = near, green = mid, violet = far) holds — **no white-out, no greying of the figure interior**.

Done live over a `/vibej` session, evolving one coat motif per tick and matching the music.

### Coat motifs ported
| Effect | Chromadepth adaptation |
|---|---|
| **FUR FIBERS** | Domain-warped light-strands through the body — carry *depth + saturation*, never lightness, so they can't wash the interior |
| **SIGIL SWIRL** | Iridescent body spiral (saturation/depth, not lightness) |
| **EMBER RISE** | Far-violet sparks rising in the lower nebula (recede behind the figure) |
| **PRISM RIM** | Iridescent edge, hue clamped to the near red→orange band so it always reads "near" |
| **STEP RIPPLE** | Far-violet lateral bands sweeping out from the figure axis |
| **WARM HEARTH** | Near red-orange halo radiating from the silhouette on warm-dark passages |
| **HEART PULSE** | Pure-red figure-core throb on bass — the strongest near-pop |
| **GROOVE BREATH** | Multiplicative full-frame breath (preserves hue+saturation = hue-safe) |
| **GHOST ECHO** | Bass-spike feedback afterimage that ages toward blue → recedes |
| **GROUND QUAKE** | Far-violet floor shockwave rings on bass + low-centroid |
| **SUB RING** | Drop-only far-violet ring from the figure base (tight gate, no bass-stacking) |

(DRIP intentionally skipped — overlaps HEART PULSE's core and would over-stack the bass radials.)

### Refinements
- **FIGURE_ZOOM** bass amplitude cranked ~2× — the figure pumps much bigger on the kick
- **CHAOS RECEDE** — far field darkens on high entropy *or* brightness so the figure stays dominant (measured figure-to-bg contrast 1.7× → 2.1×)
- **MELODIC BREATH** — pitch gently nudges figure depth in breakdowns
- **ENERGY-LIFT** — raw energy crackles the limb shimmer (fills the no-pure-energy-response gap)
- **quietGate floors** on bass/mid-gated effects — the mic-derived quietGate under-reads spectrally-narrow (pure-bass / pure-mids) passages, so those effects need a floor to fire
- Grit-outline gate raised so the fraying edge fires only on genuinely gnarly passages

### Chromadepth discipline
The key translation rule (learned the hard way): porting a coat *glow* (additive lightness) onto a saturated chromadepth figure bleaches it — in HSL, raising L past ~0.5 desaturates toward white/grey. So figure effects carry **depth (figT) + saturation**, with lightness clamped; full-frame effects **multiply** rather than add. Verified 0% white-out across the session.

## Test plan
- [Preview — handstand/1](https://handstand-coat-effects.paper-cranes-visuals.pages.dev/?shader=redaphid/handstand/1&wavelet=true&controller=wavelet-ease&image=images/handstand.png&fullscreen=true)
- Open with ChromaDepth glasses: figure interior reads red/near, limbs green/mid, nebula violet/far.
- Drive with bassy dubstep: HEART PULSE + GROUND QUAKE + the cranked zoom should pump the figure forward on kicks; far-field rings recede.
- Bright/airy passages: PRISM RIM shimmers on the edge, limbs crackle (ENERGY-LIFT), background recedes harder (CHAOS RECEDE).
- Warm mid-dominant passages: WARM HEARTH glows red-orange around the silhouette.
- Confirm no white-out or greyed interior on any passage.
- `node scripts/validate-shader.js shaders/redaphid/handstand/1.frag` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)