### PR TITLE
Controller chaining: repeated ?controller= runs a left-fold pipeline; async make()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,8 @@ vec3 position = vec3(CIRCLE_RADIUS, 0.1, 0.1);
 
 Controllers are JavaScript modules (`controllers/*.js`) that run once per frame with persistent state. They fill gaps GLSL can't: exponential decay, accumulators, state machines, double-precision math. Loaded via `?controller=<name>`. **Default to shader logic** — only use a controller when the shader literally cannot hold the state you need. Controller outputs become shader uniforms (must be explicitly declared with `uniform float`). See [docs/controllers.md](docs/controllers.md) for the full guide.
 
+**Chaining (repeat `?controller=`):** controllers run as a **left-fold pipeline** (`src/controllerChain.js`). Each gets `{ ...base features, ...everything earlier stages added this frame }` and returns the features it adds; **URL order = pipeline order, last wins on key clash**; a cross-cutting controller (smoother/recorder/clamp) goes **last**. NOT deduped — each `?controller=` is its own stage with its own `make()`/state (so a controller listed twice runs twice, and one that attaches global listeners does so once per instance). `make()` may be `async` (awaited before joining the loop). **Prefer chaining over wrapping** — compose at the URL (`?controller=wavelet-ease&controller=my-fx`) instead of importing one controller inside another. (A few existing controllers — `lattice-nav`, `gesture-knobs` — still self-import `wavelet-ease`; leave them, but write new ones to be chained.)
+
 ## Knob/MIDI Control System
 
 ### Available Knobs

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -105,7 +105,7 @@ Repeat `?controller=` to load several controllers — they run as a **left-fold 
 
 - **Order = URL order.** Each controller receives `{ ...base features, ...everything added by earlier controllers this frame }` and returns the features it adds. So a later controller can read an earlier one's output.
 - **Last wins on key clash.** A cross-cutting controller (smoother, recorder, clamp…) just goes **last** so it sees and can override the full accumulated bag.
-- **Deduped by name** — listing the same controller twice runs it once (no double touch-listeners/state).
+- **Each `?controller=` is its own stage** — listing the same controller more than once runs it that many times, each with its own `make()`/state, feeding into its own position in the pipeline (e.g. a transform applied twice, or a smoother before *and* after). Note: a controller that attaches global listeners/state will do so once per instance.
 - This replaces the need to *wrap* one controller in another. (Existing self-wrapping controllers like `lattice-nav` still work; chaining is additive.)
 
 ### Async `make()`

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -95,6 +95,31 @@ Add `?controller=<name>` to the URL (without `.js`):
 
 The controller runs in a `requestAnimationFrame` loop managed by `index.js`. On the jam page, controllers hot-swap on file save without page reload (via the `controller-update` HMR event).
 
+### Chaining (multiple controllers)
+
+Repeat `?controller=` to load several controllers — they run as a **left-fold pipeline** each frame (`src/controllerChain.js`):
+
+```
+?controller=wavelet-ease&controller=lattice-nav&controller=my-fx
+```
+
+- **Order = URL order.** Each controller receives `{ ...base features, ...everything added by earlier controllers this frame }` and returns the features it adds. So a later controller can read an earlier one's output.
+- **Last wins on key clash.** A cross-cutting controller (smoother, recorder, clamp…) just goes **last** so it sees and can override the full accumulated bag.
+- **Deduped by name** — listing the same controller twice runs it once (no double touch-listeners/state).
+- This replaces the need to *wrap* one controller in another. (Existing self-wrapping controllers like `lattice-nav` still work; chaining is additive.)
+
+### Async `make()`
+
+`make()` may be `async` — it's awaited before the controller joins the loop, so you can dynamic-import, fetch config, or await device permissions during setup:
+
+```js
+export async function make(cranes) {
+  const { thing } = await import('./heavy-thing.js')
+  return (features) => ({ /* per-frame output */ })
+}
+```
+Sync `make()` keeps working unchanged.
+
 ## Hot-Reload
 
 On the jam page (`jam.html`), controller files hot-swap the same way shaders do:

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -95,22 +95,70 @@ Add `?controller=<name>` to the URL (without `.js`):
 
 The controller runs in a `requestAnimationFrame` loop managed by `index.js`. On the jam page, controllers hot-swap on file save without page reload (via the `controller-update` HMR event).
 
-### Chaining (multiple controllers)
+### Chaining (multiple controllers) — the pipeline
 
-Repeat `?controller=` to load several controllers — they run as a **left-fold pipeline** each frame (`src/controllerChain.js`):
+Repeat `?controller=` to load several controllers. They run as a **left-fold pipeline** every frame, implemented in `src/controllerChain.js` (`loadControllers()` builds the ordered list, `composeControllers()` folds it):
 
 ```
 ?controller=wavelet-ease&controller=lattice-nav&controller=my-fx
 ```
 
-- **Order = URL order.** Each controller receives `{ ...base features, ...everything added by earlier controllers this frame }` and returns the features it adds. So a later controller can read an earlier one's output.
-- **Last wins on key clash.** A cross-cutting controller (smoother, recorder, clamp…) just goes **last** so it sees and can override the full accumulated bag.
-- **Each `?controller=` is its own stage** — listing the same controller more than once runs it that many times, each with its own `make()`/state, feeding into its own position in the pipeline (e.g. a transform applied twice, or a smoother before *and* after). Note: a controller that attaches global listeners/state will do so once per instance.
-- This replaces the need to *wrap* one controller in another. (Existing self-wrapping controllers like `lattice-nav` still work; chaining is additive.)
+The fold is exactly this:
+
+```js
+let acc = {}
+for (const run of controllers) {
+  acc = { ...acc, ...(run({ ...baseFeatures, ...acc }) ?? {}) }
+}
+window.cranes.controllerFeatures = acc
+```
+
+Rules that follow from it (internalize these):
+
+- **URL order = pipeline order.** The 1st controller sees only `baseFeatures`; the 2nd sees `baseFeatures + what the 1st added this frame`; the 3rd sees both; etc. **So a downstream controller can read an upstream one's freshly-computed output the same frame** — this is what replaces *wrapping*.
+- **Last writer wins on a key clash.** Put a cross-cutting controller (smoother, clamp, recorder, remote-broadcast) **last** so it sees and can override the whole accumulated bag.
+- **No dedupe — each `?controller=` is its own stage** with its own `make()`/state. The same controller listed twice runs twice (e.g. a transform applied at two points, or a smoother before *and* after). A controller that attaches global listeners or holds module state does so **once per instance**, so listing a listener-based one twice double-attaches.
+- **One bad stage can't break the chain** — each step is wrapped in try/catch; a throwing controller logs and contributes nothing that frame.
+
+**Prefer chaining over wrapping.** Write a controller that does one job and reads what it needs from `features`; compose at the URL. Don't `import` one controller inside another. (A couple of older controllers — `lattice-nav`, `gesture-knobs` — still self-import `wavelet-ease`; leave them as-is, but don't copy that pattern.)
+
+#### Example A — a downstream controller that reads an upstream output
+
+```js
+// melody-pulse.js — needs wavelet-ease UPSTREAM (e.g. ?controller=wavelet-ease&controller=melody-pulse)
+export function make() {
+  return (features) => {
+    const melody = features.melodyFlow ?? 0      // ← produced by wavelet-ease earlier this frame
+    return { pulse: 0.5 + 0.5 * Math.sin(melody * 6.2831) }
+  }
+}
+```
+
+#### Example B — a cross-cutting "smoother" you place LAST
+
+```js
+// smooth-all.js — eases EVERY numeric feature the chain produced. Put it last: ?...&controller=smooth-all
+export function make() {
+  const state = {}                               // its own persistent state (why it's a controller)
+  return (features) => {
+    const out = {}
+    for (const k in features) {
+      if (typeof features[k] !== 'number') continue
+      state[k] = (state[k] ?? features[k]) * 0.9 + features[k] * 0.1   // EMA
+      out[k] = state[k]
+    }
+    return out                                   // overrides the upstream keys (last wins)
+  }
+}
+```
+
+#### Gotcha: the one-frame self-feedback loop
+
+`flattenFeatures()` folds **last frame's** `controllerFeatures` back into `baseFeatures`. So a controller can see its *own previous-frame* output in `features`. That's normally fine and useful (cheap cross-frame memory), but **don't write a stage that blindly accumulates its own key** (`x = features.x + 1`) unless you intend it to grow every frame.
 
 ### Async `make()`
 
-`make()` may be `async` — it's awaited before the controller joins the loop, so you can dynamic-import, fetch config, or await device permissions during setup:
+`make()` may be `async` — it's awaited before the controller joins the loop, so you can dynamic-import heavy deps, fetch config, or await device permissions during setup:
 
 ```js
 export async function make(cranes) {
@@ -118,7 +166,7 @@ export async function make(cranes) {
   return (features) => ({ /* per-frame output */ })
 }
 ```
-Sync `make()` keeps working unchanged.
+Sync `make()` keeps working unchanged. (The per-frame function it returns must stay synchronous — it runs every `requestAnimationFrame`.)
 
 ## Hot-Reload
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const maybeStartWavelet = async (params, audioContext, sourceNode) => {
 }
 import { makeVisualizer, askForWakeLock } from './src/Visualizer.js'
 import { getInitialShader } from './src/shaderLoader.js'
+import { loadControllers, composeControllers } from './src/controllerChain.js'
 
 
 const SEED_KEY = 'paperCranes.seeds'
@@ -293,42 +294,7 @@ const animateController = (controller) => {
     requestAnimationFrame(controllerFrame)
 }
 
-// Load a controller module from a URL (local or remote)
-const loadController = async () => {
-    const controllerPath = params.get('controller')
-    if (!controllerPath) return null
-
-    try {
-        // Handle paths with or without .js extension
-        let controllerUrl = controllerPath
-        if (!controllerPath.includes('http') && !controllerPath.endsWith('.js')) {
-            controllerUrl = `/controllers/${controllerPath}.js`
-        } else if (!controllerPath.includes('http')) {
-            controllerUrl = `/controllers/${controllerPath}`
-        }
-
-        const controllerModule = await import(/* @vite-ignore */ controllerUrl)
-
-        // Handle different module formats:
-        // 1. Module exports a function directly (default export) - use it as the controller
-        // 2. Module exports a make() function - CALL it (with cranes) to get the controller
-        // 3. Module exports something else - error
-        //
-        // The make() pattern (per docs/controllers.md) returns the per-frame controller —
-        // so we must invoke make(), not return it. Returning make itself was a bug: the
-        // animation loop would call make(features) every frame, re-initializing state and
-        // returning a fresh function instead of the controller's computed values.
-
-        if (typeof controllerModule.default === 'function') return controllerModule.default
-        if (typeof controllerModule.make === 'function') return controllerModule.make(window.cranes)
-        if (typeof controllerModule === 'function') return controllerModule
-        console.error('Controller must export a function directly or provide a make() function')
-        return null
-    } catch (error) {
-        console.error(`Failed to load controller: ${error}`)
-        return null
-    }
-}
+// Controller loading/chaining lives in src/controllerChain.js (repeated ?controller= → pipeline).
 
 
 if(navigator.connection) {
@@ -387,33 +353,10 @@ const main = async () => {
         fullscreen: params.get('fullscreen') === 'true' || shaderFullscreen
     }
 
-    // Load and initialize controller if specified
-    const controllerExport = await loadController()
-
-    if (controllerExport) {
-        try {
-            let controller
-
-            // Check if the export is a make function or direct controller
-            if (typeof controllerExport === 'function') {
-                // If it takes 0-1 arguments, it's likely a direct controller function
-                if (controllerExport.length <= 1) {
-                    controller = controllerExport
-                } else {
-                    // Otherwise it's probably a make function
-                    controller = controllerExport(window.cranes)
-                }
-            }
-
-            if (typeof controller !== 'function') {
-                throw new Error('Controller must be a function or return a function')
-            }
-
-            // Setup separate animation loop for the controller
-            animateController(controller)
-        } catch (e) {
-            console.error('Failed to initialize controller:', e)
-        }
+    // Load and CHAIN controllers — every `?controller=` runs as a left-fold pipeline each frame.
+    const controllerFns = await loadControllers(window.cranes, params.getAll('controller'))
+    if (controllerFns.length) {
+        animateController(composeControllers(controllerFns))
     }
 
     // Initialize visualizer and start shader animation loop

--- a/jam.js
+++ b/jam.js
@@ -2,6 +2,7 @@ import { render, Fragment } from 'preact'
 import { useState, useEffect, useRef } from 'preact/hooks'
 import { html } from 'htm/preact'
 import { createParamsManager } from './src/params/ParamsManager.js'
+import { loadControllers, composeControllers } from './src/controllerChain.js'
 
 const searchParams = new URLSearchParams(window.location.search)
 
@@ -493,18 +494,17 @@ if (import.meta.hot) {
         flashToast('Shader updated')
     })
 
-    // Hot-swap controller without reloading — just replace the function reference.
-    // The animation loop in index.js reads from window._hotController each frame.
+    // Hot-swap controllers without reloading — rebuild the whole CHAIN (any `?controller=` in it may
+    // have been edited) and recompose into window._hotController, which the index.js loop reads.
     import.meta.hot.on('controller-update', async ({ controller }) => {
-        const currentController = new URLSearchParams(window.location.search).get('controller')
-        if (!currentController || controller !== currentController) return
+        const names = new URLSearchParams(window.location.search).getAll('controller')
+        if (!names.includes(controller)) return   // edited controller isn't in this page's chain
         try {
-            const mod = await import(/* @vite-ignore */ `/controllers/${controller}.js?t=${Date.now()}`)
-            // make() is a factory — CALL it to get the per-frame controller (matches loadController).
-            const fn = mod.default ?? (typeof mod.make === 'function' ? mod.make(window.cranes) : mod)
-            if (typeof fn !== 'function') return
-            window._hotController = fn
-            flashToast(`Controller updated: ${controller}`)
+            const fns = await loadControllers(window.cranes, names, { bust: true })   // fresh re-import
+            if (fns.length) {
+                window._hotController = composeControllers(fns)
+                flashToast(`Controller updated: ${controller}`)
+            }
         } catch (e) {
             flashToast(`Controller error: ${e.message}`)
         }

--- a/src/controllerChain.js
+++ b/src/controllerChain.js
@@ -1,0 +1,64 @@
+// Dynamic controller CHAINING.
+//
+// Multiple `?controller=` params load multiple controllers and run them as a left-fold PIPELINE
+// each frame: every controller receives { ...base features, ...everything added so far } and returns
+// the features it adds; later controllers see earlier ones' output, and on a key clash the later one
+// wins (URL order = chain order). A cross-cutting controller (smoother, recorder, …) just goes LAST.
+//
+// make() may be ASYNC (`export async function make` — e.g. to dynamic-import or fetch setup). Sync
+// makes keep working (await on a non-promise is a no-op). Existing single-controller usage and the
+// self-wrapping controllers (lattice-nav / gesture-knobs that import wavelet-ease) are unaffected —
+// chaining is purely additive.
+
+const toUrl = (name, bust) => {
+    let url = name
+    if (!name.includes('http') && !name.endsWith('.js')) url = `/controllers/${name}.js`
+    else if (!name.includes('http')) url = `/controllers/${name}`
+    if (bust) url += (url.includes('?') ? '&' : '?') + 't=' + Date.now()
+    return url
+}
+
+// module → per-frame controller fn. The documented pattern is `export function make(cranes)`; we
+// also accept a default-exported controller fn (or a bare function module) for back-compat.
+const resolve = async (mod, cranes) => {
+    if (typeof mod.make === 'function') return await mod.make(cranes)   // factory (may be async)
+    if (typeof mod.default === 'function') return mod.default           // direct controller fn
+    if (typeof mod === 'function') return mod
+    return null
+}
+
+// Load an ordered list of controller names → array of per-frame fns. Dedupes by name so listing the
+// same controller twice can't double its side-effects (e.g. touch listeners). `bust` cache-busts the
+// import (used by hot-reload to pick up edits).
+export const loadControllers = async (cranes, names, { bust = false } = {}) => {
+    const seen = new Set()
+    const fns = []
+    for (const name of names) {
+        if (!name || seen.has(name)) continue
+        seen.add(name)
+        try {
+            const mod = await import(/* @vite-ignore */ toUrl(name, bust))
+            const fn = await resolve(mod, cranes)
+            if (typeof fn === 'function') fns.push(fn)
+            else console.error(`Controller "${name}": no make() or default function export`)
+        } catch (e) {
+            console.error(`Failed to load controller "${name}":`, e)
+        }
+    }
+    return fns
+}
+
+// Fold the chain into ONE per-frame fn (keeps the existing single-fn animation loop + hot-swap
+// contract). A single controller is returned as-is. Each step is isolated so one throwing controller
+// can't break the rest of the chain.
+export const composeControllers = (fns) => {
+    if (fns.length === 1) return fns[0]
+    return (features) => {
+        let acc = {}
+        for (const fn of fns) {
+            try { acc = { ...acc, ...(fn({ ...features, ...acc }) ?? {}) } }
+            catch (e) { console.error('Controller error:', e) }
+        }
+        return acc
+    }
+}

--- a/src/controllerChain.js
+++ b/src/controllerChain.js
@@ -27,16 +27,15 @@ const resolve = async (mod, cranes) => {
     return null
 }
 
-// Load an ordered list of controller names → array of per-frame fns. Dedupes by name so listing the
-// same controller twice can't double its side-effects (e.g. touch listeners). `bust` cache-busts the
-// import (used by hot-reload to pick up edits).
+// Load an ordered list of controller names → array of per-frame fns. NO dedupe: each `?controller=`
+// is its own pipeline STAGE with its own make()/state, so listing the same controller more than once
+// runs it that many times (each instance feeds into its own stage). `bust` cache-busts the import.
 export const loadControllers = async (cranes, names, { bust = false } = {}) => {
-    const seen = new Set()
     const fns = []
     for (const name of names) {
-        if (!name || seen.has(name)) continue
-        seen.add(name)
+        if (!name) continue
         try {
+            // Module is import-cached, but every entry gets a FRESH make() → independent state/stage.
             const mod = await import(/* @vite-ignore */ toUrl(name, bust))
             const fn = await resolve(mod, cranes)
             if (typeof fn === 'function') fns.push(fn)


### PR DESCRIPTION
## Summary

Replaces single-controller loading with **dynamic chaining**: repeat `?controller=` and the controllers run as a **left-fold pipeline** each frame.

- **`src/controllerChain.js`** (new) — `loadControllers()` reads `params.getAll('controller')`, imports each, and `await`s `make()` (so `make` can be **async**). `composeControllers()` folds them: each controller receives `{ ...base features, ...everything added so far this frame }` and returns what it adds; **later wins on key clash** (URL order = chain order). A cross-cutting controller (smoother, recorder, clamp…) just goes **last**. Each step is isolated so one throwing controller can't break the chain.
- **No dedupe** — every `?controller=` is its own stage with its own `make()`/state, so the same controller can appear multiple times (e.g. a transform applied twice, or a smoother before *and* after). A controller that attaches global listeners/state does so once per instance.
- **`index.js`** — dropped `loadController` + its arity-heuristic invocation; now `await loadControllers(...)` → `animateController(composeControllers(...))`.
- **`jam.js`** — hot-reload rebuilds the whole chain (cache-busted) and recomposes into `window._hotController`, preserving the existing loop + hot-swap contract.
- **`docs/controllers.md`** — documents chaining order/semantics + async `make()`.

Existing single-controller usage and self-wrapping controllers (`lattice-nav` / `gesture-knobs` that import `wavelet-ease`) are unaffected — chaining is purely additive.

## Test plan

Verified live (headless Chromium against the dev server):
- `?controller=wavelet-ease&controller=lattice-nav` → `controllerFeatures` contains **both** sets (`spinPhase`/`melodyFlow` from wavelet-ease *and* `navX`/`navZoom` from lattice-nav), no console errors.
- **Pipeline feed-forward:** `?controller=_inc&controller=_inc&controller=_inc` (a controller that does `chainCount = input.chainCount + 1`) advances `chainCount` by exactly **3 per frame** — proving three independent stages run in order and each sees the previous stage's output.
- **Async `make()`:** a controller with `await`ed setup joins the loop, its output appears, and its per-frame state persists.
- Single-controller URLs still behave as before (`composeControllers` returns the lone fn unwrapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)